### PR TITLE
Initial geminal coefficients in the weak interaction limit

### DIFF
--- a/include/AP1roG/AP1roGGeminalCoefficients.hpp
+++ b/include/AP1roG/AP1roGGeminalCoefficients.hpp
@@ -62,7 +62,7 @@ public:
 
     /**
      *  @param ham_par      the Hamiltonian parameters
-     *  @param N_P          the number of orbitals
+     *  @param N_P      the number of electron pairs (= the number of geminals)
      *
      *  @return the AP1roG geminal coefficients in the weak interaction limit
      */
@@ -99,6 +99,35 @@ public:
      *  @return the number of 'free' geminal coefficients
      */
     static size_t numberOfGeminalCoefficients(size_t N_P, size_t K);
+
+    /**
+     *  @param K        the number of spatial orbitals
+     *  @param N_P      the number of electron pairs (= the number of geminals)
+     *  @param vector_index     the vector index of the geminal coefficient
+     *
+     *  @return the major (non-contiguous) index i (i.e. the subscript) in the matrix of the geminal coefficients. Note that i is in [0 ... N_P[
+     */
+    static size_t matrixIndexMajor(size_t K, size_t N_P, size_t vector_index);
+
+    /**
+     *  @param K        the number of spatial orbitals
+     *  @param N_P      the number of electron pairs (= the number of geminals)
+     *  @param vector_index     the vector index of the geminal coefficient
+     *
+     *  @return the minor (contiguous) index a (i.e. the subscript) in the matrix of the geminal coefficients. Note that a is in [N_P ... K[
+     */
+    static size_t matrixIndexMinor(size_t K, size_t N_P, size_t vector_index);
+
+    /**
+     *  @param K        the number of spatial orbitals
+     *  @param N_P      the number of electron pairs (= the number of geminals)
+     *
+     *  @param i        the major index (changes in i are not contiguous)
+     *  @param a        the minor index (changes in a are contiguous)
+     *
+     *  @return the vector index of the geminal coefficient G_i^a
+     */
+    static size_t vectorIndex(size_t K, size_t N_P, size_t i, size_t a);
 
 
     // PUBLIC METHODS

--- a/include/AP1roG/AP1roGGeminalCoefficients.hpp
+++ b/include/AP1roG/AP1roGGeminalCoefficients.hpp
@@ -21,6 +21,8 @@
 
 #include <Eigen/Dense>
 
