### PR TITLE
Remove dependency on Boost < 1.70.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
 
     # Install a recent version of CMake, Boost and eigen if they are not yet already installed.
     - if [ ! -f $HOME/miniconda/bin/cmake ]; then
-        conda install -c conda-forge cmake=3.13 boost-cpp=1.69.0 eigen blas mkl pybind11 benchmark;
+        conda install -c conda-forge cmake=3.13 boost-cpp=1.70.0 eigen blas mkl pybind11 benchmark;
         conda install -c gqcg libint spectra;
         conda install -c intel mkl-include mkl-static intel-openmp;
       else

--- a/tests/Basis/AOBasis_test.cpp
+++ b/tests/Basis/AOBasis_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "AOBasis"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Basis/AOBasis.hpp"
 

--- a/tests/Basis/CartesianExponents_test.cpp
+++ b/tests/Basis/CartesianExponents_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "CartesianExponents"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Basis/CartesianExponents.hpp"
 

--- a/tests/Basis/CartesianGTO_test.cpp
+++ b/tests/Basis/CartesianGTO_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "CartesianGTO"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "Basis/CartesianGTO.hpp"

--- a/tests/Basis/LibintInterfacer_test.cpp
+++ b/tests/Basis/LibintInterfacer_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "LibintInterfacer"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Basis/LibintInterfacer.hpp"
 

--- a/tests/Basis/ShellSet_test.cpp
+++ b/tests/Basis/ShellSet_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "ShellSet"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Basis/ShellSet.hpp"
 

--- a/tests/Basis/Shell_test.cpp
+++ b/tests/Basis/Shell_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "Shell"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Basis/Shell.hpp"
 

--- a/tests/CISolver/CISolver_DOCI_Davidson_test.cpp
+++ b/tests/CISolver/CISolver_DOCI_Davidson_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "DavidsonDOCISolver"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "CISolver/CISolver.hpp"
 #include "HamiltonianBuilder/DOCI.hpp"

--- a/tests/CISolver/CISolver_DOCI_Dense_test.cpp
+++ b/tests/CISolver/CISolver_DOCI_Dense_test.cpp
@@ -16,7 +16,7 @@
 // along with GQCG-gqcp.  If not, see <http://www.gnu.org/licenses/>.
 // 
 #define BOOST_TEST_MODULE "DenseDOCISolver"
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 

--- a/tests/CISolver/CISolver_DOCI_constrained_test.cpp
+++ b/tests/CISolver/CISolver_DOCI_constrained_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "ConstrainedDociSolver"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "CISolver/CISolver.hpp"

--- a/tests/CISolver/CISolver_FCI_Davidson_test.cpp
+++ b/tests/CISolver/CISolver_FCI_Davidson_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "DavidsonFCISolver"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "CISolver/CISolver.hpp"
 #include "HamiltonianBuilder/FCI.hpp"

--- a/tests/CISolver/CISolver_FCI_Dense_test.cpp
+++ b/tests/CISolver/CISolver_FCI_Dense_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "DenseDOCISolver"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "CISolver/CISolver.hpp"
 #include "FockSpace/ProductFockSpace.hpp"

--- a/tests/CISolver/CISolver_Hubbard_Davidson_test.cpp
+++ b/tests/CISolver/CISolver_Hubbard_Davidson_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "DavidsonHubbardSolver"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "CISolver/CISolver.hpp"

--- a/tests/CISolver/CISolver_Hubbard_Dense_test.cpp
+++ b/tests/CISolver/CISolver_Hubbard_Dense_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "DenseDOCISolver"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "CISolver/CISolver.hpp"

--- a/tests/CISolver/CISolver_test.cpp
+++ b/tests/CISolver/CISolver_test.cpp
@@ -16,7 +16,7 @@
 // along with GQCG-gqcp.  If not, see <http://www.gnu.org/licenses/>.
 // 
 #define BOOST_TEST_MODULE "CISolver"
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "CISolver/CISolver.hpp"

--- a/tests/FockSpace/FockSpace_test.cpp
+++ b/tests/FockSpace/FockSpace_test.cpp
@@ -16,7 +16,7 @@
 // along with GQCG-gqcp.  If not, see <http://www.gnu.org/licenses/>.
 // 
 #define BOOST_TEST_MODULE "FockSpace"
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "FockSpace/FockSpace.hpp"

