### PR TITLE
Refactor Boost support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,7 @@ target_link_libraries(gqcp
             Spectra::Spectra
             MKL::MKL
         )
-target_include_directories(gqcp PUBLIC $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>)
-target_link_libraries(gqcp PUBLIC ${Boost_LIBRARIES})
+
 target_compile_options(gqcp PUBLIC -DEIGEN_USE_MKL_ALL -DMKL_LP64)
 
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Usage of this library can be found in the documented `tests` directory, and comm
 
 Before installing gqcp, please make sure the following dependencies are available on your system:
 
-[![Boost Dependency](https://img.shields.io/badge/Boost-1.65.1+-000000.svg)](http://www.boost.org)
+[![Boost Dependency](https://img.shields.io/badge/Boost-<=1.69-000000.svg)](http://www.boost.org)
 [![Eigen3 Dependency](https://img.shields.io/badge/Eigen-3.3.4+-000000.svg)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
 [![libint2 Dependency](https://img.shields.io/badge/libint-2.3.1+-000000.svg)](https://github.com/evaleev/libint)
 [![libcint Dependency](https://img.shields.io/badge/libcint-3.0.17+-000000.svg)](https://github.com/GQCG/libcint)

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -14,7 +14,7 @@ foreach(DRIVER_SOURCE ${driver_target_sources})
     add_executable(${DRIVER_NAME} ${DRIVER_SOURCE})
 
     # Configure (include headers and link libraries) the driver
-    target_link_libraries(${DRIVER_NAME} PUBLIC gqcp)
+    target_link_libraries(${DRIVER_NAME} PUBLIC gqcp Boost::program_options)
 
     # Install the driver in a separate location
     install(TARGETS ${DRIVER_NAME} RUNTIME DESTINATION bin)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,8 +34,7 @@ foreach(TEST_SOURCE ${test_target_sources})
 
     # Configure (include headers and link libraries) the test
     target_include_directories(${TEST_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/include)
-    target_link_libraries(${TEST_NAME} PUBLIC gqcp)
-    target_compile_definitions(${TEST_NAME} PRIVATE BOOST_TEST_DYN_LINK)
+    target_link_libraries(${TEST_NAME} PUBLIC gqcp Boost::unit_test_framework)
 
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME}
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR})  # the working directory is the out-of-source build directory

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,7 +35,8 @@ foreach(TEST_SOURCE ${test_target_sources})
     # Configure (include headers and link libraries) the test
     target_include_directories(${TEST_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/include)
     target_link_libraries(${TEST_NAME} PUBLIC gqcp Boost::unit_test_framework)
-
+    target_compile_definitions(${TEST_NAME} PRIVATE BOOST_TEST_DYN_LINK)
+        
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME}
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR})  # the working directory is the out-of-source build directory
 


### PR DESCRIPTION
This PR is a follow-up for PR #368 and is intended to be able to use Boost versions higher than 1.69 (in order not to have a hard dependency on a specific version of Boost).