### PR TITLE
Add additional layer in headers (resolves #292).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ install(
         ${CMAKE_BINARY_DIR}/cmake/gqcp-config-version.cmake
         ${CMAKE_SOURCE_DIR}/cmake/FindEigen3.cmake
         ${CMAKE_SOURCE_DIR}/cmake/FindInt2.cmake
+        ${CMAKE_SOURCE_DIR}/cmake/FindMKL.cmake
         DESTINATION cmake
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,11 +149,11 @@ install(TARGETS gqcp
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include
+        INCLUDES DESTINATION include/gqcp
         )
 
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include)
-install(FILES ${CMAKE_BINARY_DIR}/include/version.hpp DESTINATION include)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include/gqcp)
+install(FILES ${CMAKE_BINARY_DIR}/include/version.hpp DESTINATION include/gqcp)
 
 install(EXPORT gqcp-targets
         FILE gqcp-targets.cmake

--- a/README.md
+++ b/README.md
@@ -135,8 +135,4 @@ For this library, there are several extra options you can pass to the `cmake ..`
 
 ### Usage in an external project
 
-If you want to use gqcp in another project, just add
-
-    find_package(gqcp 0.2.0 NO_MODULE)
-
-to its CMake configuration, and it will ben provide  `gqcp_INCLUDE_DIRS` to be used in `target_include_directories` and the target library `gqcp` to be used in `target_link_libraries`. The `NO_MODULE` option specifies that you will use the CMake config script installed by GQCP.
+We have created a small [example](https://github.com/GQCG/gqcp-link) which showcases how to use `gqcp` in an external C++ project

--- a/cmake/gqcp-config.cmake.in
+++ b/cmake/gqcp-config.cmake.in
@@ -5,7 +5,7 @@ find_dependency(Git REQUIRED)
 find_dependency(Eigen3 3.3.4 REQUIRED MODULE)
 find_dependency(Int2 REQUIRED MODULE)
 find_dependency(Boost REQUIRED COMPONENTS program_options unit_test_framework)
-find_dependency(Spectra REQUIRED MODULE)
+find_dependency(Spectra REQUIRED)
 find_dependency(Cint REQUIRED)
 
 if(NOT TARGET gqcp::gqcp)


### PR DESCRIPTION
This PR makes sure that headers are installed in `${INSTALL_PREFIX_PATH}/include/gqcp`. Hence, in accordance with the Eigen and Boost conventions, includes should have the form `#include "gqcp/gqcp.hpp".  