### PR TITLE
Vector space arithmetic

### DIFF
--- a/gqcp/include/Mathematical/Functions/LinearCombination.hpp
+++ b/gqcp/include/Mathematical/Functions/LinearCombination.hpp
@@ -129,6 +129,12 @@ public:
      */
     Self& operator*=(const CoefficientScalar& a) override {
 
+        if (std::abs(a) < 1.0e-16) {  // multiplication by zero returns a 'zero vector'
+            this->m_coefficients = std::vector<CoefficientScalar> {};
+            this->m_functions = std::vector<Function> {};
+            return *this;
+        }
+
         std::transform(this->m_coefficients.begin(), this->m_coefficients.end(),
                        this->m_coefficients.begin(), [a](const CoefficientScalar& C) { return C * a; });
 

--- a/gqcp/include/Mathematical/Functions/LinearCombination.hpp
+++ b/gqcp/include/Mathematical/Functions/LinearCombination.hpp
@@ -20,7 +20,6 @@
 
 #include "Mathematical/Functions/ScalarFunction.hpp"
 #include "Mathematical/Functions/VectorSpaceArithmetic.hpp"
-#include "Utilities/CRTP.hpp"
 
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
@@ -40,8 +39,7 @@ namespace GQCP {
 template <typename _CoefficientScalar, typename _Function>
 class LinearCombination:
     public ScalarFunction<typename _Function::Valued, typename _Function::Scalar, _Function::Cols>,
-    public VectorSpaceArithmetic<LinearCombination<_CoefficientScalar, _Function>, _CoefficientScalar>,
-    public CRTP<_Function> {
+    public VectorSpaceArithmetic<LinearCombination<_CoefficientScalar, _Function>, _CoefficientScalar> {
 
 public:
     using CoefficientScalar = _CoefficientScalar;
@@ -114,7 +112,7 @@ public:
 
 
     /*
-     *  MARK: VECTOR SPACE ARITHMETIC
+     *  MARK: Vector space arithmetic
      */
 
     /**
@@ -139,7 +137,7 @@ public:
 
 
     /*
-     *  MARK: OPERATORS
+     *  MARK: operators
      */
 
     /**

--- a/gqcp/include/Mathematical/Functions/VectorSpaceArithmetic.hpp
+++ b/gqcp/include/Mathematical/Functions/VectorSpaceArithmetic.hpp
@@ -96,6 +96,19 @@ public:
         return lhs *= a;
     }
 
+    /**
+     *  Scalar division, canonically implemented using scalar multiplication-assignment.
+     */
+    friend T operator/(const Scalar& a, T rhs) {
+        return rhs *= 1 / a;
+    }
+
+    /**
+     *  The commutative version of the previous scalar division.
+     */
+    friend T operator/(T lhs, const Scalar& a) {
+        return lhs *= 1 / a;
+    }
 
     /**
      *  Negation, canonically implemented as scalar multiplication by (-1.0).

--- a/gqcp/include/Mathematical/Functions/VectorSpaceArithmetic.hpp
+++ b/gqcp/include/Mathematical/Functions/VectorSpaceArithmetic.hpp
@@ -114,7 +114,7 @@ public:
      *  Negation, canonically implemented as scalar multiplication by (-1.0).
      */
     T operator-() const {
-        return Scalar {-1.0} * this->derived();
+        return Scalar {-1} * this->derived();
     }
 };
 

--- a/gqcp/include/Operator/SecondQuantized/SimpleSQOneElectronOperator.hpp
+++ b/gqcp/include/Operator/SecondQuantized/SimpleSQOneElectronOperator.hpp
@@ -263,7 +263,7 @@ public:
                        std::plus<MatrixRepresentation>());
 
         return *this;
-    };
+    }
 
 
     /**

--- a/gqcp/include/QCModel/CC/T2Amplitudes.hpp
+++ b/gqcp/include/QCModel/CC/T2Amplitudes.hpp
@@ -19,6 +19,7 @@
 
 
 #include "Basis/SpinorBasis/OrbitalSpace.hpp"
+#include "Mathematical/Functions/VectorSpaceArithmetic.hpp"
 #include "Mathematical/Representation/ImplicitRankFourTensorSlice.hpp"
 #include "Operator/SecondQuantized/SQHamiltonian.hpp"
 
@@ -30,9 +31,12 @@ namespace GQCP {
  *  The coupled-cluster T2-amplitudes t_{ij}^{ab}. According to context, this class may either represent restricted (i.e. spatial-orbital) amplitudes, or generalized (spinor) amplitudes.
  */
 template <typename _Scalar>