--- a/tests/FockSpace/FrozenFockSpace_test.cpp
+++ b/tests/FockSpace/FrozenFockSpace_test.cpp
@@ -16,7 +16,7 @@
 // along with GQCG-gqcp.  If not, see <http://www.gnu.org/licenses/>.
 // 
 #define BOOST_TEST_MODULE "FrozenFockSpace"
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "FockSpace/FrozenFockSpace.hpp"

--- a/tests/FockSpace/FrozenProductFockSpace_test.cpp
+++ b/tests/FockSpace/FrozenProductFockSpace_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "FrozenProductFockSpace"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "FockSpace/FrozenProductFockSpace.hpp"
 #include "FockSpace/SelectedFockSpace.hpp"

--- a/tests/FockSpace/ONV_test.cpp
+++ b/tests/FockSpace/ONV_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "ONV"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "FockSpace/ONV.hpp"
 #include "FockSpace/FockSpace.hpp"

--- a/tests/FockSpace/ProductFockSpace_test.cpp
+++ b/tests/FockSpace/ProductFockSpace_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "ProductFockSpace"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "FockSpace/ProductFockSpace.hpp"
 #include "FockSpace/SelectedFockSpace.hpp"

--- a/tests/FockSpace/SelectedFockSpace_test.cpp
+++ b/tests/FockSpace/SelectedFockSpace_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "SelectedFockSpace"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "FockSpace/SelectedFockSpace.hpp"

--- a/tests/Geminals/AP1roGGeminalCoefficients_test.cpp
+++ b/tests/Geminals/AP1roGGeminalCoefficients_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "AP1roGGeminalCoefficients"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Geminals/AP1roGGeminalCoefficients.hpp"
 

--- a/tests/Geminals/AP1roGLagrangianOptimizer_test.cpp
+++ b/tests/Geminals/AP1roGLagrangianOptimizer_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "AP1roGLagrangianOptimizer"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Geminals/AP1roGLagrangianOptimizer.hpp"
 #include "RHF/PlainRHFSCFSolver.hpp"

--- a/tests/Geminals/AP1roGPSESolver_test.cpp
+++ b/tests/Geminals/AP1roGPSESolver_test.cpp
@@ -16,7 +16,7 @@
 // along with GQCG-gqcp.  If not, see <http://www.gnu.org/licenses/>.
 // 
 #define BOOST_TEST_MODULE "AP1roGPSESolver"
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Geminals/AP1roGPSESolver.hpp"
 

--- a/tests/Geminals/AP1roGVariables_test.cpp
+++ b/tests/Geminals/AP1roGVariables_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "AP1roGVariables"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Geminals/AP1roGVariables.hpp"
 

--- a/tests/Geminals/AP1roG_test.cpp
+++ b/tests/Geminals/AP1roG_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "AP1roG"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Geminals/AP1roG.hpp"
 

--- a/tests/Geminals/APIGGeminalCoefficients_test.cpp
+++ b/tests/Geminals/APIGGeminalCoefficients_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "APIGGeminalCoefficients"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Geminals/APIGGeminalCoefficients.hpp"
 

--- a/tests/HamiltonianBuilder/DOCI_test.cpp
+++ b/tests/HamiltonianBuilder/DOCI_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "DOCI"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 

--- a/tests/HamiltonianBuilder/FCI_test.cpp
+++ b/tests/HamiltonianBuilder/FCI_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "FCI"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "HamiltonianBuilder/FCI.hpp"
 

--- a/tests/HamiltonianBuilder/FrozenCoreDOCI_test.cpp
+++ b/tests/HamiltonianBuilder/FrozenCoreDOCI_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "FrozenCoreDOCI"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "HamiltonianBuilder/FrozenCoreDOCI.hpp"
 

--- a/tests/HamiltonianBuilder/FrozenCoreFCI_test.cpp
+++ b/tests/HamiltonianBuilder/FrozenCoreFCI_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "FrozenCoreFCI"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "HamiltonianBuilder/FrozenCoreFCI.hpp"
 

--- a/tests/HamiltonianBuilder/Hubbard_test.cpp
+++ b/tests/HamiltonianBuilder/Hubbard_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "Hubbard"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "HamiltonianBuilder/Hubbard.hpp"
 

