### PR TITLE
Implement some convenient Python bindings

### DIFF
--- a/gqcpy/src/Operator/SecondQuantized/SQHamiltonian.cpp
+++ b/gqcpy/src/Operator/SecondQuantized/SQHamiltonian.cpp
@@ -40,6 +40,18 @@ void bindSQHamiltonian(py::module& module) {
             "Construct the molecular Hamiltonian in a given spinor basis."
         )
 
+        .def("__add__",
+            [ ] (const GQCP::SQHamiltonian<double>& sq_hamiltonian, const GQCP::SQOneElectronOperator<double, 1>& sq_op) {
+                return sq_hamiltonian + sq_op;
+            }
+        )
+
+        .def("__sub__",
+            [ ] (const GQCP::SQHamiltonian<double>& sq_hamiltonian, const GQCP::SQOneElectronOperator<double, 1>& sq_op) {
+                return sq_hamiltonian - sq_op;
+            }
+        )
+
         .def("core", &GQCP::SQHamiltonian<double>::core, "Return the 'core' Hamiltonian, i.e. the total of the one-electron contributions to the Hamiltonian")
 
         .def("twoElectron", &GQCP::SQHamiltonian<double>::twoElectron, "Return the total of the two-electron contributions to the Hamiltonian")

--- a/gqcpy/src/Operator/SecondQuantized/SQOneElectronOperator.cpp
+++ b/gqcpy/src/Operator/SecondQuantized/SQOneElectronOperator.cpp
@@ -19,6 +19,7 @@
 #include "Utilities/typedefs.hpp"
 
 #include <pybind11/eigen.h>
+#include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -48,6 +49,8 @@ void bindSQOneElectronOperator(py::module& module, const std::string& suffix) {
         ("ScalarSQOneElectronOperator_" + suffix).c_str(), 
         "A class that represents a second-quantized one-electron operator"
     )
+
+        .def(double() * py::self)
 
         .def("calculateExpectationValue",
             [ ] (const GQCP::SQOneElectronOperator<Scalar, 1>& op, const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& D) {  // use an itermediary Eigen matrix for the Python binding, since Pybind11 doesn't accept our types that are derived from Eigen::Matrix

--- a/gqcpy/src/QCMethod/HF/RHFSCFSolver.cpp
+++ b/gqcpy/src/QCMethod/HF/RHFSCFSolver.cpp
@@ -49,9 +49,11 @@ void bindRHFSCFSolver(py::module& module) {
         )
 
         .def_static("DIIS",
-            [ ] (const double threshold, const size_t maximum_number_of_iterations) {
-                return GQCP::RHFSCFSolver<double>::DIIS(threshold, maximum_number_of_iterations);
+            [ ] (const size_t minimum_subspace_dimension, const size_t maximum_subspace_dimension, const double threshold, const size_t maximum_number_of_iterations) {
+                return GQCP::RHFSCFSolver<double>::DIIS(minimum_subspace_dimension, maximum_subspace_dimension, threshold, maximum_number_of_iterations);
             },
+            py::arg("minimum_subspace_dimension") = 6,
+            py::arg("maximum_subspace_dimension") = 6,
             py::arg("threshold") = 1.0e-08,
             py::arg("maximum_number_of_iterations") = 128
         )


### PR DESCRIPTION
**Short description**
In this PR, I have implemented some convenient Python bindings for the addition of one-electron operators to a Hamiltonian.

**Don't forget:** 
- [ ] if new files are created: update the Doxygen file, the collective gqcp.hpp header and the CMake files
- [ ] update the documentation on [our website](https://github.com/GQCG/gqcg.github.io) and check if new Python bindings should be added
