### PR TITLE
Density matrix bindings

### DIFF
--- a/gqcp/include/Processing/DensityMatrices/OneDM.hpp
+++ b/gqcp/include/Processing/DensityMatrices/OneDM.hpp
@@ -48,13 +48,15 @@ public:
     /*
      * PUBLIC METHODS
      */
-    
+
     /**
      *  @param T          transformation matrix for the spin unresolved 1-DM
      * 
      *  @return the transformed density matrix.
      */
-    OneDM<Scalar> transformed(const TransformationMatrix<double>& T) const { return this->basisTransform(T); }
+    OneDM<Scalar> transformed(const TransformationMatrix<double>& T) const {
+        return Self(T.adjoint() * (*this) * T);
+    }
 };
 
 

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -654,15 +654,6 @@ public:
 
 
     /**
-     *  Calculate the one-electron density matrix for a full spin-resolved wave function expansion.
-     * 
-     *  @return the total (spin-summed) 1-DM
-     */
-    template <typename Z = ONVBasis>
-    enable_if_t<std::is_same<Z, SeniorityZeroONVBasis>::value, OneDM<double>> calculateSpinDensity() const { return this->calculateSpinResolved1DM().spinDensity(); }
-
-
-    /**
      *  Calculate the spin-resolved one-electron density matrix for a seniority-zero wave function expansion.
      * 
      *  @return the spin-resolved 1-DM
@@ -783,15 +774,6 @@ public:
      */
     template <typename Z = ONVBasis>
     enable_if_t<std::is_same<Z, SpinResolvedONVBasis>::value, TwoDM<double>> calculate2DM() const { return this->calculateSpinResolved2DM().spinSummed(); }
-
-
-    /**
-     *  Calculate the one-electron density matrix for a full spin-resolved wave function expansion.
-     * 
-     *  @return the total (spin-summed) 1-DM
-     */
-    template <typename Z = ONVBasis>
-    enable_if_t<std::is_same<Z, SpinResolvedONVBasis>::value, OneDM<double>> calculateSpinDensity() const { return this->calculateSpinResolved1DM().spinDensity(); }
 
 
     /**
@@ -1148,15 +1130,6 @@ public:
      */
     template <typename Z = ONVBasis>
     enable_if_t<std::is_same<Z, SpinResolvedSelectedONVBasis>::value, TwoDM<double>> calculate2DM() const { return this->calculateSpinResolved2DM().spinSummed(); }
