### PR TITLE
PR: Change class to struct for traits.

### DIFF
--- a/gqcp/include/Basis/SpinorBasis/GSpinorBasis.hpp
+++ b/gqcp/include/Basis/SpinorBasis/GSpinorBasis.hpp
@@ -456,8 +456,7 @@ public:
  *  A type that provides compile-time information on spinor bases that is otherwise not accessible through a public class alias.
  */
 template <typename _ExpansionScalar, typename _Shell>
-class SpinorBasisTraits<GSpinorBasis<_ExpansionScalar, _Shell>> {
-public:
+struct SpinorBasisTraits<GSpinorBasis<_ExpansionScalar, _Shell>> {
     // The scalar type used to represent an expansion coefficient of the spinors in the underlying scalar orbitals: real or complex.
     using ExpansionScalar = _ExpansionScalar;
 

--- a/gqcp/include/Basis/SpinorBasis/RSpinOrbitalBasis.hpp
+++ b/gqcp/include/Basis/SpinorBasis/RSpinOrbitalBasis.hpp
@@ -263,8 +263,7 @@ using RSpinorBasis = RSpinOrbitalBasis<ExpansionScalar, Shell>;
  *  A type that provides compile-time information on spinor bases that is otherwise not accessible through a public class alias.
  */
 template <typename _ExpansionScalar, typename _Shell>
-class SpinorBasisTraits<RSpinOrbitalBasis<_ExpansionScalar, _Shell>> {
-public:
+struct SpinorBasisTraits<RSpinOrbitalBasis<_ExpansionScalar, _Shell>> {
     // The scalar type used to represent an expansion coefficient of the spinors in the underlying scalar orbitals: real or complex.
     using ExpansionScalar = _ExpansionScalar;
 

--- a/gqcp/include/DensityMatrix/G1DM.hpp
+++ b/gqcp/include/DensityMatrix/G1DM.hpp
@@ -60,7 +60,7 @@ public:
  *  A type that provides compile-time information on `G1DM` that is otherwise not accessible through a public class alias.
  */
 template <typename Scalar>
-class DensityMatrixTraits<G1DM<Scalar>> {
+struct DensityMatrixTraits<G1DM<Scalar>> {
 public:
     // The type of transformation matrix that is naturally related to a `G1DM`.
     using TM = GTransformationMatrix<Scalar>;

--- a/gqcp/include/DensityMatrix/G2DM.hpp
+++ b/gqcp/include/DensityMatrix/G2DM.hpp
@@ -61,8 +61,7 @@ public:
  *  A type that provides compile-time information on `G2DM` that is otherwise not accessible through a public class alias.
  */
 template <typename Scalar>
-class DensityMatrixTraits<G2DM<Scalar>> {
-public:
+struct DensityMatrixTraits<G2DM<Scalar>> {
     // The type of transformation matrix that is naturally related to a `G2DM`.
     using TM = GTransformationMatrix<Scalar>;
 

--- a/gqcp/include/DensityMatrix/Orbital1DM.hpp
+++ b/gqcp/include/DensityMatrix/Orbital1DM.hpp
@@ -62,8 +62,7 @@ public:
  *  A type that provides compile-time information on `Orbital1DM` that is otherwise not accessible through a public class alias.
  */
 template <typename Scalar>
-class DensityMatrixTraits<Orbital1DM<Scalar>> {
-public:
+struct DensityMatrixTraits<Orbital1DM<Scalar>> {
     // The type of transformation matrix that is naturally related to an Orbital1DM. The only transformations that should be naturally possible for an orbital 1-DM are restricted transformations, thereby assuming that the density matrices for alpha and beta are equal and thus transform similarly.
     using TM = RTransformationMatrix<Scalar>;
 };

--- a/gqcp/include/DensityMatrix/SpinDensity1DM.hpp
+++ b/gqcp/include/DensityMatrix/SpinDensity1DM.hpp
@@ -62,8 +62,7 @@ public:
  *  A type that provides compile-time information on `SpinDensity1DM` that is otherwise not accessible through a public class alias.
  */
 template <typename Scalar>
-class DensityMatrixTraits<SpinDensity1DM<Scalar>> {
-public:
+struct DensityMatrixTraits<SpinDensity1DM<Scalar>> {
     // The type of transformation matrix that is naturally related to a `SpinDensity1DM`. The only transformations that should be naturally possible for a a spin-density 1-DM are restricted transformations, that transform the alpha- and beta-spin-orbitals equally.
     using TM = RTransformationMatrix<Scalar>;
 };

--- a/gqcp/include/DensityMatrix/SpinResolved1DMComponent.hpp
+++ b/gqcp/include/DensityMatrix/SpinResolved1DMComponent.hpp
@@ -61,8 +61,7 @@ public:
  *  A type that provides compile-time information on `SpinResolved1DMComponent` that is otherwise not accessible through a public class alias.
  */
 template <typename Scalar>
-class DensityMatrixTraits<SpinResolved1DMComponent<Scalar>> {
-public:
+struct DensityMatrixTraits<SpinResolved1DMComponent<Scalar>> {
     // The type of transformation matrix that is naturally related to a `SpinResolved1DMComponent`. Since a `SpinResolved1DM` naturally transforms with a `UTransformationMatrix`, a `SpinResolved1DMComponent` naturally transforms with a `UTransformationMatrixComponent`.
     using TM = UTransformationMatrixComponent<Scalar>;
 };

--- a/gqcp/include/DensityMatrix/SpinResolved2DMComponent.hpp
+++ b/gqcp/include/DensityMatrix/SpinResolved2DMComponent.hpp
@@ -62,8 +62,7 @@ public:
  *  A type that provides compile-time information on `SpinResolved2DMComponent` that is otherwise not accessible through a public class alias.
  */
 template <typename Scalar>
-class DensityMatrixTraits<SpinResolved2DMComponent<Scalar>> {
-public:
+struct DensityMatrixTraits<SpinResolved2DMComponent<Scalar>> {
     // The type of transformation matrix that is naturally related to a `SpinResolved2DMComponent`. Since a `SpinResolved2DM` naturally transforms with a `UTransformationMatrix`, a `SpinResolved2DMComponent` naturally transforms with a `UTransformationMatrixComponent`.
     using TM = UTransformationMatrixComponent<Scalar>;
 

--- a/gqcp/include/Operator/SecondQuantized/EvaluatableScalarRSQOneElectronOperator.hpp
+++ b/gqcp/include/Operator/SecondQuantized/EvaluatableScalarRSQOneElectronOperator.hpp
@@ -143,8 +143,7 @@ public:
  *  A type that provides compile-time information on operators that is otherwise not accessible through a public class alias.
  */
 template <typename _Evaluatable>
-class OperatorTraits<EvaluatableScalarRSQOneElectronOperator<_Evaluatable>> {
-public:
+struct OperatorTraits<EvaluatableScalarRSQOneElectronOperator<_Evaluatable>> {
     // The type of evaluatable function that is used as a matrix element of the one-electron operator.
     using Evaluatable = _Evaluatable;
 

--- a/gqcp/include/Operator/SecondQuantized/SQOperatorStorageBase.hpp
+++ b/gqcp/include/Operator/SecondQuantized/SQOperatorStorageBase.hpp
@@ -35,7 +35,7 @@ namespace GQCP {
  *  A type that provides compile-time information on operators that is otherwise not accessible through a public class alias.
  */
 template <typename Operator>
-class OperatorTraits {};
+struct OperatorTraits {};
 
 
 /*


### PR DESCRIPTION
**Short description**
In the current code, a trait is alternatively defined as a `struct` or `class`. In my opinion, it would be better to implement them all as `struct`s as their members should be stored as `public`.

**Related issues**
Closes #706.

**Don't forget:**
- [x] if new files are created: update the Doxygen file, the collective gqcp.hpp header and the CMake files
