### PR TITLE
added march=native to the debug flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_CXX_STANDARD 11)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -march=native")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -march=native")
 
 


### PR DESCRIPTION
Without this flag, the debug build will run into errors when executables are run (because numopt and cpputil are (normally) installed with the march=native flags)