### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,5 +99,5 @@ script:
   - git clone https://github.com/GQCG/gqcp-link.git
   - cd gqcp-link
   - mkdir build && cd build
-  - cmake .. -DCMAKE_PREFIX_PATH=~/.local/cmake -DCMAKE_MODULE_PATH=~/.local/cmake
+  - cmake .. -DCMAKE_PREFIX_PATH=${HOME}/miniconda -DGQCP_INSTALL_PREFIX=~/.local
   - make -j3 && ./test_driver

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,11 +144,11 @@ install(TARGETS gqcp
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include
+        INCLUDES DESTINATION include/gqcp
         )
 
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include)
-install(FILES ${CMAKE_BINARY_DIR}/include/version.hpp DESTINATION include)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include/gqcp)
+install(FILES ${CMAKE_BINARY_DIR}/include/version.hpp DESTINATION include/gqcp)
 
 install(EXPORT gqcp-targets
         FILE gqcp-targets.cmake

--- a/README.md
+++ b/README.md
@@ -135,8 +135,4 @@ For this library, there are several extra options you can pass to the `cmake ..`
 
 ### Usage in an external project
 
-If you want to use gqcp in another project, just add
-
-    find_package(gqcp 0.2.0 NO_MODULE)
-
-to its CMake configuration, and it will ben provide  `gqcp_INCLUDE_DIRS` to be used in `target_include_directories` and the target library `gqcp` to be used in `target_link_libraries`. The `NO_MODULE` option specifies that you will use the CMake config script installed by GQCP.
+We have created a small [example](https://github.com/GQCG/gqcp-link) which showcases how to use `gqcp` in an external C++ project

--- a/include/Basis/Integrals/BaseOneElectronIntegralBuffer.hpp
+++ b/include/Basis/Integrals/BaseOneElectronIntegralBuffer.hpp
@@ -82,6 +82,10 @@ public:
      */
     virtual IntegralScalar value(const size_t i, const size_t f1, const size_t f2) const = 0;
 
+    /**
+     *  @return if all the values of the calculated integrals are zero
+     */
+    virtual bool areIntegralsAllZero() const = 0;
 
 
     /*

--- a/include/Basis/Integrals/BaseOneElectronIntegralEngine.hpp
+++ b/include/Basis/Integrals/BaseOneElectronIntegralEngine.hpp
@@ -48,13 +48,16 @@ public:
     virtual ~BaseOneElectronIntegralEngine() = default;
 
 
-    // PUBLIC METHODS
+    // PUBLIC PURE VIRTUAL METHODS
 
     /**
+     *  Calculate all the integrals over the given shells
+     *  @note This method is not marked const to allow the Engine's internals to be changed
+     * 
      *  @param shell1           the first shell
      *  @param shell2           the second shell
      * 
-     *  This method is not marked const to allow the Engine's internals to be changed
+     *  @return a buffer containing the calculated integrals
      */
     virtual std::shared_ptr<BaseOneElectronIntegralBuffer<IntegralScalar, N>> calculate(const ShellType& shell1, const ShellType& shell2) = 0;
 };

--- a/include/Basis/Integrals/BaseTwoElectronIntegralBuffer.hpp
+++ b/include/Basis/Integrals/BaseTwoElectronIntegralBuffer.hpp
@@ -91,6 +91,11 @@ public:
      */
     virtual IntegralScalar value(const size_t i, const size_t f1, const size_t f2, const size_t f3, const size_t f4) const = 0;
 
+    /**
+     *  @return if all the values of the calculated integrals are zero
+     */
+    virtual bool areIntegralsAllZero() const = 0;
+
 
     /*
      *  PUBLIC METHODS

--- a/include/Basis/Integrals/BaseTwoElectronIntegralEngine.hpp
+++ b/include/Basis/Integrals/BaseTwoElectronIntegralEngine.hpp
@@ -47,15 +47,18 @@ public:
     virtual ~BaseTwoElectronIntegralEngine() = default;
 
 
-    // PUBLIC METHODS
+    // PUBLIC PURE VIRTUAL METHODS
 
     /**
+     *  Calculate all the integrals over the given shells
+     *  @note This method is not marked const to allow the Engine's internals to be changed
+     * 
      *  @param shell1          the first shell
      *  @param shell2          the second shell
      *  @param shell3          the third shell
      *  @param shell4          the fourth shell
      * 
-     *  This method is not marked const to allow the Engine's internals to be changed
+     *  @return a buffer containing the calculated integrals
      */
     virtual std::shared_ptr<BaseTwoElectronIntegralBuffer<IntegralScalar, N>> calculate(const ShellType& shell1, const ShellType& shell2, const ShellType& shell3, const ShellType& shell4) = 0;
 };

--- a/include/Basis/Integrals/IntegralCalculator.hpp
+++ b/include/Basis/Integrals/IntegralCalculator.hpp
@@ -71,8 +71,12 @@ public:
                 const auto bf2 = shell_set.basisFunctionIndex(sh2_index);
                 const auto shell2 = shells[sh2_index];
 
