### PR TITLE
Enable MacOS Conda package build (closes #597).

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
**Short description**
This PR reenables support for CD MacOS Conda GQCP packages.

**Related issues**
This PR is a replacement for PR #644. PR #644 shows that this PR should not fail when pushed to develop.