--- a/tests/HamiltonianBuilder/SelectedCI_test.cpp
+++ b/tests/HamiltonianBuilder/SelectedCI_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "SelectedCI"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "HamiltonianBuilder/SelectedCI.hpp"
 #include "HamiltonianBuilder/FCI.hpp"

--- a/tests/HamiltonianParameters/HamiltonianParameters_test.cpp
+++ b/tests/HamiltonianParameters/HamiltonianParameters_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "HamiltonianParameters"
 #include <boost/math/constants/constants.hpp>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "HamiltonianParameters/HamiltonianParameters.hpp"
 

--- a/tests/HoppingMatrix_test.cpp
+++ b/tests/HoppingMatrix_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "HoppingMatrix"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "HoppingMatrix.hpp"
 

--- a/tests/Mathematical/ChemicalMatrix_test.cpp
+++ b/tests/Mathematical/ChemicalMatrix_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "ChemicalMatrix"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Mathematical/ChemicalMatrix.hpp"
 

--- a/tests/Mathematical/ChemicalRankFourTensor_test.cpp
+++ b/tests/Mathematical/ChemicalRankFourTensor_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "ChemicalRankFourTensor"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Mathematical/ChemicalRankFourTensor.hpp"
 

--- a/tests/Mathematical/Matrix_test.cpp
+++ b/tests/Mathematical/Matrix_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "Matrix"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Mathematical/Matrix.hpp"
 

--- a/tests/Mathematical/Optimization/DavidsonSolver_test.cpp
+++ b/tests/Mathematical/Optimization/DavidsonSolver_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "DavidsonSolver"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Mathematical/Optimization/DavidsonSolver.hpp"
 

--- a/tests/Mathematical/Optimization/DenseSolver_test.cpp
+++ b/tests/Mathematical/Optimization/DenseSolver_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "Dense"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "Mathematical/Optimization/DenseSolver.hpp"

--- a/tests/Mathematical/Optimization/Eigenpair_test.cpp
+++ b/tests/Mathematical/Optimization/Eigenpair_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "Eigenpair"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "Mathematical/Optimization/Eigenpair.hpp"

--- a/tests/Mathematical/Optimization/IterativeIdentitiesHessianModifier_test.cpp
+++ b/tests/Mathematical/Optimization/IterativeIdentitiesHessianModifier_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "IterativeIdentitiesHessianModifier_test"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Mathematical/Optimization/IterativeIdentitiesHessianModifier.hpp"
 

--- a/tests/Mathematical/Optimization/NewtonMinimizer_test.cpp
+++ b/tests/Mathematical/Optimization/NewtonMinimizer_test.cpp
@@ -16,7 +16,7 @@
 // along with GQCG-gqcp.  If not, see <http://www.gnu.org/licenses/>.
 // 
 #define BOOST_TEST_MODULE "NewtonMinimizer"
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "Mathematical/Optimization/NewtonMinimizer.hpp"

--- a/tests/Mathematical/Optimization/NewtonSystemOfEquationsSolver_test.cpp
+++ b/tests/Mathematical/Optimization/NewtonSystemOfEquationsSolver_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "NewtonSystemOfEquations"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Mathematical/Optimization/NewtonSystemOfEquationsSolver.hpp"
 #include "Mathematical/SquareMatrix.hpp"

--- a/tests/Mathematical/Optimization/SparseSolver_test.cpp
+++ b/tests/Mathematical/Optimization/SparseSolver_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "Sparse"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Mathematical/Optimization/SparseSolver.hpp"
 

--- a/tests/Mathematical/ScalarFunction_test.cpp
+++ b/tests/Mathematical/ScalarFunction_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "ScalarFunction"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Mathematical/ScalarFunction.hpp"
 

--- a/tests/Mathematical/SquareMatrix_test.cpp
+++ b/tests/Mathematical/SquareMatrix_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "SquareMatrix"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Mathematical/SquareMatrix.hpp"
 

--- a/tests/Mathematical/SquareRankFourTensor_test.cpp
+++ b/tests/Mathematical/SquareRankFourTensor_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "SquareRankFourTensor"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Mathematical/SquareRankFourTensor.hpp"
 

--- a/tests/Mathematical/Tensor_test.cpp
+++ b/tests/Mathematical/Tensor_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "Tensor"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Mathematical/Tensor.hpp"
 

--- a/tests/Molecule/Molecule_test.cpp
+++ b/tests/Molecule/Molecule_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "Molecule"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Molecule/Molecule.hpp"
 