-                // Calculate the integrals over the shells and place the calculated integrals inside the full matrices
                 const auto buffer = engine.calculate(shell1, shell2);
+
+                // Only if the integrals are not all zero, place them inside the full matrices
+                if (buffer->areIntegralsAllZero()) {
+                    continue;
+                }
                 buffer->emplace(components, bf1, bf2);
             }  // sh2_index
         }  // sh1_index
@@ -122,7 +126,12 @@ public:
                         const auto bf4 = shell_set.basisFunctionIndex(sh4_index);
                         const auto shell4 = shells[sh4_index];
 
-                        const auto buffer = engine.calculate(shell1, shell2, shell3, shell4);  // calculate the integrals over the four shells
+                        const auto buffer = engine.calculate(shell1, shell2, shell3, shell4);
+
+                        // Only if the integrals are not all zero, place them inside the full matrices
+                        if (buffer->areIntegralsAllZero()) {
+                            continue;
+                        }
                         buffer->emplace(components, bf1, bf2, bf3, bf4);  // place the calculated integrals inside the full tensors
                     }  // sh4_index
                 }  // sh3_index

--- a/include/Basis/Integrals/Interfaces/LibcintInterfacer.hpp
+++ b/include/Basis/Integrals/Interfaces/LibcintInterfacer.hpp
@@ -25,7 +25,6 @@
 #include "Operator/TwoElectronOperator.hpp"
 
 #include <functional>
