### PR TITLE
Bugfix/rpath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ endif()
 # Set CMake variables
 include(${CMAKE_SOURCE_DIR}/cmake/SetCMakeEnvironment.cmake)
 
+# From RPATH to full installation path
+# https://stackoverflow.com/questions/30398238/cmake-rpath-not-working-could-not-find-shared-object-file
+set(CMAKE_INSTALL_RPATH "${LIBRARY_INSTALL_DIR}")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 message(STATUS "Building ${LIBRARY_NAME} in ${CMAKE_BUILD_TYPE} mode")
 
 # Find all required packages. Update CMake's MODULE_PATH to let CMake know that we have supplied our own FindXXX.cmake files in the cmake/Find directory
@@ -55,3 +60,6 @@ endif(BUILD_BENCHMARKS)
 # Set up testing
 enable_testing()
 add_subdirectory(${PROJECT_TESTS_FOLDER})
+
+
+

--- a/cmake/InstallLibrary.cmake
+++ b/cmake/InstallLibrary.cmake
@@ -5,7 +5,7 @@
 # To specify that this target should also be exported, we add the EXPORT option. This is used in conjuction with the install(EXPORT) command below
 install(TARGETS ${LIBRARY_NAME}
         EXPORT ${LIBRARY_NAME} ${EXPORT_TYPE}
-        DESTINATION ${LIBRARY_INSTALL_DIR})
+        LIBRARY DESTINATION ${LIBRARY_INSTALL_DIR})
 
 
 # Parse the version.hpp.in (input - .in) file (this replaces all @VAR@ by their CMake value)

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -1,6 +1,6 @@
 # drivers-level CMakeLists.txt
 
-foreach(DRIVER_SOURCE ${PROJECT_DRIVER_SOURCE_FILES})
+foreach(DRIVER_SOURCE ${PROJECT_DRIVERS_SOURCE_FILES})
     # Extract the filename without extension (NAME_WE) as a name for our executable
     get_filename_component(DRIVER_NAME ${DRIVER_SOURCE} NAME_WE)
 


### PR DESCRIPTION
This commit fixes errors related to libraries that cannot be found on Mac systems, typically signalled at runtime as 

dyld: Library not loaded: @rpath/libgqcp.dylib