--- a/tests/Molecule/NuclearFramework_test.cpp
+++ b/tests/Molecule/NuclearFramework_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "NuclearFramework"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Molecule/NuclearFramework.hpp"
 

--- a/tests/Molecule/Nucleus_test.cpp
+++ b/tests/Molecule/Nucleus_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "Nucleus"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Molecule/Nucleus.hpp"
 

--- a/tests/Operator/FirstQuantized/Operator_test.cpp
+++ b/tests/Operator/FirstQuantized/Operator_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "Operator"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Operator/Operator.hpp"
 

--- a/tests/Operator/OneElectronOperator_test.cpp
+++ b/tests/Operator/OneElectronOperator_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "OneElectronOperator"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Operator/OneElectronOperator.hpp"
 

--- a/tests/Operator/TwoElectronOperator_test.cpp
+++ b/tests/Operator/TwoElectronOperator_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "TwoElectronOperator"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Operator/TwoElectronOperator.hpp"
 

--- a/tests/OrbitalOptimization/AP1roGJacobiOrbitalOptimizer_test.cpp
+++ b/tests/OrbitalOptimization/AP1roGJacobiOrbitalOptimizer_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "OO-AP1roG"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "OrbitalOptimization/AP1roGJacobiOrbitalOptimizer.hpp"
 

--- a/tests/OrbitalOptimization/AP1roGLagrangianNewtonOrbitalOptimizer_test.cpp
+++ b/tests/OrbitalOptimization/AP1roGLagrangianNewtonOrbitalOptimizer_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "AP1roGLagrangianNewtonOrbitalOptimizer_test"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "OrbitalOptimization/AP1roGLagrangianNewtonOrbitalOptimizer.hpp"
 

--- a/tests/OrbitalOptimization/DOCINewtonOrbitalOptimizer_test.cpp
+++ b/tests/OrbitalOptimization/DOCINewtonOrbitalOptimizer_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "DOCI_orbital_optimization_test"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "OrbitalOptimization/DOCINewtonOrbitalOptimizer.hpp"
 

--- a/tests/OrbitalOptimization/JacobiRotationParameters_test.cpp
+++ b/tests/OrbitalOptimization/JacobiRotationParameters_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "JacobiRotationParameters"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "OrbitalOptimization/JacobiRotationParameters.hpp"
 

--- a/tests/OrbitalOptimization/Localization/ERJacobiLocalizer_test.cpp
+++ b/tests/OrbitalOptimization/Localization/ERJacobiLocalizer_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "ERJacobiLocalizer"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "OrbitalOptimization/Localization/ERJacobiLocalizer.hpp"
 

--- a/tests/OrbitalOptimization/Localization/ERNewtonLocalizer_test.cpp
+++ b/tests/OrbitalOptimization/Localization/ERNewtonLocalizer_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "ERNewtonLocalizer"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "OrbitalOptimization/Localization/ERNewtonLocalizer.hpp"
 

--- a/tests/OrbitalOptimization/OrbitalRotationGenerators_test.cpp
+++ b/tests/OrbitalOptimization/OrbitalRotationGenerators_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "OrbitalRotationGenerators_test"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "OrbitalOptimization/OrbitalRotationGenerators.hpp"
 

--- a/tests/Properties/atomic_decomposition_test.cpp
+++ b/tests/Properties/atomic_decomposition_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "atomic_decomposition"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RHF/PlainRHFSCFSolver.hpp"
 #include "HamiltonianParameters/AtomicDecompositionParameters.hpp"

--- a/tests/Properties/expectation_values_test.cpp
+++ b/tests/Properties/expectation_values_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "expectation_values"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Properties/expectation_values.hpp"
 

--- a/tests/Properties/properties_test.cpp
+++ b/tests/Properties/properties_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "properties"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "Properties/properties.hpp"

--- a/tests/RDM/DOCIRDMBuilder_test.cpp
+++ b/tests/RDM/DOCIRDMBuilder_test.cpp
@@ -16,7 +16,7 @@
 // along with GQCG-gqcp.  If not, see <http://www.gnu.org/licenses/>.
 // 
 #define BOOST_TEST_MODULE "DOCI_RDM_test"
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include "RDM/RDMCalculator.hpp"
 #include "RDM/DOCIRDMBuilder.hpp"
 