-#include <unordered_map>
 
 
 extern "C" {
@@ -68,7 +67,6 @@ namespace libcint {
 
 
 class RawContainer;
-class RawOptimizer;
 
 
 }  // namespace libcint
@@ -99,16 +97,11 @@ public:
     void setCommonOrigin(libcint::RawContainer& raw_container, const Vector<double, 3>& origin) const;
 
     /**
-     *  @param raw_optimizer                    the libcint::RawOptimizer that contains a raw libcint optimizer struct
+     *  @param libcint_optimizer                the pointer to the raw libcint_optimizer struct
      *  @param libcint_optimizer_function       the function with which the raw_optimizer should be initialized
      *  @param raw_container                    the libcint::RawContainer that holds the data needed by libcint
      */
-    void initializeOptimizer(libcint::RawOptimizer& raw_optimizer, const Libcint2eOptimizerFunction& libcint_optimizer_function, const libcint::RawContainer& raw_container) const;
-
-    /**
-     *  @param raw_optimizer                    the libcint::RawOptimizer that contains a raw libcint optimizer struct
-     */
-    void deleteOptimizer(libcint::RawOptimizer& raw_optimizer) const;
+    void initializeOptimizer(CINTOpt* libcint_optimizer, const Libcint2eOptimizerFunction& libcint_optimizer_function, const libcint::RawContainer& raw_container) const;
 
 
 
@@ -242,59 +235,6 @@ public:
     const int* atmData() const { return this->libcint_atm; }
     const int* basData() const { return this->libcint_bas; }
     const double* envData() const { return this->libcint_env; }
-
-    /*
-     *  FRIENDS
-     */
-    friend class GQCP::LibcintInterfacer;
-};
-
-
-
-/**
- *  A wrapper that owns a raw libcint CINTOpt struct
- */
-class RawOptimizer {
-private:
-    CINTOpt* libcint_optimizer;  // the libcint two-electron optimizer struct
-
-
-public:
-
-    /*
-     *  CONSTRUCTORS
-     */
-    RawOptimizer() : 
-        libcint_optimizer (nullptr)
-    {}
-
-
-    /*
-     *  DESTRUCTOR
-     */
-    ~RawOptimizer() {
-        GQCP::LibcintInterfacer().deleteOptimizer(*this);
-    }
-
-
-    /*
-     *  GETTERS
-     */
-
-    /*
-     *  Return a pointer to a const, similarly to where libcint would use 'opt'
-     */
-    const CINTOpt* opt() const {
-        return this->libcint_optimizer;
-    }
-
-    /**
-     *  Return a (modifiable) pointer to a pointer, similarly to where libcint would use '&opt'
-     */
-    CINTOpt** refOpt() {
-        return &(this->libcint_optimizer);
-    }
-
 
     /*
      *  FRIENDS

--- a/include/Basis/Integrals/Interfaces/LibcintInterfacer.hpp
+++ b/include/Basis/Integrals/Interfaces/LibcintInterfacer.hpp
@@ -50,7 +50,113 @@ FINT cint1e_r_cart(double* buf, const int* shls, const int* atm, int natm, const
 namespace GQCP {
 
 
-class LibcintInterfacer;  // forward declaration before friending
+/*
+ *  Aliases for functions that are used in Libcint
+ */
+
+using Libcint1eFunction = std::function<int (double*, const int*, const int*, int, const int*, int, const double*)>;
+using Libcint2eFunction = std::function<int (double*, const int*, const int*, int, const int*, int, const double*, const CINTOpt*)>;
+using Libcint2eOptimizerFunction = std::function<void (CINTOpt**, const int*, const int, const int*, const int, const double*)>;
+
+
+
+/*
+ *  Forward declarations
+ */
+
+namespace libcint {
+
+
+class RawContainer;
+class RawOptimizer;
+
+
+}  // namespace libcint
+
+
+
+/**
+ *  A class that takes care of the interfacing with the libcint library
+ */
+class LibcintInterfacer {
+public:
+
+    // PUBLIC METHODS - INTERFACING
+
+    /**
+     *  @param shell_set        the GQCP::ShellSet whose information should be converted
+     *
+     *  @return the information in a GQCP::ShellSet as a libcint::RawContainer
+     */
+    libcint::RawContainer convert(const ShellSet<GTOShell>& shell_set) const;
+
+    /**
+     *  Set the origin for the calculation of all vector-related integrals
+     *
+     *  @param raw_container        the libcint::RawContainer that holds the data needed by libcint
+     *  @param origin               the new origin for the calculation of all vector-related integrals
+     */
+    void setCommonOrigin(libcint::RawContainer& raw_container, const Vector<double, 3>& origin) const;
+
+    /**
+     *  @param raw_optimizer                    the libcint::RawOptimizer that contains a raw libcint optimizer struct
+     *  @param libcint_optimizer_function       the function with which the raw_optimizer should be initialized
+     *  @param raw_container                    the libcint::RawContainer that holds the data needed by libcint
+     */
+    void initializeOptimizer(libcint::RawOptimizer& raw_optimizer, const Libcint2eOptimizerFunction& libcint_optimizer_function, const libcint::RawContainer& raw_container) const;
+
+    /**
+     *  @param raw_optimizer                    the libcint::RawOptimizer that contains a raw libcint optimizer struct
+     */
+    void deleteOptimizer(libcint::RawOptimizer& raw_optimizer) const;
+
+
+
+    //  PUBLIC METHODS - INTEGRAL FUNCTIONS
+
+    /**
+     *  @param op           the overlap operator
+     * 
+     *  @return the Libcint one-electron function that corresponds to the overlap operator
+     */
+    Libcint1eFunction oneElectronFunction(const OverlapOperator& op) const;
+
+    /**
+     *  @param op               the kinetic operator
+     * 
+     *  @return the Libcint one-electron function that corresponds to the kinetic operator
+     */
+    Libcint1eFunction oneElectronFunction(const KineticOperator& op) const;
+
+    /**
+     *  @param op               the nuclear attraction operator
+     * 
+     *  @return the Libcint one-electron function that corresponds to the nuclear attraction operator
+     */
+    Libcint1eFunction oneElectronFunction(const NuclearAttractionOperator& op) const;
+
+    /**
+     *  @param op               the electronic electric dipole operator
+     * 
+     *  @return the Libcint one-electron function that corresponds to the electronic electric dipole operator
+     */
+    Libcint1eFunction oneElectronFunction(const ElectronicDipoleOperator& op) const;
+
+    /**
+     *  @param op               the Coulomb repulsion operator
+     * 
+     *  @return the Libcint two-electron function that corresponds to the Coulomb repulsion dipole operator
+     */
+    Libcint2eFunction twoElectronFunction(const CoulombRepulsionOperator& op) const;
+
+    /**
+     *  @param op               the Coulomb repulsion operator
+     * 
+     *  @return the Libcint two-electron optimizer function that corresponds to the Coulomb repulsion dipole operator
+     */
+    Libcint2eOptimizerFunction twoElectronOptimizerFunction(const CoulombRepulsionOperator& op) const;
+};
+
 
 
 namespace libcint {
@@ -77,11 +183,8 @@ static constexpr int ptr_coeff = PTR_COEFF;  // slot offset for a 'pointer' to t
 
 
 
-
 /**
  *  A wrapper that owns raw libcint 'atm', 'bas' and 'env' arrays
- * 
- *  @note There is no easy way to ask a RawContainer the corresponding shell index given a GQCP::GTOShell. This is why we are explicitly holding such a map.
  */
 class RawContainer {
 private:
@@ -147,78 +250,58 @@ public:
 };
 
 
-}  // namespace libcint
-
-
-
-
-
-using Libcint1eFunction = std::function<int (double*, const int*, const int*, int, const int*, int, const double*)>;
-using Libcint2eFunction = std::function<int (double*, const int*, const int*, int, const int*, int, const double*, const CINTOpt*)>;
-
-
-
 
 /**
- *  A class that takes care of the interfacing with the libcint library
+ *  A wrapper that owns a raw libcint CINTOpt struct
  */
-class LibcintInterfacer {
+class RawOptimizer {
+private:
+    CINTOpt* libcint_optimizer;  // the libcint two-electron optimizer struct
+
+
 public:
 
     /*
-     *  PUBLIC METHODS - INTERFACING
+     *  CONSTRUCTORS
+     */
+    RawOptimizer() : 
+        libcint_optimizer (nullptr)
+    {}
+
+
+    /*
+     *  DESTRUCTOR
+     */
+    ~RawOptimizer() {
+        GQCP::LibcintInterfacer().deleteOptimizer(*this);
+    }
+
+
+    /*
+     *  GETTERS
      */
 
-    /**
-     *  @param shell_set        the GQCP::ShellSet whose information should be converted
-     *
-     *  @return the information in a GQCP::ShellSet as a libcint::RawContainer
+    /*
+     *  Return a pointer to a const, similarly to where libcint would use 'opt'
      */
-    libcint::RawContainer convert(const ShellSet<GTOShell>& shell_set) const;
+    const CINTOpt* opt() const {
+        return this->libcint_optimizer;
+    }
 
     /**
-     *  Set the origin for the calculation of all vector-related integrals
-     *
-     *  @param raw_container        the libcint::RawContainer that holds the data needed by libcint
-     *  @param origin               the new origin for the calculation of all vector-related integrals
+     *  Return a (modifiable) pointer to a pointer, similarly to where libcint would use '&opt'
      */
-    void setCommonOrigin(libcint::RawContainer& raw_container, const Vector<double, 3>& origin) const;
+    CINTOpt** refOpt() {
+        return &(this->libcint_optimizer);
+    }
 
-    /**
-     *  @param op           the overlap operator
-     * 
-     *  @return the Libcint one-electron function that corresponds to the overlap operator
-     */
-    Libcint1eFunction oneElectronFunction(const OverlapOperator& op) const;
 
-    /**
-     *  @param op               the kinetic operator
-     * 
-     *  @return the Libcint one-electron function that corresponds to the kinetic operator
+    /*
+     *  FRIENDS
      */
-    Libcint1eFunction oneElectronFunction(const KineticOperator& op) const;
-
-    /**
-     *  @param op               the nuclear attraction operator
-     * 
-     *  @return the Libcint one-electron function that corresponds to the nuclear attraction operator
-     */
-    Libcint1eFunction oneElectronFunction(const NuclearAttractionOperator& op) const;
-
-    /**
-     *  @param op               the electronic electric dipole operator
-     * 
-     *  @return the Libcint one-electron function that corresponds to the electronic electric dipole operator
-     */
-    Libcint1eFunction oneElectronFunction(const ElectronicDipoleOperator& op) const;
-
-    /**
-     *  @param op               the Coulomb repulsion operator
-     * 
-     *  @return the Libcint two-electron function that corresponds to the Coulomb repulsion dipole operator
-     */
-    Libcint2eFunction twoElectronFunction(const CoulombRepulsionOperator& op) const;
+    friend class GQCP::LibcintInterfacer;
 };
 
 
+}  // namespace libcint
 }  // namespace GQCP