-class T2Amplitudes {
+class T2Amplitudes:
+    public VectorSpaceArithmetic<T2Amplitudes<_Scalar>, _Scalar> {
+
 public:
     using Scalar = _Scalar;
+    using Self = T2Amplitudes<Scalar>;
 
 private:
     OrbitalSpace orbital_space;  // the orbital space which covers the occupied-virtual separation
@@ -167,91 +171,44 @@ public:
      *  @return the orbital space for these T2-amplitudes, which covers the occupied-virtual separation
      */
     const OrbitalSpace& orbitalSpace() const { return this->orbital_space; }
+
+
+    /*
+     *  MARK: Vector space arithmetic
+     */
+
+    /**
+     *  Addition-assignment.
+     */
+    Self& operator+=(const Self& rhs) override {
+
+        // Prepare some variables.
+        const auto& index_maps = this->asImplicitRankFourTensorSlice().indexMaps();
+
+        const Tensor<Scalar, 4> t_sum_dense = this->asImplicitRankFourTensorSlice().asTensor().Eigen() + rhs.asImplicitRankFourTensorSlice().asTensor().Eigen();
+        const ImplicitRankFourTensorSlice<Scalar> t_sum_slice {index_maps, t_sum_dense};
+
+        this->t = t_sum_slice;
+
+        return *this;
+    }
+
+
+    /**
+     *  Scalar multiplication-assignment.
+     */
+    Self& operator*=(const Scalar& a) override {
+
+        // Prepare some variables.
+        const auto& index_maps = this->asImplicitRankFourTensorSlice().indexMaps();
+
+        const Tensor<Scalar, 4> t_multiplied_dense = a * this->asImplicitRankFourTensorSlice().asTensor().Eigen();
+        const ImplicitRankFourTensorSlice<Scalar> t_multiplied_slice {index_maps, t_multiplied_dense};
+
+        this->t = t_multiplied_slice;
+
+        return *this;
+    }
 };
-
-
-/*
- *  OPERATORS
- */
-
-/**
- *  Add two sets of T2-amplitudes.
- * 
- *  @tparam LHSScalar           the scalar type of the left-hand side
- *  @tparam RHSScalar           the scalar type of the right-hand side
- * 
- *  @param lhs                  the left-hand side
- *  @param rhs                  the right-hand side
- */
-template <typename LHSScalar, typename RHSScalar>
-auto operator+(const T2Amplitudes<LHSScalar>& lhs, const T2Amplitudes<RHSScalar>& rhs) -> T2Amplitudes<sum_t<LHSScalar, RHSScalar>> {
-
-    using ResultScalar = sum_t<LHSScalar, RHSScalar>;
-
-    // Prepare some variables.
-    const auto& orbital_space = lhs.orbitalSpace();  // assume the orbital spaces are equal for the LHS and RHS
-    const auto& index_maps = lhs.asImplicitRankFourTensorSlice().indexMaps();
-
-    const Tensor<ResultScalar, 4> t_sum_dense = lhs.asImplicitRankFourTensorSlice().asTensor().Eigen() + rhs.asImplicitRankFourTensorSlice().asTensor().Eigen();
-    const ImplicitRankFourTensorSlice<ResultScalar> t_sum_slice {index_maps, t_sum_dense};
-
-    return T2Amplitudes<ResultScalar>(t_sum_slice, orbital_space);
-}
-
-
-/**
- *  Multiply a set of T2-amplitudes with a scalar.
- * 
- *  @tparam Scalar              the scalar type of the scalar
- *  @tparam AmplitudeScalar     the scalar type of the T2-amplitudes
- * 
- *  @param scalar               the scalar
- *  @param t2                   the the T2-amplitudes
- */
-template <typename Scalar, typename AmplitudeScalar>
-auto operator*(const Scalar& scalar, const T2Amplitudes<AmplitudeScalar>& t2) -> T2Amplitudes<product_t<Scalar, AmplitudeScalar>> {
-
-    using ResultScalar = product_t<Scalar, AmplitudeScalar>;
-
-    // Prepare some variables.
-    const auto& orbital_space = t2.orbitalSpace();  // assume the orbital spaces are equal for the LHS and RHS
-    const auto& index_maps = t2.asImplicitRankFourTensorSlice().indexMaps();
-
-    const Tensor<ResultScalar, 4> t_multiplied_dense = scalar * t2.asImplicitRankFourTensorSlice().asTensor().Eigen();
-    const ImplicitRankFourTensorSlice<ResultScalar> t_multiplied_slice {index_maps, t_multiplied_dense};
-
-    return T2Amplitudes<ResultScalar>(t_multiplied_slice, orbital_space);
-}
-
-
-/**
- *  Negate a set of T2-amplitudes.
- * 
- *  @tparam Scalar              the scalar type of the T2-amplitudes
- * 
- *  @param t2                   the T2-amplitudes
- */
-template <typename Scalar>
-T2Amplitudes<Scalar> operator-(const T2Amplitudes<Scalar>& t2) {
-
-    return (-1.0) * t2;  // negation is scalar multiplication with (-1.0)
-}
-
-
-/**
- *  Subtract one set of T2-amplitudes from another.
- * 
- *  @tparam LHSScalar           the scalar type of the left-hand side
- *  @tparam RHSScalar           the scalar type of the right-hand side
- * 
- *  @param lhs                  the left-hand side
- *  @param rhs                  the right-hand side
- */
-template <typename LHSScalar, typename RHSScalar>
-auto operator-(const T2Amplitudes<LHSScalar>& lhs, const T2Amplitudes<RHSScalar>& rhs) -> T2Amplitudes<sum_t<LHSScalar, RHSScalar>> {
-
-    return lhs + (-rhs);
-}
-
 
 }  // namespace GQCP

