### PR TITLE
Point Travis to new libcint branch. MKL is now a hard requirement.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ install:
 
     # Install the GQCG fork of Libcint
     - cd /tmp
-    - git clone -b feature/cmake_refactor https://github.com/GQCG/libcint.git
+    - git clone -b develop https://github.com/GQCG/libcint.git
     - cd libcint
     - mkdir build && cd build
     - cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ install:
     - git clone -b develop https://github.com/GQCG/libcint.git
     - cd libcint
     - mkdir build && cd build
-    - cmake ..
+    - cmake .. -DUSE_MKL=TRUE
     - make -j3 && sudo make install
 
 # Run the build script

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,14 +45,6 @@ before_install:
         bash $HOME/download/miniconda.sh -b -p ${HOME}/miniconda;
       fi
 
-    # Add headers and libraries to path
-    - export CONDA_HOME=${HOME}/miniconda
-    - export C_INCLUDE_PATH=${CONDA_HOME}/include:${C_INCLUDE_PATH}
-    - export CPLUS_INCLUDE_PATH=${CONDA_HOME}/include:${CPLUS_INCLUDE_PATH}
-    - export LIBRARY_PATH=${CONDA_HOME}/lib:${LIBRARY_PATH}
-    - export LD_LIBRARY_PATH=${CONDA_HOME}/lib:${LD_LIBRARY_PATH}
-    - export DYLD_FALLBACK_LIBRARY_PATH=${CONDA_HOME}/lib:${DYLD_FALLBACK_LIBRARY_PATH}
-
     # Set GCC 8 compiler
     - export CC=/usr/bin/gcc-8
     - export CXX=/usr/bin/g++-8
@@ -92,14 +84,14 @@ install:
     - git clone -b develop https://github.com/GQCG/libcint.git
     - cd libcint
     - mkdir build && cd build
-    - cmake .. -DUSE_MKL=TRUE
+    - cmake .. -DUSE_MKL=TRUE -DCMAKE_INSTALL_PREFIX=~/.local -DCMAKE_PREFIX_PATH=${HOME}/miniconda
     - make -j3 && sudo make install
 
 # Run the build script
 script:
   - cd ${TRAVIS_BUILD_DIR}
   - mkdir build && cd build
-  - cmake .. -DBUILD_TESTS=TRUE -DBUILD_BENCHMARKS=TRUE -DBUILD_DRIVERS=TRUE -DBUILD_PYTHON_BINDINGS=TRUE -DCMAKE_INCLUDE_PATH=${HOME}/miniconda/include -DCMAKE_LIBRARY_PATH=${HOME}/miniconda/lib
+  - cmake .. -DBUILD_TESTS=TRUE -DBUILD_BENCHMARKS=TRUE -DBUILD_DRIVERS=TRUE -DBUILD_PYTHON_BINDINGS=TRUE -DCMAKE_INSTALL_PREFIX=~/.local -DCMAKE_PREFIX_PATH=${HOME}/miniconda
   - make -j3 VERBOSE=1 && env CTEST_OUTPUT_ON_FAILURE=1 make test ARGS=-j3 && sudo make install
 
 # Run the benchmarks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ option(BUILD_DOCS "Build the documentation using Doxygen" OFF)
 option(BUILD_BENCHMARKS "Build benchmarks executables" OFF)
 option(BUILD_DRIVERS "Build standard drivers" OFF)
 option(BUILD_PYTHON_BINDINGS "Build the Python bindings" OFF)
-option(EIGEN_USE_MKL "Eigen uses MKL" OFF)
 
 # Look for supporting libraries
 # -----------------------------
@@ -26,11 +25,8 @@ find_package(Git REQUIRED)
 find_package(Eigen3 3.3.4 REQUIRED)
 find_package(Int2 REQUIRED)
 find_package(Spectra REQUIRED)
-find_package(Cint REQUIRED)
-
-if(EIGEN_USE_MKL)
-    find_package(MKL REQUIRED)
-endif()
+find_package(cint REQUIRED)
+find_package(MKL REQUIRED)
 
 if(BUILD_TESTS)
     find_package(Boost REQUIRED COMPONENTS program_options unit_test_framework)
@@ -86,18 +82,13 @@ target_link_libraries(gqcp
         PUBLIC
             Eigen3::Eigen
             Int2::Int2
-            Cint::Cint
+            cint::cint
             Spectra::Spectra
+            MKL::MKL
         )
 target_include_directories(gqcp PUBLIC $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>)
 target_link_libraries(gqcp PUBLIC ${Boost_LIBRARIES})