--- a/include/Basis/Integrals/Interfaces/LibcintOneElectronIntegralBuffer.hpp
+++ b/include/Basis/Integrals/Interfaces/LibcintOneElectronIntegralBuffer.hpp
@@ -44,6 +44,8 @@ private:
     double scaling_factor;  // a factor that multiplies every calculated value (for example in the dipole integrals, an extra factor -1 should be included)
     std::vector<IntegralScalar> buffer;  // the libcint integral data converted to a C++ vector
 
+    int result;  // the result of the libcint_function call
+
 
 public:
     /*
@@ -55,10 +57,12 @@ public:
      *  @param nbf1                 the number of basis functions in the first shell
      *  @param nbf2                 the number of basis functions in the second shell
      *  @param scaling_factor       a factor that multiplies every calculated value (for example in the dipole integrals, an extra factor -1 should be included)
+     *  @param result               the result of the libcint_function call
      */
-    LibcintOneElectronIntegralBuffer(const std::vector<IntegralScalar>& buffer, const size_t nbf1, const size_t nbf2, const double scaling_factor=1.0) :
+    LibcintOneElectronIntegralBuffer(const std::vector<IntegralScalar>& buffer, const size_t nbf1, const size_t nbf2, const int result, const double scaling_factor=1.0) :
         scaling_factor (scaling_factor),
         buffer (buffer),
+        result (result),
         BaseOneElectronIntegralBuffer<IntegralScalar, N>(nbf1, nbf2)
     {}
 
@@ -83,7 +87,7 @@ public:
      *  @return if all the values of the calculated integrals are zero
      */
     bool areIntegralsAllZero() const override {
-        return false;  // the interface for 'not0' is not yet implemented
+        return (this->result == 0);
     }
 };
 

--- a/include/Basis/Integrals/Interfaces/LibcintOneElectronIntegralBuffer.hpp
+++ b/include/Basis/Integrals/Interfaces/LibcintOneElectronIntegralBuffer.hpp
@@ -74,8 +74,16 @@ public:
      * 
      *  @return a value from this integral buffer
      */
