### PR TITLE
Separate workflows for build and deploy website.

### DIFF
--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -2,7 +2,7 @@ name: Deploy website
 
 # This workflow is triggered on a pull-request. This is a single event so no brackets are needed.
 on: 
-  pull-request:
+  pull_request:
     # This workflow will only start if files in site/docs/ or site/website are changed.
     paths: 
     - site/docs/

--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -1,0 +1,51 @@
+name: Deploy website
+
+# This workflow is triggered on a pull-request. This is a single event so no brackets are needed.
+on: 
+  pull-request:
+    # This workflow will only start if files in site/docs/ or site/website are changed.
+    paths: 
+    - site/docs/
+    - site/website/
+
+jobs:
+  build:
+    # Configures a build matrix containing multiple operating systems. For each configuration, a copy of the job runs and reports a status.
+    runs-on: ${{ matrix.os }}
+    # To specify the array of operating systems, we must list them under 'strategy'.
+    strategy:
+      matrix:
+        # This job runs on the latest version of Linux.
+        os: [ubuntu-latest]
+    steps:
+    # The checkout action must be included when your workflow requires a copy of your repository's code.
+    - uses: actions/checkout@v2
+
+    # Download and install conda such that we can use it to install the required packages for Docusaurus.
+    - name: Download conda (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $HOME/miniconda.sh
+
+    - name: Install conda   
+      run: |  
+        bash $HOME/miniconda.sh -b -u -p $HOME/miniconda
+        echo "::add-path::$HOME/miniconda/bin"
+
+    # Nodejs and Yarn are required packages to run Docusaurus.
+    - name: Install Nodejs and Yarn
+      run: |
+        conda install -c anaconda nodejs
+        conda install -c conda-forge yarn
+
+    # Run the Docusaurus installation script.
+    - name: Docusaurus installation
+      run: |
+        cd site/website
+        npx docusaurus-init
+        yarn
+
+    # Build the site
+    - name: Build site using Docusaurus
+      run: |
+        cd site/website
+        yarn run build

--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -1,4 +1,4 @@
-name: Deploy website
+name: Build website
 
 # This workflow is triggered on a pull-request. This is a single event so no brackets are needed.
 on: 

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -1,8 +1,10 @@
 name: Deploy website
 
-# This workflow is triggered on a pull request. This is a single event so no brackets are needed.
+# This workflow is triggered on a push to the develop branch. This is a single event so no brackets are needed.
 on: 
-  pull_request:
+  push:
+    branches:
+     - develop
     # This workflow will only start if files in site/docs/ or site/website are changed.
     paths: 
     - site/docs/


### PR DESCRIPTION
**Short description**
In this PR, I have made a distinction between a `push` to `develop` and a `pull_request`. The first will deploy the website to [the remote documentation site](https://gqcg.github.io/GQCP/) while the latter will only build it remotely to check if there are no compilation errors.

**Related issues**
#609 