+#include "HamiltonianParameters/HamiltonianParameters.hpp"
+
 
 namespace GQCP {
 
@@ -58,6 +60,14 @@ public:
      */
     AP1roGGeminalCoefficients(const Eigen::VectorXd& g, size_t N_P, size_t K);
 
+    /**
+     *  @param ham_par      the Hamiltonian parameters
+     *  @param N_P          the number of orbitals
+     *
+     *  @return the AP1roG geminal coefficients in the weak interaction limit
+     */
+    static AP1roGGeminalCoefficients WeakInteractionLimit(const HamiltonianParameters& ham_par, size_t N_P);
+
 
     // OPERATORS
     /**
@@ -71,7 +81,7 @@ public:
      *  @param i        the major index (changes in i are not contiguous)
      *  @param a        the minor index (changes in a are contiguous)
      *
-     *  @ return the geminal coefficient G_i^a
+     *  @return the geminal coefficient G_i^a
      */
     double operator()(size_t i, size_t a) const;
 
@@ -79,6 +89,16 @@ public:
     // GETTERS
     size_t get_N_P() const { return this->N_P; }
     size_t get_K() const { return this->K; }
+
+
+    // STATIC PUBLIC METHODS
+    /**
+     *  @param N_P      the number of electron pairs (= the number of geminals)
+     *  @param K        the number of spatial orbitals
+     *
+     *  @return the number of 'free' geminal coefficients
+     */
+    static size_t numberOfGeminalCoefficients(size_t N_P, size_t K);
 
 
     // PUBLIC METHODS
@@ -93,37 +113,24 @@ public:
     Eigen::MatrixXd asMatrix() const;
 
     /**
-     *  @param N_P      the number of electron pairs (= the number of geminals)
-     *  @param K        the number of spatial orbitals
+     *  @param vector_index     the vector index of the geminal coefficient
      *
-     *  @return the number of 'free' geminal coefficients
-     */
-    static size_t numberOfGeminalCoefficients(size_t N_P, size_t K);
-
-    /**
-     *  For a geminal coefficient g_mu, return its major index in the matrix of geminal coefficients.
-     *
-     *      Note that:
-     *          - the major index is i (i.e. the subscript), since changes in i are not contiguous
-     *          - i is in [0 ... N_P[
+     *  @return the major (non-contiguous) index i (i.e. the subscript) in the matrix of the geminal coefficients. Note that i is in [0 ... N_P[
      */
     size_t matrixIndexMajor(size_t vector_index) const;
 
     /**
-     *  For a geminal coefficient g_mu, return its minor index in the matrix of geminal coefficients.
+     *  @param vector_index     the vector index of the geminal coefficient
      *
-     *      Note that:
-     *          - the minor index is a (i.e. the superscript), since changes in a are contiguous
-     *          - a is in [N_P ... K[
+     *  @return the minor (contiguous) index a (i.e. the subscript) in the matrix of the geminal coefficients. Note that a is in [N_P ... K[
      */
     size_t matrixIndexMinor(size_t vector_index) const;
 
     /**
-     *  For a geminal coefficient G_i^a, return its index in the vector of geminal coefficients.
+     *  @param i        the major index (changes in i are not contiguous)
+     *  @param a        the minor index (changes in a are contiguous)
      *
-     *      Note that
-     *          - i is in [0 ... N_P[       is the 'major' index (i.e. changes in i are not contiguous)
-     *          - a is in [N_P ... K[       is the 'minor' index (i.e. changes in a are contiguous)
+     *  @return the vector index of the geminal coefficient G_i^a
      */
     size_t vectorIndex(size_t i, size_t a) const;
 };