--- a/gqcp/tests/Operator/SecondQuantized/SQOneElectronOperator_test.cpp
+++ b/gqcp/tests/Operator/SecondQuantized/SQOneElectronOperator_test.cpp
@@ -84,6 +84,8 @@ BOOST_AUTO_TEST_CASE(SQOneElectronOperator_of_GTOs_transform) {
     }
 
     BOOST_CHECK(ref_coeff_result_01.size() == coeff_result_01.size());
+    std::cout << ref_coeff_result_01.size() << std::endl;
+    std::cout << coeff_result_01.size() << std::endl;
 
     const std::vector<double> ref_coeff_result_11 {1.0};
     const auto coeff_result_11 = rho_transformed_par(1, 1).coefficients();

--- a/gqcp/tests/Operator/SecondQuantized/SQOneElectronOperator_test.cpp
+++ b/gqcp/tests/Operator/SecondQuantized/SQOneElectronOperator_test.cpp
@@ -84,8 +84,6 @@ BOOST_AUTO_TEST_CASE(SQOneElectronOperator_of_GTOs_transform) {
     }
 
     BOOST_CHECK(ref_coeff_result_01.size() == coeff_result_01.size());
-    std::cout << ref_coeff_result_01.size() << std::endl;
-    std::cout << coeff_result_01.size() << std::endl;
 
     const std::vector<double> ref_coeff_result_11 {1.0};
     const auto coeff_result_11 = rho_transformed_par(1, 1).coefficients();
@@ -93,8 +91,6 @@ BOOST_AUTO_TEST_CASE(SQOneElectronOperator_of_GTOs_transform) {
         BOOST_CHECK(std::abs(ref_coeff_result_11[i] - coeff_result_11[i]) < 1.0e-12);
     }
     BOOST_CHECK(ref_coeff_result_11.size() == coeff_result_11.size());
-    std::cout << ref_coeff_result_11.size() << std::endl;
-    std::cout << coeff_result_11.size() << std::endl;
 }
 
 

--- a/gqcp/tests/Operator/SecondQuantized/SQOneElectronOperator_test.cpp
+++ b/gqcp/tests/Operator/SecondQuantized/SQOneElectronOperator_test.cpp
@@ -82,6 +82,7 @@ BOOST_AUTO_TEST_CASE(SQOneElectronOperator_of_GTOs_transform) {
     for (size_t i = 0; i < ref_coeff_result_01.size(); i++) {
         BOOST_CHECK(std::abs(ref_coeff_result_01[i] - coeff_result_01[i]) < 1.0e-12);
     }
+
     BOOST_CHECK(ref_coeff_result_01.size() == coeff_result_01.size());
 
     const std::vector<double> ref_coeff_result_11 {1.0};
@@ -90,6 +91,8 @@ BOOST_AUTO_TEST_CASE(SQOneElectronOperator_of_GTOs_transform) {
         BOOST_CHECK(std::abs(ref_coeff_result_11[i] - coeff_result_11[i]) < 1.0e-12);
     }
     BOOST_CHECK(ref_coeff_result_11.size() == coeff_result_11.size());
+    std::cout << ref_coeff_result_11.size() << std::endl;
+    std::cout << coeff_result_11.size() << std::endl;
 }
 
 


### PR DESCRIPTION
**Short description**
In line with the large operator refactor going on right now, I'll use this PR to tackle some smaller issues that are related to vector space arithmetic.

**Related issues**
- closes #415 

**Additional context**
Issue #415 has different parts to it:
- [x] implement a division operator;
- [x] Implement `VectorSpaceArithmetic` on `LinearCombination`;
- [ ] ~Implement `VectorSpaceArithmetic` on `Field`~;
- [x] Implement `VectorSpaceArithmetic` on `T1Amplitudes`;
- [x] Implement `VectorSpaceArithmetic` on `T2Amplitudes`.

**Don't forget:**
- [ ] if new files are created: update the Doxygen file, the collective gqcp.hpp header and the CMake files