-    virtual IntegralScalar value(const size_t i, const size_t f1, const size_t f2) const {
+    IntegralScalar value(const size_t i, const size_t f1, const size_t f2) const override {
         return this->scaling_factor * this->buffer[f1 + this->nbf1 * (f2 + this->nbf2 * i)];  // column-major
+    }
+
+
+    /**
+     *  @return if all the values of the calculated integrals are zero
+     */
+    bool areIntegralsAllZero() const override {
+        return false;  // the interface for 'not0' is not yet implemented
     }
 };
 

--- a/include/Basis/Integrals/Interfaces/LibcintOneElectronIntegralEngine.hpp
+++ b/include/Basis/Integrals/Interfaces/LibcintOneElectronIntegralEngine.hpp
@@ -135,10 +135,10 @@ public:
 
 
         // Let libcint compute the integrals and return the corresponding buffer
-        this->libcint_function(libcint_buffer, shell_indices, libcint_raw_container.atmData(), libcint_raw_container.numberOfAtoms(), libcint_raw_container.basData(), libcint_raw_container.numberOfBasisFunctions(), libcint_raw_container.envData());
+        const auto result = this->libcint_function(libcint_buffer, shell_indices, libcint_raw_container.atmData(), libcint_raw_container.numberOfAtoms(), libcint_raw_container.basData(), libcint_raw_container.numberOfBasisFunctions(), libcint_raw_container.envData());
         std::vector<double> buffer_converted (libcint_buffer, libcint_buffer + N*nbf1*nbf2);  // std::vector constructor from .begin() and .end()
 
-        return std::make_shared<LibcintOneElectronIntegralBuffer<IntegralScalar, N>>(buffer_converted, nbf1, nbf2, this->scaling_factor);
+        return std::make_shared<LibcintOneElectronIntegralBuffer<IntegralScalar, N>>(buffer_converted, nbf1, nbf2, result, this->scaling_factor);
     }
 };
 

--- a/include/Basis/Integrals/Interfaces/LibcintTwoElectronIntegralBuffer.hpp
+++ b/include/Basis/Integrals/Interfaces/LibcintTwoElectronIntegralBuffer.hpp
@@ -40,6 +40,8 @@ public:
 private:
     std::vector<IntegralScalar> buffer;  // the libcint integral data converted to a C++ vector
 
+    int result;  // the result of the libcint_function call
+
 
 public:
     /*
@@ -52,9 +54,11 @@ public:
      *  @param nbf2                 the number of basis functions in the second shell
      *  @param nbf3                 the number of basis functions in the third shell
      *  @param nbf4                 the number of basis functions in the fourth shell
+     *  @param result               the result of the libcint_function call
      */
-    LibcintTwoElectronIntegralBuffer(const std::vector<IntegralScalar>& buffer, const size_t nbf1, const size_t nbf2, const size_t nbf3, const size_t nbf4) :
+    LibcintTwoElectronIntegralBuffer(const std::vector<IntegralScalar>& buffer, const size_t nbf1, const size_t nbf2, const size_t nbf3, const size_t nbf4, const int result) :
         buffer (buffer),
+        result (result),
         BaseTwoElectronIntegralBuffer<IntegralScalar, N>(nbf1, nbf2, nbf3, nbf4)
     {}
 
@@ -81,7 +85,7 @@ public:
      *  @return if all the values of the calculated integrals are zero
      */
     bool areIntegralsAllZero() const override {
-        return false;  // the interface for 'not0' is not yet implemented
+        return (result == 0);
     }
 };
 

--- a/include/Basis/Integrals/Interfaces/LibcintTwoElectronIntegralBuffer.hpp
+++ b/include/Basis/Integrals/Interfaces/LibcintTwoElectronIntegralBuffer.hpp
@@ -72,8 +72,16 @@ public:
      * 
      *  @return a value from this integral buffer
      */
-    virtual IntegralScalar value(const size_t i, const size_t f1, const size_t f2, const size_t f3, const size_t f4) const {
+    IntegralScalar value(const size_t i, const size_t f1, const size_t f2, const size_t f3, const size_t f4) const override {
         return this->buffer[f1 + this->nbf1 * (f2 + this->nbf2 * (f3 + this->nbf3 * (f4 + this->nbf4 * i)))];  // column major
+    }
+
+
+    /**
+     *  @return if all the values of the calculated integrals are zero
+     */
+    bool areIntegralsAllZero() const override {
+        return false;  // the interface for 'not0' is not yet implemented
     }
 };
 

--- a/include/Basis/Integrals/Interfaces/LibcintTwoElectronIntegralEngine.hpp
+++ b/include/Basis/Integrals/Interfaces/LibcintTwoElectronIntegralEngine.hpp
@@ -101,10 +101,10 @@ public:
 
 
         // Let libcint compute the integrals and return the corresponding buffer