--- a/src/AP1roG/AP1roGGeminalCoefficients.cpp
+++ b/src/AP1roG/AP1roGGeminalCoefficients.cpp
@@ -70,7 +70,22 @@ AP1roGGeminalCoefficients::AP1roGGeminalCoefficients(const Eigen::VectorXd& g, s
  */
 AP1roGGeminalCoefficients AP1roGGeminalCoefficients::WeakInteractionLimit(const HamiltonianParameters& ham_par, size_t N_P) {
 
+    auto K = ham_par.get_K();
+    auto number_of_geminal_coefficients = AP1roGGeminalCoefficients::numberOfGeminalCoefficients(N_P, K);
+    auto h = ham_par.get_h();  // core Hamiltonian integrals
+    auto g = ham_par.get_g();  // two-electron integrals
 
+    // Provide the weak interaction limit values for the geminal coefficients
+    Eigen::VectorXd g_vector = Eigen::VectorXd::Zero(number_of_geminal_coefficients);
+    for (size_t mu = 0; mu < number_of_geminal_coefficients; mu++) {
+        size_t i = AP1roGGeminalCoefficients::matrixIndexMajor(K, N_P, mu);
+        size_t a = AP1roGGeminalCoefficients::matrixIndexMinor(K, N_P, mu);
+
+        g_vector(mu) = - g(a,i,a,i) / (2 * (h(a,a) - h(i,i)));
+    }
+
+
+    return AP1roGGeminalCoefficients(g_vector, N_P, K);
 }
 
 
@@ -121,6 +136,58 @@ size_t AP1roGGeminalCoefficients::numberOfGeminalCoefficients(size_t N_P, size_t
     return N_P * (K - N_P);
 }
 
+/**
+ *  @param K        the number of spatial orbitals
+ *  @param N_P      the number of electron pairs (= the number of geminals)
+ *  @param vector_index     the vector index of the geminal coefficient
+ *
+ *  @return the major (non-contiguous) index i (i.e. the subscript) in the matrix of the geminal coefficients. Note that i is in [0 ... N_P[
+ */
+size_t AP1roGGeminalCoefficients::matrixIndexMajor(size_t K, size_t N_P, size_t vector_index) {
+
+    return vector_index / (K - N_P);  // in the mathematical notes, we use the floor function, which is the same as integer division
+}
+
+
+/**
+ *  @param K        the number of spatial orbitals
+ *  @param N_P      the number of electron pairs (= the number of geminals)
+ *  @param vector_index     the vector index of the geminal coefficient
+ *
+ *  @return the minor (contiguous) index a (i.e. the subscript) in the matrix of the geminal coefficients. Note that a is in [N_P ... K[
+ */
+size_t AP1roGGeminalCoefficients::matrixIndexMinor(size_t K, size_t N_P, size_t vector_index) {
+
+    return vector_index % (K - N_P) + N_P;  // we add N_P since we want a to be in [N_P ... K[
+}
+
+/**
+ *  @param K        the number of spatial orbitals
+ *  @param N_P      the number of electron pairs (= the number of geminals)
+ *
+ *  @param i        the major index (changes in i are not contiguous)
+ *  @param a        the minor index (changes in a are contiguous)
+ *
+ *  @return the vector index of the geminal coefficient G_i^a
+ */
+size_t AP1roGGeminalCoefficients::vectorIndex(size_t K, size_t N_P, size_t i, size_t a) {
+
+    // Check for invalid values for i and a
+    if (i >= N_P) {
+        throw std::invalid_argument("The major index i (subscript) must be smaller than N_P.");
+    }
+    if (a < N_P) {
+        throw std::invalid_argument("The minor index a (superscript) must be larger than or equal to N_P.");
+    }
+
+
+    // The conversion from i and a to a single vector index is just a little more complicated than row-major storage
+    // If we were to use the row-major storage formula, we would end up with
+    //      mu = a + (K - N_P) * i
+    // but since we would really like our indices abcd (virtual orbitals) to start at N_P, we should subtract N_P accordingly
+    return (a - N_P) + (K - N_P) * i;
+}
+
 
 /*
  *  PUBLIC METHODS
@@ -154,7 +221,7 @@ Eigen::MatrixXd AP1roGGeminalCoefficients::asMatrix() const {
  */
 size_t AP1roGGeminalCoefficients::matrixIndexMajor(size_t vector_index) const {
 
-    return vector_index / (this->K - this->N_P);  // in the mathematical notes, we use the floor function, which is the same as integer division
+    return AP1roGGeminalCoefficients::matrixIndexMajor(this->K, this->N_P, vector_index);
 }
 
 
@@ -165,7 +232,7 @@ size_t AP1roGGeminalCoefficients::matrixIndexMajor(size_t vector_index) const {
  */
 size_t AP1roGGeminalCoefficients::matrixIndexMinor(size_t vector_index) const {
 
-    return vector_index % (this->K - this->N_P) + this->N_P;  // we add N_P since we want a to be in [N_P ... K[
+    return AP1roGGeminalCoefficients::matrixIndexMinor(this->K, this->N_P, vector_index);
 }
 
 
@@ -177,20 +244,7 @@ size_t AP1roGGeminalCoefficients::matrixIndexMinor(size_t vector_index) const {
  */
 size_t AP1roGGeminalCoefficients::vectorIndex(size_t i, size_t a) const {
 
-    // Check for invalid values for i and a
-    if (i >= this->N_P) {
-        throw std::invalid_argument("The major index i (subscript) must be smaller than N_P.");
-    }
-    if (a < this->N_P) {
-        throw std::invalid_argument("The minor index a (superscript) must be larger than or equal to N_P.");
-    }
-
-
-    // The conversion from i and a to a single vector index is just a little more complicated than row-major storage.
-    // If we were to use the row-major storage formula, we would end up with
-    //      mu = a + (K - N_P) * i
-    // but since we would really like our indices abcd (virtual orbitals) to start at N_P, we should subtract N_P accordingly
-    return (a - this->N_P) + (this->K - this->N_P) * i;
+    return AP1roGGeminalCoefficients::vectorIndex(this->K, this->N_P, i, a);
 }
 
 

--- a/src/AP1roG/AP1roGGeminalCoefficients.cpp
+++ b/src/AP1roG/AP1roGGeminalCoefficients.cpp
@@ -35,7 +35,21 @@ AP1roGGeminalCoefficients::AP1roGGeminalCoefficients() :
 
 
 /**
- *  Constructor based on given geminal coefficients @param g, which are in vector (row-major) form
+ *  Constructor that sets the geminal coefficients to zero
+ *
+ *  @param N_P      the number of electron pairs (= the number of geminals)
+ *  @param K        the number of spatial orbitals
+ */
+AP1roGGeminalCoefficients::AP1roGGeminalCoefficients(size_t N_P, size_t K) :
+AP1roGGeminalCoefficients(Eigen::VectorXd::Zero(AP1roGGeminalCoefficients::numberOfGeminalCoefficients(N_P, K)), N_P, K)
+{}
+
+
+/**
+ *  @param g        the geminal coefficients in a vector representation that is in row-major storage
+ *
+ *  @param N_P      the number of electron pairs (= the number of geminals)
+ *  @param K        the number of spatial orbitals
  */
 AP1roGGeminalCoefficients::AP1roGGeminalCoefficients(const Eigen::VectorXd& g, size_t N_P, size_t K) :
     N_P (N_P),
@@ -49,19 +63,71 @@ AP1roGGeminalCoefficients::AP1roGGeminalCoefficients(const Eigen::VectorXd& g, s
 
 
 /**
- *  Constructor setting the geminal coefficients to zero, based on the number of orbitals @param K and number of electron pairs @param N_P
+ *  @param ham_par      the Hamiltonian parameters
+ *  @param N_P          the number of orbitals
+ *
+ *  @return the AP1roG geminal coefficients in the weak interaction limit
  */
-AP1roGGeminalCoefficients::AP1roGGeminalCoefficients(size_t N_P, size_t K) :
-    AP1roGGeminalCoefficients(Eigen::VectorXd::Zero(AP1roGGeminalCoefficients::numberOfGeminalCoefficients(N_P, K)), N_P, K)
-{}
+AP1roGGeminalCoefficients AP1roGGeminalCoefficients::WeakInteractionLimit(const HamiltonianParameters& ham_par, size_t N_P) {
 
+
+}
+
+
+
+/*
+ *  OPERATORS
+ */
+
+/**
+ *  @param mu       a vector index
+ *
+ *  @return the geminal coefficient g_mu
+ */
+double AP1roGGeminalCoefficients::operator()(size_t mu) const {
+    return this->g(mu);
+}
+
+
+/**
+ *  @param i        the major index (changes in i are not contiguous)
+ *  @param a        the minor index (changes in a are contiguous)
+ *
+ *  @return the geminal coefficient G_i^a
+ */
+double AP1roGGeminalCoefficients::operator()(size_t i, size_t a) const {
+    size_t mu = this->vectorIndex(i, a);
+    return this->operator()(mu);
+}
+
+
+/*
+ *  STATIC PUBLIC METHODS
+ */
+
+/**
+ *  @param N_P      the number of electron pairs (= the number of geminals)
+ *  @param K        the number of spatial orbitals
+ *
+ *  @return the number of 'free' geminal coefficients
+ */
+size_t AP1roGGeminalCoefficients::numberOfGeminalCoefficients(size_t N_P, size_t K) {
+
+    // Check if we can have N_P geminals in K orbitals
+    if (N_P >= K) {
+        throw std::invalid_argument("Can't have that many geminals in this few number of orbitals.");
+    }
+
+    return N_P * (K - N_P);
+}
 
 
 /*
  *  PUBLIC METHODS
  */
+
 /**
- *  Construct and @return the geminal coefficients in matrix form
+ *  @return the geminal coefficients in matrix form
  */
 Eigen::MatrixXd AP1roGGeminalCoefficients::asMatrix() const {
 
@@ -81,45 +147,10 @@ Eigen::MatrixXd AP1roGGeminalCoefficients::asMatrix() const {
 }
 
 
-/*
- *  OPERATORS
- */
 /**
- *  @return the geminal coefficient g_mu, in which @param mu is a 'vector index'
- */
-double AP1roGGeminalCoefficients::operator()(size_t mu) const {
-    return this->g(mu);
-}
-
-/**
- *  @ return the geminal coefficient G_i^a, in which @param i is the major index (changes in i are not contiguous) and @param a is the minor index (changes in a are contiguous)
- */
-double AP1roGGeminalCoefficients::operator()(size_t i, size_t a) const {
-    size_t mu = this->vectorIndex(i, a);
-    return this->operator()(mu);
-}
-
-
-/**
- *  @return the number of free geminal coefficients given a number of geminals @param N_P and a number of spatial orbitals @param K
- */
-size_t AP1roGGeminalCoefficients::numberOfGeminalCoefficients(size_t N_P, size_t K) {
-
-    // Check if we can have N_P geminals in K orbitals
-    if (N_P >= K) {
-        throw std::invalid_argument("Can't have that many geminals in this few number of orbitals.");
-    }
-
-    return N_P * (K - N_P);
-}
-
-
-/**
- *  For a geminal coefficient g_mu, return its major index in the matrix of geminal coefficients.
+ *  @param vector_index     the vector index of the geminal coefficient
  *
- *      Note that:
- *          - the major index is i (i.e. the subscript), since changes in i are not contiguous
- *          - i is in [0 ... N_P[
+ *  @return the major (non-contiguous) index i (i.e. the subscript) in the matrix of the geminal coefficients. Note that i is in [0 ... N_P[
  */
 size_t AP1roGGeminalCoefficients::matrixIndexMajor(size_t vector_index) const {
 
@@ -128,11 +159,9 @@ size_t AP1roGGeminalCoefficients::matrixIndexMajor(size_t vector_index) const {
 
 
 /**
- *  For a geminal coefficient g_mu, return its minor index in the matrix of geminal coefficients.
+ *  @param vector_index     the vector index of the geminal coefficient
  *
- *      Note that:
- *          - the minor index is a (i.e. the superscript), since changes in a are contiguous
- *          - a is in [N_P ... K[
+ *  @return the minor (contiguous) index a (i.e. the subscript) in the matrix of the geminal coefficients. Note that a is in [N_P ... K[
  */
 size_t AP1roGGeminalCoefficients::matrixIndexMinor(size_t vector_index) const {
 
@@ -141,11 +170,10 @@ size_t AP1roGGeminalCoefficients::matrixIndexMinor(size_t vector_index) const {
 
 
 /**
- *  For a geminal coefficient G_i^a, return its index in the vector of geminal coefficients.
+ *  @param i        the major index (changes in i are not contiguous)
+ *  @param a        the minor index (changes in a are contiguous)
  *
- *      Note that
- *          - i is in [0 ... N_P[       is the 'major' index (i.e. changes in i are not contiguous)
- *          - a is in [N_P ... K[       is the 'minor' index (i.e. changes in a are contiguous)
+ *  @return the vector index of the geminal coefficient G_i^a
  */
 size_t AP1roGGeminalCoefficients::vectorIndex(size_t i, size_t a) const {
 

--- a/tests/AP1roG/AP1roGPSESolver_test.cpp
+++ b/tests/AP1roG/AP1roGPSESolver_test.cpp
@@ -17,8 +17,8 @@
 // 
 #define BOOST_TEST_MODULE "AP1roGPSESolver"
 
-
 #include "AP1roG/AP1roGPSESolver.hpp"
+//#include "AP1roG/AP1roGGeminalCoefficients.hpp"
 
 #include "HamiltonianParameters/HamiltonianParameters_constructors.hpp"
 #include "Molecule.hpp"
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE ( h2_631gdp ) {
     ref_ap1rog_coefficients << -0.05949796, -0.05454253, -0.03709503, -0.02899231, -0.02899231, -0.01317386, -0.00852702, -0.00852702, -0.00517996;
 
 
-    // 1. Do an RHF calculation
+    // Prepare molecular Hamiltonian parameters in the RHF basis
     GQCP::Molecule h2 ("../tests/data/h2_olsens.xyz");
     auto ao_basis = std::make_shared<GQCP::AOBasis>(h2, "6-31G**");
     auto ao_mol_ham_par = GQCP::constructMolecularHamiltonianParameters(ao_basis);
@@ -75,10 +75,10 @@ BOOST_AUTO_TEST_CASE ( h2_631gdp ) {
     plain_scf_solver.solve();
     auto rhf = plain_scf_solver.get_solution();
 
-
-
-    // 2. Solve the AP1roG pSE equations
     auto mol_ham_par = GQCP::HamiltonianParameters(ao_mol_ham_par, rhf.get_C());
+
+
+    // Solve the AP1roG pSE equations with the initial guess being 0
     GQCP::AP1roGPSESolver ap1rog_pse_solver (h2, mol_ham_par);
     ap1rog_pse_solver.solve();
 
@@ -87,7 +87,47 @@ BOOST_AUTO_TEST_CASE ( h2_631gdp ) {
     Eigen::VectorXd ap1rog_coefficients = ap1rog.get_geminal_coefficients().asVector();
 
 
-    // Check the energy and coefficients
+    BOOST_CHECK(std::abs(electronic_energy - ref_ap1rog_energy) < 1.0e-05);
+
+    for (size_t i = 0; i < 9; i++) {
+        BOOST_CHECK(std::abs(ap1rog_coefficients(i) - ref_ap1rog_coefficients(i)) < 1.0e-05);
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE ( h2_631gdp_weak_interaction_limit ) {
+
+    // We have some reference data from olsens: H2 with HF/6-31G** orbitals
+    //  AP1roG energy: -1.8696828608304892
+    //  AP1roG coefficients: [-0.05949796, -0.05454253, -0.03709503, -0.02899231, -0.02899231, -0.01317386, -0.00852702, -0.00852702, -0.00517996]
+
+    double ref_ap1rog_energy = -1.8696828608304892;
+    Eigen::VectorXd ref_ap1rog_coefficients (9);
+    ref_ap1rog_coefficients << -0.05949796, -0.05454253, -0.03709503, -0.02899231, -0.02899231, -0.01317386, -0.00852702, -0.00852702, -0.00517996;
+
+
+    // Prepare molecular Hamiltonian parameters in the RHF basis
+    GQCP::Molecule h2 ("../tests/data/h2_olsens.xyz");
+    size_t N_P = h2.get_N() / 2;
+    auto ao_basis = std::make_shared<GQCP::AOBasis>(h2, "6-31G**");
+    auto ao_mol_ham_par = GQCP::constructMolecularHamiltonianParameters(ao_basis);
+
+    GQCP::PlainRHFSCFSolver plain_scf_solver (ao_mol_ham_par, h2);
+    plain_scf_solver.solve();
+    auto rhf = plain_scf_solver.get_solution();
+
+    auto mol_ham_par = GQCP::HamiltonianParameters(ao_mol_ham_par, rhf.get_C());
+
+
+    // Solve the AP1roG pSE equations, with the initial guess being the weak interaction limit coefficients
+    GQCP::AP1roGPSESolver ap1rog_pse_solver (h2, mol_ham_par, GQCP::AP1roGGeminalCoefficients::WeakInteractionLimit(mol_ham_par, N_P));
+    ap1rog_pse_solver.solve();
+
+    auto ap1rog = ap1rog_pse_solver.get_solution();
+    double electronic_energy = ap1rog.get_electronic_energy();
+    Eigen::VectorXd ap1rog_coefficients = ap1rog.get_geminal_coefficients().asVector();
+
+
     BOOST_CHECK(std::abs(electronic_energy - ref_ap1rog_energy) < 1.0e-05);
 
     for (size_t i = 0; i < 9; i++) {


### PR DESCRIPTION
This PR implements the ability to use the weak interaction limit for the AP1roG geminal coefficients as the initial guess for solving the PSEs.