### PR TITLE
Calculate 1DM with ONVPath API.

### DIFF
--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -594,7 +594,7 @@ public:
 
                     const double value = onv_path.sign() * this->coefficient(I) * this->coefficient(J);
 
-                    // Add the one-electron integral as matrix elements of a Hermitian matrix.
+                    // Add the density matrix elements as elements of a Hermitian matrix.
                     ONV_iterator.addColumnwise(I, value);
                     ONV_iterator.addRowwise(I, value);
 

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -547,7 +547,7 @@ public:
         this->m_coefficients = current_coefficients;
     }
 
-
+    // deze functie met ONVPath API herschrijven
     /**
      *  Calculate the orbital one-electron density matrix for a seniority-zero wave function expansion.
      * 

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -246,28 +246,28 @@ BOOST_AUTO_TEST_CASE(calculate1DM_SpinUnresolved) {
     // Set up an example linear expansion.
     const size_t M = 3;
     const size_t N = 1;
-    const GQCP::SpinUnresolvedONVBasis onv_basis_SUR {M, N};
+    const GQCP::SpinUnresolvedONVBasis onv_basis_SU {M, N};
 
-    GQCP::VectorX<double> coefficients {onv_basis_SUR.dimension()};
+    GQCP::VectorX<double> coefficients {onv_basis_SU.dimension()};
     coefficients << 1, 2, -3;
 
-    const GQCP::LinearExpansion<GQCP::SpinUnresolvedONVBasis> linear_expansion_SUR {onv_basis_SUR, coefficients};
+    const GQCP::LinearExpansion<GQCP::SpinUnresolvedONVBasis> linear_expansion_SU {onv_basis_SU, coefficients};
 
 
     // Check some 1-DM values with calculateNDMElement().
-    const auto D_SUR = linear_expansion_SUR.calculate1DM();
-    BOOST_CHECK(std::abs(linear_expansion_SUR.calculateNDMElement({0}, {0}) - D_SUR(0, 0)) < 1.0e-12);  // D(0,0) : a^\dagger_0 a_0
-    BOOST_CHECK(std::abs(linear_expansion_SUR.calculateNDMElement({0}, {1}) - D_SUR(0, 1)) < 1.0e-12);  // D(0,1) : a^\dagger_0 a_1
-    BOOST_CHECK(std::abs(linear_expansion_SUR.calculateNDMElement({2}, {1}) - D_SUR(2, 1)) < 1.0e-12);  // D(2,1) : a^\dagger_2 a_1
+    const auto D_SU = linear_expansion_SU.calculate1DM();
+    BOOST_CHECK(std::abs(linear_expansion_SU.calculateNDMElement({0}, {0}) - D_SU(0, 0)) < 1.0e-12);  // D(0,0) : a^\dagger_0 a_0
+    BOOST_CHECK(std::abs(linear_expansion_SU.calculateNDMElement({0}, {1}) - D_SU(0, 1)) < 1.0e-12);  // D(0,1) : a^\dagger_0 a_1
+    BOOST_CHECK(std::abs(linear_expansion_SU.calculateNDMElement({2}, {1}) - D_SU(2, 1)) < 1.0e-12);  // D(2,1) : a^\dagger_2 a_1
 
     // Check with a reference SpinResolved 1-DM.
     const GQCP::SpinResolvedONVBasis onv_basis_SR {M, N, 0};
     const GQCP::LinearExpansion<GQCP::SpinResolvedONVBasis> linear_expansion_SR {onv_basis_SR, coefficients};
 
     const auto D_SR = linear_expansion_SR.calculate1DM();
-    BOOST_CHECK(std::abs(D_SUR(0, 0) - D_SR(0, 0)) < 1.0e-12);  // D(0,0) : a^\dagger_0 a_0
-    BOOST_CHECK(std::abs(D_SUR(0, 1) - D_SR(0, 1)) < 1.0e-12);  // D(0,1) : a^\dagger_0 a_1
-    BOOST_CHECK(std::abs(D_SUR(2, 1) - D_SR(2, 1)) < 1.0e-12);  // D(2,1) : a^\dagger_2 a_1
+    BOOST_CHECK(std::abs(D_SU(0, 0) - D_SR(0, 0)) < 1.0e-12);  // D(0,0) : a^\dagger_0 a_0
+    BOOST_CHECK(std::abs(D_SU(0, 1) - D_SR(0, 1)) < 1.0e-12);  // D(0,1) : a^\dagger_0 a_1
+    BOOST_CHECK(std::abs(D_SU(2, 1) - D_SR(2, 1)) < 1.0e-12);  // D(2,1) : a^\dagger_2 a_1
 }
 
 

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -238,6 +238,29 @@ BOOST_AUTO_TEST_CASE(expansions) {
     BOOST_CHECK(std::abs(random_expansion.coefficients().norm() - 1.0) < 1.0e-12);  // check if the coefficient vector is normalized
 }
 
+/**
+ *  Check some 1-DM values calculated for the SpinUnresolvedONVBasis by comparing them to the general function calculateNDMElement.
+ */
+BOOST_AUTO_TEST_CASE(calculate1DM_SpinUnresolved) {
+
+    // Set up an example linear expansion.
+    const size_t M = 3;
+    const size_t N = 1;
+    const GQCP::SpinUnresolvedONVBasis onv_basis {M, N};
+
+    GQCP::VectorX<double> coefficients {onv_basis.dimension()};
+    coefficients << 1, 2, -3;
+
+    const GQCP::LinearExpansion<GQCP::SpinUnresolvedONVBasis> linear_expansion {onv_basis, coefficients};
+
+
+    // Check some 1-DM values.
+    const auto D = linear_expansion.calculate1DM();
+    BOOST_CHECK(std::abs(linear_expansion.calculateNDMElement({0}, {0}) - D(0, 0)) < 1.0e-12);  // d(0,0) : a^\dagger_0 a_0
+    BOOST_CHECK(std::abs(linear_expansion.calculateNDMElement({0}, {1}) - D(0, 1)) < 1.0e-12);  // d(0,1) : a^\dagger_0 a_1
+    BOOST_CHECK(std::abs(linear_expansion.calculateNDMElement({2}, {1}) - D(2, 1)) < 1.0e-12);  // d(2,1) : a^\dagger_2 a_1
+}
+
 
 /**
  *  Check if calculateNDMElement throws as expected.

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -246,19 +246,28 @@ BOOST_AUTO_TEST_CASE(calculate1DM_SpinUnresolved) {
     // Set up an example linear expansion.
     const size_t M = 3;
     const size_t N = 1;
-    const GQCP::SpinUnresolvedONVBasis onv_basis {M, N};
+    const GQCP::SpinUnresolvedONVBasis onv_basis_SUR {M, N};
 
-    GQCP::VectorX<double> coefficients {onv_basis.dimension()};
+    GQCP::VectorX<double> coefficients {onv_basis_SUR.dimension()};
     coefficients << 1, 2, -3;
 
-    const GQCP::LinearExpansion<GQCP::SpinUnresolvedONVBasis> linear_expansion {onv_basis, coefficients};
+    const GQCP::LinearExpansion<GQCP::SpinUnresolvedONVBasis> linear_expansion_SUR {onv_basis_SUR, coefficients};
 
 
-    // Check some 1-DM values.
-    const auto D = linear_expansion.calculate1DM();
-    BOOST_CHECK(std::abs(linear_expansion.calculateNDMElement({0}, {0}) - D(0, 0)) < 1.0e-12);  // d(0,0) : a^\dagger_0 a_0
-    BOOST_CHECK(std::abs(linear_expansion.calculateNDMElement({0}, {1}) - D(0, 1)) < 1.0e-12);  // d(0,1) : a^\dagger_0 a_1
-    BOOST_CHECK(std::abs(linear_expansion.calculateNDMElement({2}, {1}) - D(2, 1)) < 1.0e-12);  // d(2,1) : a^\dagger_2 a_1
+    // Check some 1-DM values with calculateNDMElement().
+    const auto D_SUR = linear_expansion_SUR.calculate1DM();
+    BOOST_CHECK(std::abs(linear_expansion_SUR.calculateNDMElement({0}, {0}) - D_SUR(0, 0)) < 1.0e-12);  // D(0,0) : a^\dagger_0 a_0
+    BOOST_CHECK(std::abs(linear_expansion_SUR.calculateNDMElement({0}, {1}) - D_SUR(0, 1)) < 1.0e-12);  // D(0,1) : a^\dagger_0 a_1
+    BOOST_CHECK(std::abs(linear_expansion_SUR.calculateNDMElement({2}, {1}) - D_SUR(2, 1)) < 1.0e-12);  // D(2,1) : a^\dagger_2 a_1
+
+    // Check with a reference SpinResolved 1-DM.
+    const GQCP::SpinResolvedONVBasis onv_basis_SR {M, N, 0};
+    const GQCP::LinearExpansion<GQCP::SpinResolvedONVBasis> linear_expansion_SR {onv_basis_SR, coefficients};
+
+    const auto D_SR = linear_expansion_SR.calculate1DM();
+    BOOST_CHECK(std::abs(D_SUR(0, 0) - D_SR(0, 0)) < 1.0e-12);  // D(0,0) : a^\dagger_0 a_0
+    BOOST_CHECK(std::abs(D_SUR(0, 1) - D_SR(0, 1)) < 1.0e-12);  // D(0,1) : a^\dagger_0 a_1
+    BOOST_CHECK(std::abs(D_SUR(2, 1) - D_SR(2, 1)) < 1.0e-12);  // D(2,1) : a^\dagger_2 a_1
 }
 
 


### PR DESCRIPTION
**Short description**
The calculation of the one-electron density matrix will be refactored such that it will make use of the `ONVPath` API.

**Related issues**
https://github.com/GQCG/GQCP/issues/687 https://github.com/GQCG/GQCP/issues/648
closes https://github.com/GQCG/GQCP/issues/719

**Don't forget:**
- [ ] if new files are created: update the Doxygen file, the collective gqcp.hpp header and the CMake files
