### PR TITLE
Switch to conda installer for benchmark (Closes #319).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
 
     # Install a recent version of CMake, Boost and eigen if they are not yet already installed.
     - if [ ! -f $HOME/miniconda/bin/cmake ]; then
-        conda install -c conda-forge cmake=3.13 boost-cpp eigen blas mkl pybind11;
+        conda install -c conda-forge cmake=3.13 boost-cpp eigen blas mkl pybind11 benchmark;
         conda install -c gqcg libint spectra;
         conda install -c intel mkl-include mkl-static intel-openmp;
       else
@@ -67,17 +67,6 @@ install:
       fi
     - export PATH=${HOME}/miniconda/bin:${PATH} # Use conda CMake
     - export LIBINT_DATA_PATH=${HOME}/miniconda/share/libint/2.3.1/basis
-
-    # Install google benchmark
-    - mkdir /tmp/bench && cd /tmp/bench
-    # Fork from tmhuysen for cmake fix
-    - git clone https://github.com/tmhuysen/benchmark.git
-    # Benchmark requires Google Test as a dependency. Add the source tree as a subdirectory.
-    - cd benchmark
-    - git clone https://github.com/google/googletest.git
-    - mkdir build && cd build
-    - cmake .. -DCMAKE_BUILD_TYPE=RELEASE
-    - make -j3 && sudo make install
 
     # Install the GQCG fork of Libcint
     - cd /tmp

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -12,9 +12,8 @@ foreach(BENCHMARK_SOURCE ${benchmark_target_sources})
     add_executable(${BENCHMARK_NAME} ${BENCHMARK_SOURCE})
 
     # Configure (include headers and link libraries) the benchmark ...
-    target_include_directories(${BENCHMARK_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/include)
     target_link_libraries(${BENCHMARK_NAME} PUBLIC gqcp)
-    target_link_libraries(${BENCHMARK_NAME} PUBLIC "-lbenchmark")  # link google benchmarks
+    target_link_libraries(${BENCHMARK_NAME} PUBLIC benchmark::benchmark)  # link google benchmarks
 
 endforeach()
 


### PR DESCRIPTION
This PR removes the dependency on the benchmark fork from tmhuysen.