--- a/tests/RDM/FCIRDMBuilder_test.cpp
+++ b/tests/RDM/FCIRDMBuilder_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "FCI_RDM_test"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RDM/RDMCalculator.hpp"
 #include "RDM/FCIRDMBuilder.hpp"

--- a/tests/RDM/FrozenCoreDOCIRDMBuilder_test.cpp
+++ b/tests/RDM/FrozenCoreDOCIRDMBuilder_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "FrozenCoreDOCIRDM_test"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RDM/RDMCalculator.hpp"
 #include "RDM/SelectedRDMBuilder.hpp"

--- a/tests/RDM/FrozenCoreFCIRDMBuilder_test.cpp
+++ b/tests/RDM/FrozenCoreFCIRDMBuilder_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "FrozenCoreFCIRDM_test"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RDM/RDMCalculator.hpp"
 #include "RDM/SelectedRDMBuilder.hpp"

--- a/tests/RDM/OneRDM_test.cpp
+++ b/tests/RDM/OneRDM_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "OneRDM"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RDM/OneRDM.hpp"
 

--- a/tests/RDM/RDMCalculator_test.cpp
+++ b/tests/RDM/RDMCalculator_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "RDMCalculator_test"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "RDM/RDMCalculator.hpp"

--- a/tests/RDM/SelectedRDMBuilder_test.cpp
+++ b/tests/RDM/SelectedRDMBuilder_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "Selected_RDM_test"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RDM/RDMCalculator.hpp"
 #include "RDM/SelectedRDMBuilder.hpp"

--- a/tests/RDM/SpinUnresolvedFCIRDMBuilder_test.cpp
+++ b/tests/RDM/SpinUnresolvedFCIRDMBuilder_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "UnresolvedCIRDMBuilder_test"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RDM/SpinUnresolvedFCIRDMBuilder.hpp"
 

--- a/tests/RDM/TwoRDM_test.cpp
+++ b/tests/RDM/TwoRDM_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "TwoRDM"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RDM/TwoRDM.hpp"
 

--- a/tests/RHF/DIISRHFSCFSolver_test.cpp
+++ b/tests/RHF/DIISRHFSCFSolver_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "DIISRHFSCFSolver"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RHF/DIISRHFSCFSolver.hpp"
 #include "HamiltonianParameters/HamiltonianParameters.hpp"

--- a/tests/RHF/PlainRHFSCFSolver_test.cpp
+++ b/tests/RHF/PlainRHFSCFSolver_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "PlainRHFSCFSolver"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RHF/PlainRHFSCFSolver.hpp"
 #include "HamiltonianParameters/HamiltonianParameters.hpp"

--- a/tests/RHF/RHF_test.cpp
+++ b/tests/RHF/RHF_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "RHF"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 
 #include "RHF/RHF.hpp"

--- a/tests/RHF/constrained_RHF_test.cpp
+++ b/tests/RHF/constrained_RHF_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "constrained_RHF"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RHF/DIISRHFSCFSolver.hpp"
 #include "HamiltonianParameters/HamiltonianParameters.hpp"

--- a/tests/RMP2_test.cpp
+++ b/tests/RMP2_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "RMP2"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "RMP2.hpp"
 

--- a/tests/Utilities/linalg_test.cpp
+++ b/tests/Utilities/linalg_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "linalg_test"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Utilities/linalg.hpp"
 

--- a/tests/Utilities/miscellaneous_test.cpp
+++ b/tests/Utilities/miscellaneous_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "miscellaneous"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "Utilities/miscellaneous.hpp"
 

--- a/tests/WaveFunction/WaveFunction_test.cpp
+++ b/tests/WaveFunction/WaveFunction_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "WaveFunction"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "WaveFunction/WaveFunction.hpp"
 #include "FockSpace/FockSpace.hpp"

--- a/tests/elements_test.cpp
+++ b/tests/elements_test.cpp
@@ -17,7 +17,7 @@
 // 
 #define BOOST_TEST_MODULE "elements"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "elements.hpp"
 

--- a/tests/units_test.cpp
+++ b/tests/units_test.cpp
@@ -18,7 +18,7 @@
 #define BOOST_TEST_MODULE "units"
 
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <cstdlib>
 #include <cmath>


### PR DESCRIPTION
This PR is a follow-up for PR #368 and is intended to be able to use Boost versions higher than 1.69 (in order not to have a hard dependency on a specific version of Boost).