### PR TITLE
Make the DIIS algorithm more flexible

### DIFF
--- a/include/RHF/DIISRHFSCFSolver.hpp
+++ b/include/RHF/DIISRHFSCFSolver.hpp
@@ -32,10 +32,11 @@ namespace GQCP {
 
 class DIISRHFSCFSolver : public RHFSCFSolver {
 private:
+    size_t minimum_subspace_dimension;
     size_t maximum_subspace_dimension;
 
     std::deque<OneElectronOperator<double>> fock_matrix_deque = {};  // deque of Fock matrices used in the DIIS algorithm
-    std::deque<SquareMatrix<double>> error_matrix_deque = {};  // deque of error matrices used in the DIIS algorithm
+    std::deque<OneElectronOperator<double>> error_matrix_deque = {};  // deque of error matrices used in the DIIS algorithm
 
 
     // PRIVATE METHODS
@@ -53,11 +54,12 @@ public:
     /**
      *  @param ham_par                          the Hamiltonian parameters in AO basis
      *  @param molecule                         the molecule used for the SCF calculation
-     *  @param maximum_subspace_dimension       the maximum DIIS subspace dimension before a collapse occurs
+     *  @param minimum_subspace_dimension       the minimum number of Fock matrices that have to be in the subspace before enabling DIIS
+     *  @param maximum_subspace_dimension       the maximum DIIS subspace dimension before the oldest Fock matrices get discarded (one at a time)
      *  @param threshold                        the convergence treshold on the Frobenius norm on the AO density matrix
      *  @param maximum_number_of_iterations     the maximum number of iterations for the SCF procedure
      */
-    DIISRHFSCFSolver(HamiltonianParameters<double> ham_par, Molecule molecule, size_t maximum_subspace_dimension = 6, double threshold=1.0e-08, size_t maximum_number_of_iterations=128);
+    DIISRHFSCFSolver(HamiltonianParameters<double> ham_par, Molecule molecule, size_t minimum_subspace_dimension=6, size_t maximum_subspace_dimension=6, double threshold=1.0e-08, size_t maximum_number_of_iterations=128);
 };
 
 

--- a/include/RHF/DIISRHFSCFSolver.hpp
+++ b/include/RHF/DIISRHFSCFSolver.hpp
@@ -32,8 +32,8 @@ namespace GQCP {
 
 class DIISRHFSCFSolver : public RHFSCFSolver {
 private:
-    size_t minimum_subspace_dimension;
-    size_t maximum_subspace_dimension;
+    size_t minimum_subspace_dimension;  // the minimum number of Fock matrices that have to be in the subspace before enabling DIIS
+    size_t maximum_subspace_dimension;  // the maximum DIIS subspace dimension before the oldest Fock matrices get discarded (one at a time)
 
     std::deque<OneElectronOperator<double>> fock_matrix_deque = {};  // deque of Fock matrices used in the DIIS algorithm
     std::deque<OneElectronOperator<double>> error_matrix_deque = {};  // deque of error matrices used in the DIIS algorithm

--- a/src/RHF/DIISRHFSCFSolver.cpp
+++ b/src/RHF/DIISRHFSCFSolver.cpp
@@ -76,11 +76,10 @@ OneElectronOperator<double> DIISRHFSCFSolver::calculateNewFockMatrix(const OneRD
             f_AO += y(i) * this->fock_matrix_deque[i];
         }
 
+    }
 
-    }  // subspace collapse
 
-
-    // Collapse the subspace if it becomes too large, discard the oldest entry
+    // Discard the oldest entry in the Fock matrix subspace if it becomes too large
     if (n > this->maximum_subspace_dimension) {
         this->fock_matrix_deque.pop_front();
         this->error_matrix_deque.pop_front();

--- a/src/RHF/DIISRHFSCFSolver.cpp
+++ b/src/RHF/DIISRHFSCFSolver.cpp
@@ -65,8 +65,9 @@ OneElectronOperator<double> DIISRHFSCFSolver::calculateNewFockMatrix(const OneRD
         b(n) = -1;  // the last entry of b is accessed through n: dimension of b is n+1 - 1 because of computers
 
 
-        // Solve the DIIS non-linear equations
-        VectorX<double> y = B.inverse() * b;
+        // Solve the DIIS linear equations B y = b
+        Eigen::HouseholderQR<Eigen::MatrixXd> lin_solver (B);
+        VectorX<double> y = lin_solver.solve(b);
 
 
         // Use the coefficients that are in y to construct 'the best' Fock matrix as a linear combination of previous Fock matrices


### PR DESCRIPTION
I did a force push to reset the changes that had been made, as I think updating the DIIS algorithm doesn't have to include the conditioning number step, since that seems to have no impact whatsoever.

The DIIS algorithm will be more flexible if we
- keep the `maximum_subspace_dimension`, such that if there are too many Fock matrices, the oldest one is discarded 
- introduce a `minimum_subspace_dimension`, such that DIIS is only enabled when there have been at least this many iterations (and thus Fock matrices)