-        this->libcint_function(libcint_buffer, shell_indices, libcint_raw_container.atmData(), libcint_raw_container.numberOfAtoms(), libcint_raw_container.basData(), libcint_raw_container.numberOfBasisFunctions(), libcint_raw_container.envData(), nullptr);
+        const auto result = this->libcint_function(libcint_buffer, shell_indices, libcint_raw_container.atmData(), libcint_raw_container.numberOfAtoms(), libcint_raw_container.basData(), libcint_raw_container.numberOfBasisFunctions(), libcint_raw_container.envData(), nullptr);
         std::vector<double> buffer_converted (libcint_buffer, libcint_buffer + N*nbf1*nbf2*nbf3*nbf4);  // std::vector constructor from .begin() and .end()
 
-        return std::make_shared<LibcintTwoElectronIntegralBuffer<IntegralScalar, N>>(buffer_converted, nbf1, nbf2, nbf3, nbf4);
+        return std::make_shared<LibcintTwoElectronIntegralBuffer<IntegralScalar, N>>(buffer_converted, nbf1, nbf2, nbf3, nbf4, result);
     }
 };
 

--- a/include/Basis/Integrals/Interfaces/LibcintTwoElectronIntegralEngine.hpp
+++ b/include/Basis/Integrals/Interfaces/LibcintTwoElectronIntegralEngine.hpp
@@ -105,13 +105,9 @@ public:
         double libcint_buffer[N * nbf1 * nbf2 * nbf3 * nbf4];
 
 
-        // Let libcint compute the integrals with the aid of the optimization struct and return the corresponding buffer
-        CINTOpt* opt;
-        this->libcint_optimizer_function(&opt, this->libcint_raw_container.atmData(), this->libcint_raw_container.numberOfAtoms(), this->libcint_raw_container.basData(), this->libcint_raw_container.numberOfBasisFunctions(), this->libcint_raw_container.envData());
+        // Let libcint compute the integrals and return the corresponding buffer
+        const auto result = this->libcint_function(libcint_buffer, shell_indices, this->libcint_raw_container.atmData(), this->libcint_raw_container.numberOfAtoms(), this->libcint_raw_container.basData(), this->libcint_raw_container.numberOfBasisFunctions(), this->libcint_raw_container.envData(), nullptr);  // no optimizer struct
 
-        const auto result = this->libcint_function(libcint_buffer, shell_indices, this->libcint_raw_container.atmData(), this->libcint_raw_container.numberOfAtoms(), this->libcint_raw_container.basData(), this->libcint_raw_container.numberOfBasisFunctions(), this->libcint_raw_container.envData(), opt);
-
-        CINTdel_optimizer(&opt);
 
         std::vector<double> buffer_converted (libcint_buffer, libcint_buffer + N*nbf1*nbf2*nbf3*nbf4);  // std::vector constructor from .begin() and .end()
         return std::make_shared<LibcintTwoElectronIntegralBuffer<IntegralScalar, N>>(buffer_converted, nbf1, nbf2, nbf3, nbf4, result);

--- a/include/Basis/Integrals/Interfaces/LibintOneElectronIntegralBuffer.hpp
+++ b/include/Basis/Integrals/Interfaces/LibintOneElectronIntegralBuffer.hpp
@@ -78,8 +78,15 @@ public:
      * 
      *  @return the integral corresponding to the given basis functions from the buffer
      */
-    IntegralScalar value(const size_t i, const size_t f1, const size_t f2) const {
+    IntegralScalar value(const size_t i, const size_t f1, const size_t f2) const override {
         return this->scaling_factor * this->libint2_buffer[i + this->component_offset][f2 + f1 * this->nbf2]; // integrals are packed in row-major form
+    }
+
+    /**
+     *  @return if all the values of the calculated integrals are zero
+     */
+    bool areIntegralsAllZero() const override {
+        return (this->libint2_buffer[0] == nullptr);
     }
 };
 

--- a/include/Basis/Integrals/Interfaces/LibintTwoElectronIntegralBuffer.hpp
+++ b/include/Basis/Integrals/Interfaces/LibintTwoElectronIntegralBuffer.hpp
@@ -74,9 +74,16 @@ public:
      * 
      *  @return a value from this integral buffer
      */
-    IntegralScalar value(const size_t i, const size_t f1, const size_t f2, const size_t f3, const size_t f4) const {
+    IntegralScalar value(const size_t i, const size_t f1, const size_t f2, const size_t f3, const size_t f4) const override {
 
-        return libint2_buffer[i][f4 + this->nbf4 * (f3 + this->nbf3 * (f2 + this->nbf2 * (f1)))];  // integrals are packed in row-major form
+        return this->libint2_buffer[i][f4 + this->nbf4 * (f3 + this->nbf3 * (f2 + this->nbf2 * (f1)))];  // integrals are packed in row-major form
+    }
+
+    /**
+     *  @return if all the values of the calculated integrals are zero
+     */
+    bool areIntegralsAllZero() const override {
+        return (this->libint2_buffer[0] == nullptr);
     }
 };
 

--- a/src/Basis/LibcintInterfacer.cpp
+++ b/src/Basis/LibcintInterfacer.cpp
@@ -121,24 +121,6 @@ void LibcintInterfacer::setCommonOrigin(libcint::RawContainer& raw_container, co
 }
 
 