-
-
-    /**
-     *  Calculate the one-electron density matrix for a full spin-resolved wave function expansion.
-     * 
-     *  @return the total (spin-summed) 1-DM
-     */
-    template <typename Z = ONVBasis>
-    enable_if_t<std::is_same<Z, SpinResolvedSelectedONVBasis>::value, OneDM<double>> calculateSpinDensity() const { return this->calculateSpinResolved1DM().spinDensity(); }
 
 
     /**

--- a/gqcpy/gqcpy.cpp
+++ b/gqcpy/gqcpy.cpp
@@ -95,6 +95,13 @@ void bindSQTwoElectronOperator(py::module& module);
 void bindUSQHamiltonian(py::module& module);
 
 
+// Processing - DensityMatrices
+void bindOneDM(py::module& module);
+void bindSpinResolvedOneDM(py::module& module);
+void bindSpinResolvedTwoDM(py::module& module);
+void bindTwoDM(py::module& module);
+
+
 // Processing - Properties
 void bindDOCIElectricalResponseSolver(py::module& module);
 void bindRHFElectricalResponseSolver(py::module& module);
@@ -249,6 +256,13 @@ PYBIND11_MODULE(gqcpy, module) {
     gqcpy::bindSQOneElectronOperators(module);
     gqcpy::bindSQTwoElectronOperator(module);
     gqcpy::bindUSQHamiltonian(module);
+
+
+    // Processing - DensityMatrices
+    gqcpy::bindOneDM(module);
+    gqcpy::bindSpinResolvedOneDM(module);
+    gqcpy::bindSpinResolvedTwoDM(module);
+    gqcpy::bindTwoDM(module);
 
 
     // Processing - Properties

--- a/gqcpy/src/Processing/CMakeLists.txt
+++ b/gqcpy/src/Processing/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(DensityMatrices)
 add_subdirectory(Properties)
 
 set(python_bindings_sources ${python_bindings_sources} PARENT_SCOPE)

--- a/gqcpy/src/Processing/DensityMatrices/CMakeLists.txt
+++ b/gqcpy/src/Processing/DensityMatrices/CMakeLists.txt
@@ -1,0 +1,8 @@
+list(APPEND python_bindings_sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/OneDM_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/SpinResolvedOneDM_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/SpinResolvedTwoDM_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/TwoDM_bindings.cpp  
+)
+
+set(python_bindings_sources ${python_bindings_sources} PARENT_SCOPE)

--- a/gqcpy/src/Processing/DensityMatrices/OneDM_bindings.cpp
+++ b/gqcpy/src/Processing/DensityMatrices/OneDM_bindings.cpp
@@ -1,0 +1,42 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Processing/DensityMatrices/OneDM.hpp"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+
+namespace py = pybind11;
+
+
+namespace gqcpy {
+
+
+void bindOneDM(py::module& module) {
+    py::class_<GQCP::OneDM<Scalar>>(module, "OneDM", "A single particle density matrix");
+
+    // PUBLIC METHODS
+
+    .def(
+        "transformed",
+        &GQCP::OneDM<Scalar>::transformed,
+        "Return the transformed density matrix.")
+}
+
+
+}  // namespace gqcpy

--- a/gqcpy/src/Processing/DensityMatrices/OneDM_bindings.cpp
+++ b/gqcpy/src/Processing/DensityMatrices/OneDM_bindings.cpp
@@ -28,14 +28,17 @@ namespace gqcpy {
 
 
 void bindOneDM(py::module& module) {
-    py::class_<GQCP::OneDM<Scalar>>(module, "OneDM", "A single particle density matrix");
+    py::class_<GQCP::OneDM<double>>(module, "OneDM", "A single particle density matrix")
 
-    // PUBLIC METHODS
+        // PUBLIC METHODS
 
-    .def(
-        "transformed",
-        &GQCP::OneDM<Scalar>::transformed,
-        "Return the transformed density matrix.")
+        .def(
+            "transformed",
+            [](const Eigen::MatrixXd& D, const Eigen::MatrixXd& T) {
+                return GQCP::OneDM<double> {D}.transformed(GQCP::TransformationMatrix<double> {T});
+            },
+            py::arg("T"),
+            "Return the transformed density matrix.");
 }
 
 

--- a/gqcpy/src/Processing/DensityMatrices/SpinResolvedOneDM_bindings.cpp
+++ b/gqcpy/src/Processing/DensityMatrices/SpinResolvedOneDM_bindings.cpp
@@ -28,14 +28,14 @@ namespace gqcpy {
 
 
 void bindSpinResolvedOneDM(py::module& module) {
-    py::class_<GQCP::SpinResolvedOneDM<Scalar>>(module, "SpinResolvedOneDM", "A class that represents a spin resolved one DM.")
+    py::class_<GQCP::SpinResolvedOneDM<double>>(module, "SpinResolvedOneDM", "A class that represents a spin resolved one DM.")
 
         // CONSTRUCTORS
 
         .def_static(
             "fromRestricted",
-            [](const OneDM<Scalar>& D) {
-                return GQCP::SpinResolvedOneDM<Scalar>::FromRestricted(D);
+            [](const Eigen::MatrixXd& D) {
+                return GQCP::SpinResolvedOneDM<double>::FromRestricted(GQCP::OneDM<double> {D});
             },
             "Return a spin resolved One DM created from a restricted basis.")
 
@@ -43,17 +43,17 @@ void bindSpinResolvedOneDM(py::module& module) {
 
         .def(
             "alpha",
-            &GQCP::SpinResolvedOneDM<Scalar>::alpha,
+            &GQCP::SpinResolvedOneDM<double>::alpha,
             "Return the alpha part of the spin resolved One DM.")
 
         .def(
             "beta",
-            &GQCP::SpinResolvedOneDM<Scalar>::beta,
+            &GQCP::SpinResolvedOneDM<double>::beta,
             "Return the beta part of the spin resolved one DM.")
 
         .def(
             "numberOfOrbitals",
-            [](const SpinResolvedOneDM<Scalar>& D, const GQCP::Spin sigma) {
+            [](const GQCP::SpinResolvedOneDM<double>& D, const GQCP::Spin sigma) {
                 return D.numberOfOrbitals(sigma);
             },
             py::arg("sigma"),
@@ -61,14 +61,13 @@ void bindSpinResolvedOneDM(py::module& module) {
 
         .def(
             "spinDensity",
-            &GQCP::SpinResolvedOneDM<Scalar>::spinDensity,
+            &GQCP::SpinResolvedOneDM<double>::spinDensity,
             "Return the spin-density matrix, i.e. the difference between the alpha and beta 1-DM.")
 
         .def(
             "spinSummed",
-            &GQCP::SpinResolvedOneDM<Scalar>::spinSummed,
-            "Return the spin-summed density matrix, i.e. the sum of the alpha and beta 1-DM.")
+            &GQCP::SpinResolvedOneDM<double>::spinSummed,
+            "Return the spin-summed density matrix, i.e. the sum of the alpha and beta 1-DM.");
 }
-
 
 }  // namespace gqcpy

--- a/gqcpy/src/Processing/DensityMatrices/SpinResolvedOneDM_bindings.cpp
+++ b/gqcpy/src/Processing/DensityMatrices/SpinResolvedOneDM_bindings.cpp
@@ -1,0 +1,74 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Processing/DensityMatrices/SpinResolvedOneDM.hpp"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+
+namespace py = pybind11;
+
+
+namespace gqcpy {
+
+
+void bindSpinResolvedOneDM(py::module& module) {
+    py::class_<GQCP::SpinResolvedOneDM<Scalar>>(module, "SpinResolvedOneDM", "A class that represents a spin resolved one DM.")
+
+        // CONSTRUCTORS
+
+        .def_static(
+            "fromRestricted",
+            [](const OneDM<Scalar>& D) {
+                return GQCP::SpinResolvedOneDM<Scalar>::FromRestricted(D);
+            },
+            "Return a spin resolved One DM created from a restricted basis.")
+
+        // PUBLIC METHODS
+
+        .def(
+            "alpha",
+            &GQCP::SpinResolvedOneDM<Scalar>::alpha,
+            "Return the alpha part of the spin resolved One DM.")
+
+        .def(
+            "beta",
+            &GQCP::SpinResolvedOneDM<Scalar>::beta,
+            "Return the beta part of the spin resolved one DM.")
+
+        .def(
+            "numberOfOrbitals",
+            [](const SpinResolvedOneDM<Scalar>& D, const GQCP::Spin sigma) {
+                return D.numberOfOrbitals(sigma);
+            },
+            py::arg("sigma"),
+            "Return the number of orbitals (spinors or spin-orbitals, depending on the context) that correspond to the given spin.")
+
+        .def(
+            "spinDensity",
+            &GQCP::SpinResolvedOneDM<Scalar>::spinDensity,
+            "Return the spin-density matrix, i.e. the difference between the alpha and beta 1-DM.")
+
+        .def(
+            "spinSummed",
+            &GQCP::SpinResolvedOneDM<Scalar>::spinSummed,
+            "Return the spin-summed density matrix, i.e. the sum of the alpha and beta 1-DM.")
+}
+
+
+}  // namespace gqcpy

--- a/gqcpy/src/Processing/DensityMatrices/SpinResolvedTwoDM_bindings.cpp
+++ b/gqcpy/src/Processing/DensityMatrices/SpinResolvedTwoDM_bindings.cpp
@@ -28,43 +28,43 @@ namespace gqcpy {
 
 
 void bindSpinResolvedTwoDM(py::module& module) {
-    py::class_<GQCP::SpinResolvedTwoDM<Scalar>>(module, "SpinResolvedTwoDM", "A class that represents a spin resolved two DM.")
+    py::class_<GQCP::SpinResolvedTwoDM<double>>(module, "SpinResolvedTwoDM", "A class that represents a spin resolved two DM.")
 
         // PUBLIC METHODS
 
         .def(
             "alphaAlpha",
-            &GQCP::SpinResolvedTwoDM<Scalar>::alphaAlpha,
+            &GQCP::SpinResolvedTwoDM<double>::alphaAlpha,
             "Return the pure alpha component of the spin resolved two DM")
 
         .def(
             "alphaBeta",
-            &GQCP::SpinResolvedTwoDM<Scalar>::alphaBeta,
+            &GQCP::SpinResolvedTwoDM<double>::alphaBeta,
             "Return the mixed alpha-beta component of the spin resolved two DM")
 
         .def(
             "betaAlpha",
-            &GQCP::SpinResolvedTwoDM<Scalar>::betaAlpha,
+            &GQCP::SpinResolvedTwoDM<double>::betaAlpha,
             "Return the mixed beta-alpha component of the spin resolved two DM")
 
         .def(
             "betaBeta",
-            &GQCP::SpinResolvedTwoDM<Scalar>::betaBeta,
+            &GQCP::SpinResolvedTwoDM<double>::betaBeta,
             "Return the pure beta component of the spin resolved two DM")
 
         .def(
             "numberOfOrbitals",
-            [](const SpinResolvedTwoDM<Scalar>& d, const GQCP::Spin sigma, const GQCP::Spin tau) {
+            [](const GQCP::SpinResolvedTwoDM<double>& d, const GQCP::Spin sigma, const GQCP::Spin tau) {
                 return d.numberOfOrbitals(sigma, tau);
             },
             "Return the number of orbitals (spinors or spin-orbitals, depending on the context) that are related to the sigma-tau part of the spin-resolved 2-DM.")
 
         .def(
             "spinSummed",
-            [](const SpinResolvedTwoDM<Scalar>& d) {
+            [](const GQCP::SpinResolvedTwoDM<double>& d) {
                 return d.spinSummed();
             },
-            "Return the spin-summed (total) 2-DM, i.e. the sum of four spin parts.")
-
-    // PUBLIC METHODS
+            "Return the spin-summed (total) 2-DM, i.e. the sum of four spin parts.");
 }
+
+}  // namespace gqcpy

--- a/gqcpy/src/Processing/DensityMatrices/SpinResolvedTwoDM_bindings.cpp
+++ b/gqcpy/src/Processing/DensityMatrices/SpinResolvedTwoDM_bindings.cpp
@@ -1,0 +1,70 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Processing/DensityMatrices/SpinResolvedTwoDM.hpp"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+
+namespace py = pybind11;
+
+
+namespace gqcpy {
+
+
+void bindSpinResolvedTwoDM(py::module& module) {
+    py::class_<GQCP::SpinResolvedTwoDM<Scalar>>(module, "SpinResolvedTwoDM", "A class that represents a spin resolved two DM.")
+
+        // PUBLIC METHODS
+
+        .def(
+            "alphaAlpha",
+            &GQCP::SpinResolvedTwoDM<Scalar>::alphaAlpha,
+            "Return the pure alpha component of the spin resolved two DM")
+
+        .def(
+            "alphaBeta",
+            &GQCP::SpinResolvedTwoDM<Scalar>::alphaBeta,
+            "Return the mixed alpha-beta component of the spin resolved two DM")
+
+        .def(
+            "betaAlpha",
+            &GQCP::SpinResolvedTwoDM<Scalar>::betaAlpha,
+            "Return the mixed beta-alpha component of the spin resolved two DM")
+
+        .def(
+            "betaBeta",
+            &GQCP::SpinResolvedTwoDM<Scalar>::betaBeta,
+            "Return the pure beta component of the spin resolved two DM")
+
+        .def(
+            "numberOfOrbitals",
+            [](const SpinResolvedTwoDM<Scalar>& d, const GQCP::Spin sigma, const GQCP::Spin tau) {
+                return d.numberOfOrbitals(sigma, tau);
+            },
+            "Return the number of orbitals (spinors or spin-orbitals, depending on the context) that are related to the sigma-tau part of the spin-resolved 2-DM.")
+
+        .def(
+            "spinSummed",
+            [](const SpinResolvedTwoDM<Scalar>& d) {
+                return d.spinSummed();
+            },
+            "Return the spin-summed (total) 2-DM, i.e. the sum of four spin parts.")
+
+    // PUBLIC METHODS
+}

--- a/gqcpy/src/Processing/DensityMatrices/TwoDM_bindings.cpp
+++ b/gqcpy/src/Processing/DensityMatrices/TwoDM_bindings.cpp
@@ -27,25 +27,25 @@ namespace py = pybind11;
 namespace gqcpy {
 
 
-void bindOneDM(py::module& module) {
+void bindTwoDM(py::module& module) {
 
-    py::class_<GQCP::TwoDM<Scalar>>(module, "TwoDM", "A two-particle density matrix");
+    py::class_<GQCP::TwoDM<double>>(module, "TwoDM", "A two-particle density matrix")
 
-    // PUBLIC METHODS
+        // PUBLIC METHODS
 
-    .def(
-        "reduce",
-        [](const TwoDM<Scalar>& d) {
-            return d.reduce();
-        },
-        "Return a partial contraction of the 2-DM, where D(p,q) = d(p,q,r,r).")
+        .def(
+            "reduce",
+            [](const GQCP::TwoDM<double>& d) {
+                return d.reduce();
+            },
+            "Return a partial contraction of the 2-DM, where D(p,q) = d(p,q,r,r).")
 
         .def(
             "trace",
-            [](const TwoDM<Scalar>& d) {
+            [](const GQCP::TwoDM<double>& d) {
                 return d.trace();
             },
-            "Return the trace of the 2-DM, i.e. d(p,p,q,q).")
+            "Return the trace of the 2-DM, i.e. d(p,p,q,q).");
 }
 
 

--- a/gqcpy/src/Processing/DensityMatrices/TwoDM_bindings.cpp
+++ b/gqcpy/src/Processing/DensityMatrices/TwoDM_bindings.cpp
@@ -1,0 +1,52 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Processing/DensityMatrices/TwoDM.hpp"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+
+namespace py = pybind11;
+
+
+namespace gqcpy {
+
+
+void bindOneDM(py::module& module) {
+
+    py::class_<GQCP::TwoDM<Scalar>>(module, "TwoDM", "A two-particle density matrix");
+
+    // PUBLIC METHODS
+
+    .def(
+        "reduce",
+        [](const TwoDM<Scalar>& d) {
+            return d.reduce();
+        },
+        "Return a partial contraction of the 2-DM, where D(p,q) = d(p,q,r,r).")
+
+        .def(
+            "trace",
+            [](const TwoDM<Scalar>& d) {
+                return d.trace();
+            },
+            "Return the trace of the 2-DM, i.e. d(p,p,q,q).")
+}
+
+
+}  // namespace gqcpy

--- a/gqcpy/src/QCMethod/HF/UHF/UHFSCFEnvironment_bindings.cpp
+++ b/gqcpy/src/QCMethod/HF/UHF/UHFSCFEnvironment_bindings.cpp
@@ -79,7 +79,7 @@ void bindUHFSCFEnvironment(py::module& module) {
             })
 
 
-        // Define read-only 'getters'.
+        // Define read-only 'getters'
         .def_readonly(
             "coefficient_matrices_alpha",
             &GQCP::UHFSCFEnvironment<double>::coefficient_matrices_alpha)
@@ -88,6 +88,19 @@ void bindUHFSCFEnvironment(py::module& module) {
             "coefficient_matrices_beta",
             &GQCP::UHFSCFEnvironment<double>::coefficient_matrices_beta)
 
+        .def_readonly(
+            "spin_resolved_density_matrices",
+            &GQCP::UHFSCFEnvironment<double>::density_matrices)
+
+        .def_readonly(
+            "error_vectors_alpha",
+            &GQCP::UHFSCFEnvironment<double>::error_vectors_alpha)
+
+        .def_readonly(
+            "error_vectors_beta",
+            &GQCP::UHFSCFEnvironment<double>::error_vectors_beta)
+
+        // Define getters for non-native components
         .def(
             "density_matrices_alpha",
             [](const GQCP::UHFSCFEnvironment<double>& environment) {
@@ -123,15 +136,6 @@ void bindUHFSCFEnvironment(py::module& module) {
 
                 return beta_fock_matrices;
             })
-
-        .def_readonly(
-            "error_vectors_alpha",
-            &GQCP::UHFSCFEnvironment<double>::error_vectors_alpha)
-
-        .def_readonly(
-            "error_vectors_beta",
-            &GQCP::UHFSCFEnvironment<double>::error_vectors_beta)
-
 
         // Bind methods for the replacement of the most current iterates.
         .def("replace_current_coefficient_matrix_alpha",

--- a/gqcpy/src/QCMethod/HF/UHF/UHFSCFEnvironment_bindings.cpp
+++ b/gqcpy/src/QCMethod/HF/UHF/UHFSCFEnvironment_bindings.cpp
@@ -89,7 +89,7 @@ void bindUHFSCFEnvironment(py::module& module) {
             &GQCP::UHFSCFEnvironment<double>::coefficient_matrices_beta)
 
         .def_readonly(
-            "spin_resolved_density_matrices",
+            "density_matrices",
             &GQCP::UHFSCFEnvironment<double>::density_matrices)
 
         .def_readonly(

--- a/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
+++ b/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
@@ -148,12 +148,18 @@ void bindLinearExpansion<GQCP::SeniorityZeroONVBasis>(py::module& module, const 
              "Return the expansion coefficients of this linear expansion wave function model.")
 
         .def(
-            "calculateSpinDensity",
+            "calculateSpinResolved1DM",
             [](const GQCP::LinearExpansion<GQCP::SeniorityZeroONVBasis>& linear_expansion) {
-                return linear_expansion.calculateSpinDensity();
+                return linear_expansion.calculateSpinResolved1DM();
             },
-            "Return the spin density matrix for a seniority-zero wave function expansion.");
-    ;
+            "Return the spin-resolved 1-DM.")
+
+        .def(
+            "calculateSpinResolved2DM",
+            [](const GQCP::LinearExpansion<GQCP::SeniorityZeroONVBasis>& linear_expansion) {
+                return linear_expansion.calculateSpinResolved2DM();
+            },
+            "Return the spin resolved 2-DM.");
 }
 
 
@@ -237,11 +243,18 @@ void bindLinearExpansion<GQCP::SpinResolvedONVBasis>(py::module& module, const s
             "Iterate over all expansion coefficients and corresponding ONVs, and apply the given callback function.")
 
         .def(
-            "calculateSpinDensity",
+            "calculateSpinResolved1DM",
             [](const GQCP::LinearExpansion<GQCP::SpinResolvedONVBasis>& linear_expansion) {
-                return linear_expansion.calculateSpinDensity();
+                return linear_expansion.calculateSpinResolved1DM();
             },
-            "Return the spin density matrix for a full spin-resolved wave function expansion.");
+            "Return the spin-resolved 1-DM.")
+
+        .def(
+            "calculateSpinResolved2DM",
+            [](const GQCP::LinearExpansion<GQCP::SpinResolvedONVBasis>& linear_expansion) {
+                return linear_expansion.calculateSpinResolved2DM();
+            },
+            "Return the spin resolved 2-DM.");
 }
 
 
@@ -307,11 +320,18 @@ void bindLinearExpansion<GQCP::SpinResolvedSelectedONVBasis>(py::module& module,
              "Return the expansion coefficients of this linear expansion wave function model.")
 
         .def(
-            "calculateSpinDensity",
+            "calculateSpinResolved1DM",
             [](const GQCP::LinearExpansion<GQCP::SpinResolvedSelectedONVBasis>& linear_expansion) {
-                return linear_expansion.calculateSpinDensity();
+                return linear_expansion.calculateSpinResolved1DM();
             },
-            "Return the spin density matrix for a full spin-resolved wave function expansion.");
+            "Return the spin-resolved 1-DM.")
+
+        .def(
+            "calculateSpinResolved2DM",
+            [](const GQCP::LinearExpansion<GQCP::SpinResolvedSelectedONVBasis>& linear_expansion) {
+                return linear_expansion.calculateSpinResolved2DM();
+            },
+            "Return the spin resolved 2-DM.");
 }
 
 


### PR DESCRIPTION
**Short description**
The functionality to work with both spin resolved and regular density matrix types in python will prove to be very valuable further down the road. In this PR I will tackle this functionality.

**Related issues**
- closes #677 

**Additional context**
I have removed the `spinDensity` binding from `linearExpansion`, since the `SpinResolvedOneDM` binding can now calculate this for us. I have, however, added the `calculateSpinResolved1DM` and `calculateSpinResolved2DM` functionalities to the `linearExpansion` bindings. This grants a lot of freedom to manipulate the density matrices using the python bindings. 

**Don't forget:**
- [x] if new files are created: update the Doxygen file, the collective gqcp.hpp header and the CMake files
