### PR TITLE
Add Python version info (closes #346)

### DIFF
--- a/cmake/version.hpp.in
+++ b/cmake/version.hpp.in
@@ -31,7 +31,7 @@ namespace ${PROJECT_NAME_UPPERCASE} {
  *  A class that holds version-related info: the version numbers and the corresponding git SHA1
  */
 struct Version {
-private:
+public:
     static constexpr size_t major = ${PROJECT_VERSION_MAJOR};
     static constexpr size_t minor = ${PROJECT_VERSION_MINOR};
     static constexpr size_t patch = ${PROJECT_VERSION_PATCH};

--- a/gqcpy/CMakeLists.txt
+++ b/gqcpy/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND python_bindings_sources
         ${CMAKE_CURRENT_SOURCE_DIR}/bindings.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/version.cpp
     )
 
 add_subdirectory(QCMethod)

--- a/gqcpy/__init__.py.in
+++ b/gqcpy/__init__.py.in
@@ -1,1 +1,5 @@
 from .gqcpy import *
+
+
+# Print version-related information upon import
+print("gqcpy version {} @ {}".format(gqcpy.Version.full, gqcpy.Version.git_sha1))

--- a/gqcpy/bindings.cpp
+++ b/gqcpy/bindings.cpp
@@ -27,6 +27,7 @@ namespace gqcpy {
 
 void bindQCMethodHubbard(py::module& module);
 void bindQCMethodFCI(py::module& module);
+void bindVersion(py::module& module);
 
 }  // namespace gqcpy
 
@@ -40,4 +41,5 @@ PYBIND11_MODULE (gqcpy, module) {
 
     gqcpy::bindQCMethodHubbard(module);
     gqcpy::bindQCMethodFCI(module);
+    gqcpy::bindVersion(module);
 }

--- a/gqcpy/version.cpp
+++ b/gqcpy/version.cpp
@@ -15,11 +15,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with GQCG-gqcp.  If not, see <http://www.gnu.org/licenses/>.
 // 
-#include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include "QCMethod/FCI.hpp"
+#include "version.hpp"
 
 
 namespace py = pybind11;
@@ -28,13 +27,15 @@ namespace py = pybind11;
 namespace gqcpy {
 
 
-void bindQCMethodFCI(py::module& module) {
-    py::class_<GQCP::QCMethod::FCI>(module, "FCI", "Construct and solve the FCI Hamiltonian.")
-        .def(py::init<const std::string, const std::string, const size_t, const size_t>(), py::arg("xyz_filename"), py::arg("basis_set"), py::arg("num_alpha"), py::arg("num_beta"))
-        .def("solve", &GQCP::QCMethod::FCI::solve, "Solve the eigenvalue equations such that the lowest energy and corresponding eigenvector become available. ")
-        .def("get_energy", &GQCP::QCMethod::FCI::energy, "Get the lowest energy.");
+void bindVersion(py::module& module) {
+    py::class_<GQCP::Version>(module, "Version", "Information on the GQCP version")
+        .def_property_readonly_static("major", [] (py::object) { return GQCP::Version::major; }, "The GQCP major version")
+        .def_property_readonly_static("minor", [] (py::object) { return GQCP::Version::minor; }, "The GQCP minor version")
+        .def_property_readonly_static("patch", [] (py::object) { return GQCP::Version::patch; }, "The GQCP patch version")
+        .def_property_readonly_static("full", [] (py::object) { return GQCP::Version::full; }, "The full GQCP version")
+        .def_property_readonly_static("git_sha1", [] (py::object) { return GQCP::Version::git_SHA1; }, "The current GQCP commit SHA1")
+        ;
 }
-
 
 
 }  // namespace gqcpy

--- a/gqcpy/version.cpp
+++ b/gqcpy/version.cpp
@@ -33,8 +33,7 @@ void bindVersion(py::module& module) {
         .def_property_readonly_static("minor", [] (py::object) { return GQCP::Version::minor; }, "The GQCP minor version")
         .def_property_readonly_static("patch", [] (py::object) { return GQCP::Version::patch; }, "The GQCP patch version")
         .def_property_readonly_static("full", [] (py::object) { return GQCP::Version::full; }, "The full GQCP version")
-        .def_property_readonly_static("git_sha1", [] (py::object) { return GQCP::Version::git_SHA1; }, "The current GQCP commit SHA1")
-        ;
+        .def_property_readonly_static("git_sha1", [] (py::object) { return GQCP::Version::git_SHA1; }, "The current GQCP commit SHA1");
 }
 
 


### PR DESCRIPTION
In this PR, I've implemented the printing of the version info upon loading `gqcpy`.