### PR TITLE
Clean up test.

### DIFF
--- a/gqcp/tests/Processing/Properties/CMakeLists.txt
+++ b/gqcp/tests/Processing/Properties/CMakeLists.txt
@@ -1,5 +1,4 @@
 list(APPEND test_target_sources
-    ${CMAKE_CURRENT_SOURCE_DIR}/expectation_values_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/properties_test.cpp
 )
 


### PR DESCRIPTION
This PR cleans up `properties_test.cpp`. It also closes #751. (This issue should already have been closed, since the Dyson amplitude calculation was already re-enabled).

**Don't forget:**
- [x] if new files are created: update the Doxygen file, the collective gqcp.hpp header and the CMake files