-if (EIGEN_USE_MKL)
-    target_link_libraries(gqcp
-        PUBLIC
-            MKL::MKL
-        )
-    target_compile_options(gqcp PUBLIC -DEIGEN_USE_MKL_ALL -DMKL_LP64)
-endif()
+target_compile_options(gqcp PUBLIC -DEIGEN_USE_MKL_ALL -DMKL_LP64)
 
 
 # Setup Python Bindings

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -29,28 +29,20 @@ find_path(MKL_INCLUDE_DIR mkl.h HINTS $ENV{MKLROOT}/include)
 find_library(MKL_INTERFACE_LIBRARY NAMES libmkl_intel_lp64.a PATHS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64)
 find_library(MKL_INTEL_THREAD NAMES libmkl_intel_thread.a PATHS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64)
 find_library(MKL_CORE_LIBRARY NAMES libmkl_core.a PATHS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64)
-find_library(MKL_LAPACK NAMES libmkl_lapack.a PATHS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64)
 get_filename_component(IOMP5_ROOT $ENV{MKLROOT}/.. ABSOLUTE) # The root of IOMP installation can be one directory above the MKL root.
 find_library(MKL_IOMP5 NAMES libiomp5.so libiomp5.dylib PATHS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64 ${IOMP5_ROOT}/lib ${IOMP5_ROOT}/lib/intel64) # This library should be dynamically linked.
 
-mark_as_advanced(MKL_INCLUDE_DIR MKL_INTERFACE_LIBRARY MKL_INTEL_THREAD MKL_CORE_LIBRARY MKL_LAPACK MKL_IOMP5)
+mark_as_advanced(MKL_INCLUDE_DIR MKL_INTERFACE_LIBRARY MKL_INTEL_THREAD MKL_CORE_LIBRARY MKL_IOMP5)
 
-if("${MKL_LAPACK}" STREQUAL "MKL_LAPACK-NOTFOUND")
-    find_package_handle_standard_args(MKL REQUIRED_VARS
-        MKL_INCLUDE_DIR MKL_INTERFACE_LIBRARY MKL_INTEL_THREAD MKL_CORE_LIBRARY MKL_IOMP5) # sets MKL_FOUND
+find_package_handle_standard_args(MKL REQUIRED_VARS
+    MKL_INCLUDE_DIR MKL_INTERFACE_LIBRARY MKL_INTEL_THREAD MKL_CORE_LIBRARY MKL_IOMP5) # sets MKL_FOUND
 
-    if(MKL_FOUND AND NOT TARGET MKL::MKL)
-        add_library(MKL::MKL INTERFACE IMPORTED)
-        target_include_directories(MKL::MKL INTERFACE ${MKL_INCLUDE_DIR})
+if(MKL_FOUND AND NOT TARGET MKL::MKL)
+    add_library(MKL::MKL INTERFACE IMPORTED)
+    target_include_directories(MKL::MKL INTERFACE ${MKL_INCLUDE_DIR})
+    if(NOT APPLE)
+        target_link_libraries(MKL::MKL INTERFACE  -Wl,--start-group ${MKL_INTERFACE_LIBRARY} ${MKL_INTEL_THREAD} ${MKL_CORE_LIBRARY} -Wl,--end-group ${MKL_IOMP5} pthread m dl)
+    else()
         target_link_libraries(MKL::MKL INTERFACE ${MKL_INTERFACE_LIBRARY} ${MKL_INTEL_THREAD} ${MKL_CORE_LIBRARY} ${MKL_IOMP5} pthread m dl)
-    endif()
-else()
-    find_package_handle_standard_args(MKL REQUIRED_VARS
-            MKL_INCLUDE_DIR MKL_INTERFACE_LIBRARY MKL_INTEL_THREAD MKL_CORE_LIBRARY MKL_LAPACK MKL_IOMP5) # sets MKL_FOUND
-
-    if(MKL_FOUND AND NOT TARGET MKL::MKL)
-        add_library(MKL::MKL INTERFACE IMPORTED)
-        target_include_directories(MKL::MKL INTERFACE ${MKL_INCLUDE_DIR})
-        target_link_libraries(MKL::MKL INTERFACE ${MKL_INTERFACE_LIBRARY} ${MKL_INTEL_THREAD} ${MKL_CORE_LIBRARY} ${MKL_LAPACK} ${MKL_IOMP5} pthread m dl)
     endif()
 endif()


### PR DESCRIPTION
This PR fixes the Travis issues. In light of:

- the dependency on libcint and its dependency on a BLAS library
- the Eigen support for MKL and its current use in production

MKL is now required to compile GQCP (the -DEIGEN_USE_MKL has been deleted).