-/**
- *  @param raw_optimizer                    the libcint::RawOptimizer that contains a raw libcint optimizer struct
- *  @param libcint_optimizer_function       the function with which the raw_optimizer should be initialized
- *  @param raw_container                    the libcint::RawContainer that holds the data needed by libcint
- */
-void LibcintInterfacer::initializeOptimizer(libcint::RawOptimizer& raw_optimizer, const Libcint2eOptimizerFunction& libcint_optimizer_function, const libcint::RawContainer& raw_container) const {
-
-    libcint_optimizer_function(raw_optimizer.refOpt(), raw_container.atmData(), raw_container.numberOfAtoms(), raw_container.basData(), raw_container.numberOfBasisFunctions(), raw_container.envData());
-}
-
-
-/**
- *  @param raw_optimizer                    the libcint::RawOptimizer that contains a raw libcint optimizer struct
- */
-void LibcintInterfacer::deleteOptimizer(libcint::RawOptimizer& raw_optimizer) const {
-
-    CINTdel_optimizer(raw_optimizer.refOpt());
-}
 
 
 
@@ -192,6 +174,7 @@ Libcint1eFunction LibcintInterfacer::oneElectronFunction(const ElectronicDipoleO
  *  @return the Libcint two-electron function that corresponds to the Coulomb repulsion dipole operator
  */
 Libcint2eFunction LibcintInterfacer::twoElectronFunction(const CoulombRepulsionOperator& op) const {
+
     return cint2e_cart;
 }
 
@@ -202,6 +185,7 @@ Libcint2eFunction LibcintInterfacer::twoElectronFunction(const CoulombRepulsionO
  *  @return the Libcint two-electron optimizer function that corresponds to the Coulomb repulsion dipole operator
  */
 Libcint2eOptimizerFunction LibcintInterfacer::twoElectronOptimizerFunction(const CoulombRepulsionOperator& op) const {
+
     return cint2e_cart_optimizer;
 }
 

--- a/src/Basis/LibcintInterfacer.cpp
+++ b/src/Basis/LibcintInterfacer.cpp
@@ -122,6 +122,31 @@ void LibcintInterfacer::setCommonOrigin(libcint::RawContainer& raw_container, co
 
 
 /**
+ *  @param raw_optimizer                    the libcint::RawOptimizer that contains a raw libcint optimizer struct
+ *  @param libcint_optimizer_function       the function with which the raw_optimizer should be initialized
+ *  @param raw_container                    the libcint::RawContainer that holds the data needed by libcint
+ */
+void LibcintInterfacer::initializeOptimizer(libcint::RawOptimizer& raw_optimizer, const Libcint2eOptimizerFunction& libcint_optimizer_function, const libcint::RawContainer& raw_container) const {
+
+    libcint_optimizer_function(raw_optimizer.refOpt(), raw_container.atmData(), raw_container.numberOfAtoms(), raw_container.basData(), raw_container.numberOfBasisFunctions(), raw_container.envData());
+}
+
+
+/**
+ *  @param raw_optimizer                    the libcint::RawOptimizer that contains a raw libcint optimizer struct
+ */
+void LibcintInterfacer::deleteOptimizer(libcint::RawOptimizer& raw_optimizer) const {
+
+    CINTdel_optimizer(raw_optimizer.refOpt());
+}
+
+
+
+/*
+ *  PUBLIC METHODS - INTEGRAL FUNCTIONS
+ */
+
+/**
  *  @param op           the overlap operator
  * 
  *  @return the Libcint one-electron function that corresponds to the overlap operator
@@ -168,6 +193,16 @@ Libcint1eFunction LibcintInterfacer::oneElectronFunction(const ElectronicDipoleO
  */
 Libcint2eFunction LibcintInterfacer::twoElectronFunction(const CoulombRepulsionOperator& op) const {
     return cint2e_cart;
+}
+
+
+/**
+ *  @param op               the Coulomb repulsion operator
+ * 
+ *  @return the Libcint two-electron optimizer function that corresponds to the Coulomb repulsion dipole operator
+ */
+Libcint2eOptimizerFunction LibcintInterfacer::twoElectronOptimizerFunction(const CoulombRepulsionOperator& op) const {
+    return cint2e_cart_optimizer;
 }
 
 

--- a/tests/Basis/AOBasis_test.cpp
+++ b/tests/Basis/AOBasis_test.cpp
@@ -172,7 +172,5 @@ BOOST_AUTO_TEST_CASE ( dissociatedMoleculeBasis ) {
     auto NO = GQCP::Molecule(nuclei, +1);
     GQCP::AOBasis basis (NO, "STO-3G");
 
-
-
     BOOST_CHECK_NO_THROW(GQCP::AOBasis basis (NO, "STO-3G"));
 }

--- a/tests/Basis/AOBasis_test.cpp
+++ b/tests/Basis/AOBasis_test.cpp
@@ -164,3 +164,16 @@ BOOST_AUTO_TEST_CASE ( libcint_vs_libint2_dipole_origin ) {
         BOOST_CHECK(dipole_libcint[i].isApprox(dipole_libint2[i], 1.0e-08));
     }
 }
+
+
+BOOST_AUTO_TEST_CASE ( dissociatedMoleculeBasis ) {
+
+    // Test if we can succesfully initialize NO+ at long intra molecular distance
+    auto N = GQCP::Nucleus(7, 3.5, 0, 0);
+    auto O = GQCP::Nucleus(8, -3.5, 0, 0);
+    std::vector<GQCP::Nucleus> nuclei {N,O};
+    auto NO = GQCP::Molecule(nuclei, +1);
+    GQCP::AOBasis basis (NO, "STO-3G");
+
+    BOOST_CHECK_NO_THROW(GQCP::AOBasis basis (NO, "STO-3G"));
+}

--- a/tests/Basis/AOBasis_test.cpp
+++ b/tests/Basis/AOBasis_test.cpp
@@ -128,16 +128,13 @@ BOOST_AUTO_TEST_CASE ( libcint_vs_libint2_H2O_STO_3G ) {
     const auto T_libcint = ao_basis.calculateLibcintKineticIntegrals();
     const auto V_libcint = ao_basis.calculateLibcintNuclearIntegrals();
     const auto dipole_libcint = ao_basis.calculateLibcintDipoleIntegrals();
-    // const auto g_libcint = ao_basis.calculateLibcintCoulombRepulsionIntegrals();
-
-    // std::cout << "g_libcint " << std::endl;
-    // g_libcint.print();
+    const auto g_libcint = ao_basis.calculateLibcintCoulombRepulsionIntegrals();
 
     const auto S_libint2 = ao_basis.calculateLibintOverlapIntegrals();
     const auto T_libint2 = ao_basis.calculateLibintKineticIntegrals();
     const auto V_libint2 = ao_basis.calculateLibintNuclearIntegrals();
     const auto dipole_libint2 = ao_basis.calculateLibintDipoleIntegrals();
-    // const auto g_libint2 = ao_basis.calculateLibintCoulombRepulsionIntegrals();
+    const auto g_libint2 = ao_basis.calculateLibintCoulombRepulsionIntegrals();
 
     BOOST_CHECK(S_libcint.isApprox(S_libint2, 1.0e-08));
     BOOST_CHECK(T_libcint.isApprox(T_libint2, 1.0e-08));
@@ -145,7 +142,7 @@ BOOST_AUTO_TEST_CASE ( libcint_vs_libint2_H2O_STO_3G ) {
     for (size_t i = 0; i < 3; i++) {
         BOOST_CHECK(dipole_libcint[i].isApprox(dipole_libint2[i], 1.0e-08));
     }
-    // BOOST_CHECK(g_libcint.isApprox(g_libint2, 1.0e-08));
+    BOOST_CHECK(g_libcint.isApprox(g_libint2, 1.0e-08));
 }
 
 
@@ -174,6 +171,8 @@ BOOST_AUTO_TEST_CASE ( dissociatedMoleculeBasis ) {
     std::vector<GQCP::Nucleus> nuclei {N,O};
     auto NO = GQCP::Molecule(nuclei, +1);
     GQCP::AOBasis basis (NO, "STO-3G");
+
+
 
     BOOST_CHECK_NO_THROW(GQCP::AOBasis basis (NO, "STO-3G"));
 }

--- a/tests/HamiltonianParameters/HamiltonianParameters_test.cpp
+++ b/tests/HamiltonianParameters/HamiltonianParameters_test.cpp
@@ -423,3 +423,14 @@ BOOST_AUTO_TEST_CASE ( areOrbitalsOrthonormal ) {
     auto mol_ham_par = GQCP::HamiltonianParameters<double>(ao_ham_par, rhf.get_C());
     BOOST_CHECK(mol_ham_par.areOrbitalsOrthonormal());
 }
+
+BOOST_AUTO_TEST_CASE ( dissociatedMoleculeParameters ) {
+
+    // Test if we can succesfully initialize NO+ at long intra molecular distance
+    auto N = GQCP::Nucleus(7, 3.5, 0, 0);
+    auto O = GQCP::Nucleus(8, -3.5, 0, 0);
+    std::vector<GQCP::Nucleus> nuclei {N,O};
+    auto NO = GQCP::Molecule(nuclei, +1);
+
+    BOOST_CHECK_NO_THROW(GQCP::HamiltonianParameters<double>::Molecular(NO, "STO-3G"));
+}


### PR DESCRIPTION
**Short description**
Travis currently fails: this PR aims to resolve this.

**Longer description**
The error that Travis reported lead us to a bug that was introduced in #353. As it was related to some integrals being zero in the Libint2 calculations, I implemented a 'screening' function for the Libint buffers, which is a function that checks if all the integrals calculated over two or four shells are zero. Since the extension for the Libcint buffers and the implementation of the two-electron optimizers were straightforward (and my memory of Libcint was still fresh), this PR also closes #399.