### PR TITLE
RHF Stability analysis

### DIFF
--- a/gqcp/include/QCModel/HF/GHF.hpp
+++ b/gqcp/include/QCModel/HF/GHF.hpp
@@ -311,7 +311,7 @@ public:
     /**
      *  @return the eigenvalues of the one-electron Fock Operator as a matrix.
      */
-    GQCP::MatrixX<Scalar> calculateFockMatrix() const {
+    GQCP::MatrixX<Scalar> calculateFockOperatorEigenvalues() const {
 
         // Create the orbital space to determine the loops.
         const auto orbital_space = this->orbitalSpace();
@@ -369,8 +369,8 @@ public:
         const auto g = gsq_hamiltonian.twoElectron().transformed(this->coefficientMatrix()).antisymmetrized().parameters();
 
         // The elements F_BA and F_IJ are the eigenvalues of the one-electron Fock operator.
-        // The calculateFockMatrix API can be used to find these values
-        const auto F_values = this->calculateFockMatrix();
+        // The calculateFockOperatorEigenvalues API can be used to find these values
+        const auto F_values = this->calculateFockOperatorEigenvalues();
 
         // The next step is to create the needed tensor slice.
         // Zero-initialize an occupied-virtual-occupied-virtual object.

--- a/gqcp/include/QCModel/HF/GHF.hpp
+++ b/gqcp/include/QCModel/HF/GHF.hpp
@@ -321,9 +321,9 @@ public:
         const auto& n_virt = orbital_space.numberOfOrbitals(OccupationType::k_virtual);
 
         // Create the F matrix
-        GQCP::MatrixX<Scalar> F_values(n_occ, n_virt);
-        for (int a = 0; a < n_occ; a++) {
-            for (int i = 0; i < n_virt; i++) {
+        GQCP::MatrixX<Scalar> F_values(n_virt, n_occ);
+        for (int a = 0; a < n_virt; a++) {
+            for (int i = 0; i < n_occ; i++) {
                 F_values(a, i) = this->virtualOrbitalEnergies()[a] + (-1 * this->occupiedOrbitalEnergies()[i]);
             }
         }
@@ -385,8 +385,8 @@ public:
         auto A_iajb = A_iajb_slice.asTensor();
 
         // Add the previously calculated F values on the correct positions.
-        for (int a = 0; a < n_occ; a++) {
-            for (int i = 0; i < n_virt; i++) {
+        for (int a = 0; a < n_virt; a++) {
+            for (int i = 0; i < n_occ; i++) {
                 A_iajb(i, a, i, a) += F_values(a, i);
             }
         }

--- a/gqcp/include/QCModel/HF/GHF.hpp
+++ b/gqcp/include/QCModel/HF/GHF.hpp
@@ -369,7 +369,7 @@ public:
         const auto& F_values = this->calculateFValues();
 
         // The next step is to create the needed tensor slice.
-        // zero-initialize an occupied-virtual-occupied-virtual object
+        // Zero-initialize an occupied-virtual-occupied-virtual object.
         auto A_iajb_slice = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
         for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
             for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
@@ -421,6 +421,7 @@ public:
         const auto& g = gsq_hamiltonian.twoElectron().transformed(this->coefficientMatrix()).antisymmetrized();
 
         // The next step is to create the needed tensor slice.
+        // Zero-initialize an occupied-virtual-occupied-virtual object.
         auto B_iajb_slice = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
         for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
             for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {

--- a/gqcp/include/QCModel/HF/RHF.hpp
+++ b/gqcp/include/QCModel/HF/RHF.hpp
@@ -353,7 +353,7 @@ public:
      *  Construct the `singlet A` stability matrix from the RHF stability conditions.
      * 
      *  @note The formula for the `singlet A` matrix is as follows:
-     *      A_IAJB = \delta_IJ * (F_R)_BA - \delta_AB * (F_R)_IJ + 2*(AI|JB) - (AB|JI)
+     *      A_IAJB = \delta_IJ * (F_R)_BA - \delta_AB * (F_R)_IJ + 2 * (AI|JB) - (AB|JI)
      * 
      *  @param rsq_hamiltonian      The second quantized hamiltonian, which contains the necessary two electron operators.
      */
@@ -411,6 +411,60 @@ public:
         const GQCP::MatrixX<Scalar> singlet_A_matrix = singlet_A_iajb.reshape(n_occ * n_virt, n_occ * n_virt);
 
         return singlet_A_matrix;
+    }
+
+
+    /**
+     *  Construct the `singlet B` stability matrix from the RHF stability conditions.
+     * 
+     *  @note The formula for the `singlet A` matrix is as follows:
+     *      A_IAJB = 2 * (AI|BJ) - (AJ|BI)
+     * 
+     *  @param rsq_hamiltonian      The second quantized hamiltonian, which contains the necessary two electron operators.
+     */
+    const GQCP::MatrixX<Scalar> calculateSingletAStabilityMatrix(const RSQHamiltonian<Scalar>& rsq_hamiltonian) const {
+
+        // Create the orbital space.
+        const auto orbital_space = this->orbitalSpace();
+
+        // Create the number of occupied and virtual orbitals.
+        const auto& n_occ = orbital_space.numberOfOrbitals(OccupationType::k_occupied);
+        const auto& n_virt = orbital_space.numberOfOrbitals(OccupationType::k_virtual);
+
+        // We need the two-electron integrals in MO basis, hence why we transform them with the coefficient matrix.
+        // The ground state coefficient matrix is obtained from the QCModel.
+        const auto& g = rsq_hamiltonian.twoElectron().transformed(this->coefficientMatrix());
+
+        // The next step is to create the needed tensor slices.
+        // Zero-initialize an occupied-virtual-occupied-virtual object.
+        auto singlet_B_slice_1 = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
+        for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
+            for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
+                for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
+                    for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
+                        singlet_A_slice_1(i, a, j, b) = 2 * g.parameters()(a, i, b, j);
+                    }
+                }
+            }
+        }
+
+        auto singlet_B_slice_2 = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
+        for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
+            for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
+                for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
+                    for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
+                        singlet_A_slice_2(i, a, j, b) = -1 * g.parameters()(a, j, b, i);
+                    }
+                }
+            }
+        }
+
+        auto singlet_B_iajb = singlet_B_slice_1.asTensor() + singlet_A_slice_2.asTensor();
+
+        // Finally, reshape the tensor to a matrix.
+        const GQCP::MatrixX<Scalar> singlet_B_matrix = singlet_B_iajb.reshape(n_occ * n_virt, n_occ * n_virt);
+
+        return singlet_B_matrix;
     }
 
 

--- a/gqcp/include/QCModel/HF/RHF.hpp
+++ b/gqcp/include/QCModel/HF/RHF.hpp
@@ -25,6 +25,7 @@
 #include "Mathematical/Representation/SquareMatrix.hpp"
 #include "Operator/SecondQuantized/RSQOneElectronOperator.hpp"
 #include "Operator/SecondQuantized/SQHamiltonian.hpp"
+#include "QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp"
 #include "QuantumChemical/Spin.hpp"
 
 
@@ -443,7 +444,7 @@ public:
             for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
                 for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
                     for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
-                        singlet_A_slice_1(i, a, j, b) = 2 * g.parameters()(a, i, b, j);
+                        singlet_B_slice_1(i, a, j, b) = 2 * g.parameters()(a, i, b, j);
                     }
                 }
             }
@@ -454,14 +455,14 @@ public:
             for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
                 for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
                     for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
-                        singlet_A_slice_2(i, a, j, b) = -1 * g.parameters()(a, j, b, i);
+                        singlet_B_slice_2(i, a, j, b) = -1 * g.parameters()(a, j, b, i);
                     }
                 }
             }
         }
 
         // Turn the ImplicitRankFourTensorSlices in an actual Tensor and add them together.
-        auto singlet_B_iajb = singlet_B_slice_1.asTensor() + singlet_A_slice_2.asTensor();
+        auto singlet_B_iajb = singlet_B_slice_1.asTensor() + singlet_B_slice_2.asTensor();
 
         // Finally, reshape the tensor to a matrix.
         const GQCP::MatrixX<Scalar> singlet_B_matrix = singlet_B_iajb.reshape(n_occ * n_virt, n_occ * n_virt);
@@ -553,7 +554,7 @@ public:
             for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
                 for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
                     for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
-                        triplet_A_slice(i, a, j, b) = -1 * g.parameters()(a, j, b, i);
+                        triplet_B_slice(i, a, j, b) = -1 * g.parameters()(a, j, b, i);
                     }
                 }
             }
@@ -566,6 +567,17 @@ public:
         const GQCP::MatrixX<Scalar> triplet_B_matrix = triplet_B_iajb.reshape(n_occ * n_virt, n_occ * n_virt);
 
         return triplet_B_matrix;
+    }
+
+
+    /**
+     *  Calculate the RHF stability matrices and return them.
+     *
+     *  @return The RHF stability matrices.
+     */
+    RHFStabilityMatrices<Scalar> calculateStabilityMatrices(const RSQHamiltonian<Scalar>& rsq_hamiltonian) const {
+        return RHFStabilityMatrices<Scalar> {this->calculateSingletAStabilityMatrix(rsq_hamiltonian), this->calculateSingletBStabilityMatrix(rsq_hamiltonian),
+                                             this->calculateTripletAStabilityMatrix(rsq_hamiltonian), this->calculateTripletBStabilityMatrix(rsq_hamiltonian)};
     }
 
 

--- a/gqcp/include/QCModel/HF/RHF.hpp
+++ b/gqcp/include/QCModel/HF/RHF.hpp
@@ -382,25 +382,25 @@ public:
             for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
                 for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
                     for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
-                        singlet_A_slice_1(i, a, j, b) = 2 * g.parameters()(a, i, j, b);
+                        singlet_A_slice_1(i, a, j, b) = 2 * g.parameters()(a, i, j, b) - 1 * g.parameters()(a, b, j, i);
                     }
                 }
             }
         }
 
-        auto singlet_A_slice_2 = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
-        for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
-            for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
-                for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
-                    for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
-                        singlet_A_slice_2(i, a, j, b) = -1 * g.parameters()(a, b, j, i);
-                    }
-                }
-            }
-        }
+        // auto singlet_A_slice_2 = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
+        // for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
+        //     for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
+        //         for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
+        //             for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
+        //                 singlet_A_slice_2(i, a, j, b) = -1 * g.parameters()(a, b, j, i);
+        //             }
+        //         }
+        //     }
+        // }
 
         // Turn the ImplicitRankFourTensorSlices in an actual Tensor and add them together.
-        auto singlet_A_iajb = singlet_A_slice_1.asTensor() + singlet_A_slice_2.asTensor();
+        auto singlet_A_iajb = singlet_A_slice_1.asTensor();  // + singlet_A_slice_2.asTensor();
 
         // Add the previously calculated F values on the correct positions.
         for (int a = 0; a < n_occ; a++) {
@@ -424,7 +424,7 @@ public:
      * 
      *  @param rsq_hamiltonian      The second quantized hamiltonian, which contains the necessary two electron operators.
      */
-    const GQCP::MatrixX<Scalar> calculateSingletAStabilityMatrix(const RSQHamiltonian<Scalar>& rsq_hamiltonian) const {
+    const GQCP::MatrixX<Scalar> calculateSingletBStabilityMatrix(const RSQHamiltonian<Scalar>& rsq_hamiltonian) const {
 
         // Create the orbital space.
         const auto orbital_space = this->orbitalSpace();
@@ -444,25 +444,25 @@ public:
             for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
                 for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
                     for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
-                        singlet_B_slice_1(i, a, j, b) = 2 * g.parameters()(a, i, b, j);
+                        singlet_B_slice_1(i, a, j, b) = 2 * g.parameters()(a, i, b, j) - 1 * g.parameters()(a, j, b, i);
                     }
                 }
             }
         }
 
-        auto singlet_B_slice_2 = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
-        for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
-            for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
-                for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
-                    for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
-                        singlet_B_slice_2(i, a, j, b) = -1 * g.parameters()(a, j, b, i);
-                    }
-                }
-            }
-        }
+        // auto singlet_B_slice_2 = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
+        // for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
+        //     for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
+        //         for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
+        //             for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
+        //                 singlet_B_slice_2(i, a, j, b) = -1 * g.parameters()(a, j, b, i);
+        //             }
+        //         }
+        //     }
+        // }
 
         // Turn the ImplicitRankFourTensorSlices in an actual Tensor and add them together.
-        auto singlet_B_iajb = singlet_B_slice_1.asTensor() + singlet_B_slice_2.asTensor();
+        auto singlet_B_iajb = singlet_B_slice_1.asTensor();  // + singlet_B_slice_2.asTensor();
 
         // Finally, reshape the tensor to a matrix.
         const GQCP::MatrixX<Scalar> singlet_B_matrix = singlet_B_iajb.reshape(n_occ * n_virt, n_occ * n_virt);
@@ -632,7 +632,7 @@ public:
         const auto& n_occ = this->orbitalSpace().numberOfOrbitals(OccupationType::k_occupied);
 
         std::vector<double> mo_energies;  // We use a std::vector in order to be able to slice the vector later on.
-        for (int i = 0; i < this->numberOfSpinors(); i++) {
+        for (int i = 0; i < this->numberOfSpatialOrbitals(); i++) {
             mo_energies.push_back(this->orbitalEnergy(i));
         }
 
@@ -701,7 +701,7 @@ public:
         const auto& n_occ = this->orbitalSpace().numberOfOrbitals(OccupationType::k_occupied);
 
         std::vector<double> mo_energies;  // We use a std::vector in order to be able to slice the vector later on.
-        for (int i = 0; i < this->numberOfSpinors(); i++) {
+        for (int i = 0; i < this->numberOfSpatialOrbitals(); i++) {
             mo_energies.push_back(this->orbitalEnergy(i));
         }
 

--- a/gqcp/include/QCModel/HF/RHF.hpp
+++ b/gqcp/include/QCModel/HF/RHF.hpp
@@ -350,6 +350,71 @@ public:
 
 
     /**
+     *  Construct the `singlet A` stability matrix from the RHF stability conditions.
+     * 
+     *  @note The formula for the `singlet A` matrix is as follows:
+     *      A_IAJB = \delta_IJ * (F_R)_BA - \delta_AB * (F_R)_IJ + 2*(AI|JB) - (AB|JI)
+     * 
+     *  @param rsq_hamiltonian      The second quantized hamiltonian, which contains the necessary two electron operators.
+     */
+    const GQCP::MatrixX<Scalar> calculateSingletAStabilityMatrix(const RSQHamiltonian<Scalar>& rsq_hamiltonian) const {
+
+        // Create the orbital space.
+        const auto orbital_space = this->orbitalSpace();
+
+        // Create the number of occupied and virtual orbitals.
+        const auto& n_occ = orbital_space.numberOfOrbitals(OccupationType::k_occupied);
+        const auto& n_virt = orbital_space.numberOfOrbitals(OccupationType::k_virtual);
+
+        // We need the two-electron integrals in MO basis, hence why we transform them with the coefficient matrix.
+        // The ground state coefficient matrix is obtained from the QCModel.
+        const auto& g = rsq_hamiltonian.twoElectron().transformed(this->coefficientMatrix());
+
+        // The elements (F_R)_AA and (F_R)_IJ are the eigenvalues of the one-electron Fock operator.
+        // The calculateFValues API can be used to find these values
+        const auto& F_values = this->calculateFValues();
+
+        // The next step is to create the needed tensor slices.
+        // Zero-initialize an occupied-virtual-occupied-virtual object.
+        auto singlet_A_slice_1 = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
+        for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
+            for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
+                for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
+                    for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
+                        singlet_A_slice_1(i, a, j, b) = 2 * g.parameters()(a, i, j, b);
+                    }
+                }
+            }
+        }
+
+        auto singlet_A_slice_2 = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
+        for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
+            for (const auto& a : orbital_space.indices(OccupationType::k_virtual)) {
+                for (const auto& j : orbital_space.indices(OccupationType::k_occupied)) {
+                    for (const auto& b : orbital_space.indices(OccupationType::k_virtual)) {
+                        singlet_A_slice_2(i, a, j, b) = -1 * g.parameters()(a, b, j, i);
+                    }
+                }
+            }
+        }
+
+        auto singlet_A_iajb = singlet_A_slice_1.asTensor() + singlet_A_slice_2.asTensor();
+
+        // Add the previously calculated F values on the correct positions.
+        for (int a = 0; a < n_occ; a++) {
+            for (int i = 0; i < n_virt; i++) {
+                singlet_A_iajb(i, a, i, a) += F_values(a, i);
+            }
+        }
+
+        // Finally, reshape the tensor to a matrix.
+        const GQCP::MatrixX<Scalar> singlet_A_matrix = singlet_A_iajb.reshape(n_occ * n_virt, n_occ * n_virt);
+
+        return singlet_A_matrix;
+    }
+
+
+    /**
      *  @return the coefficient matrix that expresses every spatial orbital (as a column) in its underlying scalar basis
      */
     const RTransformationMatrix<Scalar>& coefficientMatrix() const { return this->C; }

--- a/gqcp/include/QCModel/HF/RHF.hpp
+++ b/gqcp/include/QCModel/HF/RHF.hpp
@@ -375,7 +375,7 @@ public:
         // The calculateFValues API can be used to find these values
         const auto& F_values = this->calculateFValues();
 
-        // The next step is to create the needed tensor slices.
+        // The next step is to create the needed tensor slice.
         // Zero-initialize an occupied-virtual-occupied-virtual object.
         auto singlet_A_slice = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
         for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
@@ -388,8 +388,8 @@ public:
             }
         }
 
-        // Turn the ImplicitRankFourTensorSlices in an actual Tensor and add them together.
-        auto singlet_A_iajb = singlet_A_slice.asTensor();  // + singlet_A_slice_2.asTensor();
+        // Turn the ImplicitRankFourTensorSlice in an actual Tensor.
+        auto singlet_A_iajb = singlet_A_slice.asTensor();
 
         // Add the previously calculated F values on the correct positions.
         for (int a = 0; a < n_virt; a++) {
@@ -426,7 +426,7 @@ public:
         // The ground state coefficient matrix is obtained from the QCModel.
         const auto& g = rsq_hamiltonian.twoElectron().transformed(this->coefficientMatrix());
 
-        // The next step is to create the needed tensor slices.
+        // The next step is to create the needed tensor slice.
         // Zero-initialize an occupied-virtual-occupied-virtual object.
         auto singlet_B_slice = orbital_space.template initializeRepresentableObjectFor<Scalar>(OccupationType::k_occupied, OccupationType::k_virtual, OccupationType::k_occupied, OccupationType::k_virtual);
         for (const auto& i : orbital_space.indices(OccupationType::k_occupied)) {
@@ -439,8 +439,8 @@ public:
             }
         }
 
-        // Turn the ImplicitRankFourTensorSlices in an actual Tensor and add them together.
-        auto singlet_B_iajb = singlet_B_slice.asTensor();  // + singlet_B_slice_2.asTensor();
+        // Turn the ImplicitRankFourTensorSlice in an actual Tensor.
+        auto singlet_B_iajb = singlet_B_slice.asTensor();
 
         // Finally, reshape the tensor to a matrix.
         const GQCP::MatrixX<Scalar> singlet_B_matrix = singlet_B_iajb.reshape(n_occ * n_virt, n_occ * n_virt);
@@ -487,7 +487,7 @@ public:
             }
         }
 
-        // Turn the ImplicitRankFourTensorSlice in an actual Tensor
+        // Turn the ImplicitRankFourTensorSlice in an actual Tensor.
         auto triplet_A_iajb = triplet_A_slice.asTensor();
 
         // Add the previously calculated F values on the correct positions.
@@ -538,7 +538,7 @@ public:
             }
         }
 
-        // Turn the ImplicitRankFourTensorSlice in an actual Tensor
+        // Turn the ImplicitRankFourTensorSlice in an actual Tensor.
         auto triplet_B_iajb = triplet_B_slice.asTensor();
 
         // Finally, reshape the tensor to a matrix.

--- a/gqcp/include/QCModel/HF/StabilityMatrices/CMakeLists.txt
+++ b/gqcp/include/QCModel/HF/StabilityMatrices/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(gqcp
     PRIVATE
         GHFStabilityMatrices.hpp
+        RHFStabilitymatrices.hpp
 )

--- a/gqcp/include/QCModel/HF/StabilityMatrices/GHFStabilityMatrices.hpp
+++ b/gqcp/include/QCModel/HF/StabilityMatrices/GHFStabilityMatrices.hpp
@@ -137,7 +137,7 @@ public:
      */
     const bool isInternallyStable(const double threshold = -1.0e-5) const {
 
-        // The first step is to calculate the correct stability matrix: This method checks the internal stability of a real valued wavefunction.
+        // The first step is to calculate the correct stability matrix: This method checks the internal stability of a real or complex valued wavefunction.
         const auto stability_matrix = this->internal();
 
         // Check whether or not the stability matrix is positive semi-definite. This indicates stability.
@@ -151,7 +151,7 @@ public:
     template <typename S = Scalar>
     enable_if_t<std::is_same<S, double>::value, bool> isExternallyStable(const double threshold = -1.0e-5) const {
 
-        // The first step is to calculate the correct stability matrix: This method checks the internal stability of a real valued wavefunction.
+        // The first step is to calculate the correct stability matrix: This method checks the external stability of a real valued wavefunction.
         const auto stability_matrix = this->external();
 
         // Check whether or not the stability matrix is positive semi-definite. This indicates stability.
@@ -199,7 +199,7 @@ public:
         if (this->isInternallyStable() == true) {
             std::cout << "The complex valued GHF wavefunction is internally stable." << std::endl;
         } else {
-            std::cout << "The real complex GHF wavefunction contains an internal instability." << std::endl;
+            std::cout << "The complex valued GHF wavefunction contains an internal instability." << std::endl;
         }
     }
 };

--- a/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
+++ b/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
@@ -242,8 +242,8 @@ public:
         std::vector<bool> stabilities;
 
         // Check both external stabilities and add the results to the vector.
-        stabilities.push_back(this->isComplexConjugateStable());
-        stabilities.push_back(this->isTripletStable()));
+        stabilities.push_back(this->isComplexConjugateStable(threshold));
+        stabilities.push_back(this->isTripletStable(threshold));
 
         return stabilities;
     }
@@ -254,7 +254,7 @@ public:
      */
     template <typename S = Scalar>
     enable_if_t<std::is_same<S, complex>::value, bool> isExternallyStable(const double threshold = -1.0e-5) const {
-        return this->isTripletStable();
+        return this->isTripletStable(threshold);
     }
 
 
@@ -281,14 +281,14 @@ public:
         const auto external_stabilities = this->isExternallyStable();
 
         // The real->complex external stability on vector position 0.
-        if (this->external_stabilities[0] == true) {
+        if (external_stabilities[0] == true) {
             std::cout << "The real valued RHF wavefunction is stable within the real RHF space." << std::endl;
         } else {
             std::cout << "The real valued RHF wavefunction contains a real->complex instability." << std::endl;
         }
 
         // The restricted->unrestricted external stability on vector position 1.
-        if (this->external_stabilities[1] == true) {
+        if (external_stabilities[1] == true) {
             std::cout << "The real valued RHF wavefunction is stable within the real RHF/UHF space." << std::endl;
         } else {
             std::cout << "The real valued RHF wavefunction contains a restricted->unrestricted instability." << std::endl;

--- a/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
+++ b/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
@@ -277,15 +277,18 @@ public:
             std::cout << "The real valued RHF wavefunction contains an internal instability." << std::endl;
         }
 
-        // Next check the real->complex external stability
-        if (this->isComplexConjugateStable() == true) {
+        // `isExternallyStable()` checks 2 possible external stabilities.
+        const auto external_stabilities = this->isExternallyStable();
+
+        // The real->complex external stability on vector position 0.
+        if (this->external_stabilities[0] == true) {
             std::cout << "The real valued RHF wavefunction is stable within the real RHF space." << std::endl;
         } else {
             std::cout << "The real valued RHF wavefunction contains a real->complex instability." << std::endl;
         }
 
-        // Finally check the restricted->unrestricted external stability
-        if (this->isComplexTripletStable() == true) {
+        // The restricted->unrestricted external stability on vector position 1.
+        if (this->external_stabilities[1] == true) {
             std::cout << "The real valued RHF wavefunction is stable within the real RHF/UHF space." << std::endl;
         } else {
             std::cout << "The real valued RHF wavefunction contains a restricted->unrestricted instability." << std::endl;

--- a/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
+++ b/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
@@ -231,21 +231,13 @@ public:
 
 
     /**
-     *  @return a vector containing 2 booleans.
-     * 
-     *  @note The first value will tell us whether or not the real->complex stability matrix belongs to a stable or unstable set of parameters. The second one does the same for the real valued restricted->unrestricted stability matrix.
+     *  @return whether the parameters are completely externally stable.
      */
     template <typename S = Scalar>
-    enable_if_t<std::is_same<S, double>::value, std::vector<bool>> isExternallyStable(const double threshold = -1.0e-5) const {
+    enable_if_t<std::is_same<S, double>::value, bool> isExternallyStable(const double threshold = -1.0e-5) const {
 
-        // Since we have to check 2 stabilities, we have to return 2 booleans. Hence why we create a vector.
-        std::vector<bool> stabilities;
-
-        // Check both external stabilities and add the results to the vector.
-        stabilities.push_back(this->isComplexConjugateStable(threshold));
-        stabilities.push_back(this->isTripletStable(threshold));
-
-        return stabilities;
+        // Return whether the parameters are completely externally stable.
+        return this->isComplexConjugateStable(threshold) && this->isTripletStable(threshold);
     }
 
 

--- a/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
+++ b/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
@@ -158,10 +158,10 @@ public:
 
 
     /**
-     *  @return the internal stability matrix of the complex RHF method.
+     *  @return the restricted->unrestricted external stability matrix of the complex RHF method.
      *
-     *  @note The internal stability condition of the real GHF method is checked using (triplet_A,   triplet_B  )
-     *                                                                                 (triplet_B^*, triplet_A^*)
+     *  @note The restricted->unrestricted external stability condition of the real GHF method is checked using (triplet_A,   triplet_B  )
+     *                                                                                                          (triplet_B^*, triplet_A^*)
      */
     template <typename S = Scalar>
     enable_if_t<std::is_same<S, complex>::value, MatrixX<complex>> restrictedUnrestricted() const {

--- a/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
+++ b/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
@@ -269,18 +269,15 @@ public:
             std::cout << "The real valued RHF wavefunction contains an internal instability." << std::endl;
         }
 
-        // `isExternallyStable()` checks 2 possible external stabilities.
-        const auto external_stabilities = this->isExternallyStable();
-
         // The real->complex external stability on vector position 0.
-        if (external_stabilities[0] == true) {
+        if (this->isComplexConjugateStable() == true) {
             std::cout << "The real valued RHF wavefunction is stable within the real/complex RHF space." << std::endl;
         } else {
             std::cout << "The real valued RHF wavefunction contains a real->complex instability." << std::endl;
         }
 
         // The restricted->unrestricted external stability on vector position 1.
-        if (external_stabilities[1] == true) {
+        if (this->isTripletStable() == true) {
             std::cout << "The real valued RHF wavefunction is stable within the real RHF/UHF space." << std::endl;
         } else {
             std::cout << "The real valued RHF wavefunction contains a restricted->unrestricted instability." << std::endl;

--- a/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
+++ b/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
@@ -1,0 +1,320 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+
+#include "Mathematical/Representation/Matrix.hpp"
+#include "Utilities/aliases.hpp"
+
+
+namespace GQCP {
+
+
+/**
+ *  The restricted Hartree-Fock stability matrices.
+ * 
+ *  @tparam _Scalar             The type of scalar that is used for the elements of the stability matrices: real or complex.
+ */
+template <typename _Scalar>
+class RHFStabilityMatrices {
+public:
+    // The type of scalar that is used for the elements of the stability matrices: real or complex.
+    using Scalar = _Scalar;
+
+    // The type of one of the components
+    using Matrix = MatrixX<Scalar>;
+
+private:
+    // The singlet A submatrix.
+    Matrix singlet_A;
+
+    // The singlet B submatrix.
+    Matrix singlet_B;
+
+    // The triplet A submatrix.
+    Matrix triplet_A;
+
+    // The triplet B submatrix.
+    Matrix triplet_B;
+
+public:
+    /*
+     *  MARK: Constructors
+     */
+
+    /*
+     *  Construct the object containing all building blocks for the RHF stability matrices.
+     * 
+     *  @param singlet_A        The singlet A submatrix.
+     *  @param singlet_B        The singlet B submatrix.
+     *  @param triplet_A        The triplet A submatrix.
+     *  @param triplet_B        The triplet B submatrix.
+     */
+    RHFStabilityMatrices(const Matrix& singlet_A, const Matrix& singlet_B, const Matrix& triplet_A, const Matrix& triplet_B) :
+        singlet_A {singlet_A},
+        singlet_B {singlet_B},
+        triplet_A {triplet_A},
+        triplet_B {triplet_B} {}
+
+public:
+    /*
+     *  MARK: Accessing the submatrices
+     */
+
+    /**
+     *  @return A read-only reference to the singlet A submatrix.
+     */
+    const Matrix& singletA() const { return this->singlet_A; }
+
+    /**
+     *  @return A read-only reference to the singlet B submatrix.
+     */
+    const Matrix& singletB() const { return this->singlet_B; }
+
+    /**
+     *  @return A read-only reference to the triplet A submatrix.
+     */
+    const Matrix& tripletA() const { return this->triplet_A; }
+
+    /**
+     *  @return A read-only reference to the triplet B submatrix.
+     */
+    const Matrix& tripletB() const { return this->triplet_B; }
+
+
+    /*
+     *  MARK: Constructing the stability matrices
+     */
+
+    /**
+     *  Construct the internal stability matrix of the real RHF method.
+     *
+     *  @note The internal stability condition of the real RHF method is checked using singlet_A + singlet_B.
+     */
+    template <typename S = Scalar>
+    enable_if_t<std::is_same<S, double>::value, MatrixX<double>> internal() const { return this->singletA() + this->singletB(); }
+
+
+    /**
+     *  Construct the real->complex external stability matrix of the real RHF method.
+     *
+     *  @note The real->complex external stability condition of the real RHF method is checked using singlet_A - singlet_B.
+     */
+    template <typename S = Scalar>
+    enable_if_t<std::is_same<S, double>::value, MatrixX<double>> realComplexExternal() const { return this->singletA() - this->singletB(); }
+
+
+    /**
+     *  Construct the restricted->unrestricted external stability matrix of the real RHF method.
+     *
+     *  @note The restricted->unrestricted external stability condition of the real RHF method is checked using triplet_A + triplet_B.
+     */
+    template <typename S = Scalar>
+    enable_if_t<std::is_same<S, double>::value, MatrixX<double>> restrictedUnrestrictedExternal() const { return this->tripletA() + this->tripletB(); }
+
+
+    /**
+     *  @return the internal stability matrix of the complex RHF method.
+     *
+     *  @note The internal stability condition of the real GHF method is checked using (singlet_A,   singlet_B  )
+     *                                                                                 (singlet_B^*, singlet_A^*)
+     */
+    template <typename S = Scalar>
+    enable_if_t<std::is_same<S, complex>::value, MatrixX<complex>> internal() const {
+
+        // Calculate the necessary partial stability matrices.
+        const auto singlet_A = this->singletA();
+        const auto singlet_B = this->singletB();
+
+        // Determine the dimensions of the total stability matrix.
+        const auto K = singlet_A.dimension(0);
+        const auto dim = 2 * K;
+
+        // Create the total stability matrix as specified above in the documentation.
+        Matrix singlet_H {dim, dim};
+
+        singlet_H.topLeftCorner(K, K) = singlet_A;
+        singlet_H.topRightCorner(K, K) = singlet_B;
+        singlet_H.bottomLeftCorner(K, K) = singlet_B.conjugate();
+        singlet_H.bottomRightCorner(K, K) = singlet_A.conjugate();
+
+        return singlet_H;
+    }
+
+
+    /**
+     *  @return the internal stability matrix of the complex RHF method.
+     *
+     *  @note The internal stability condition of the real GHF method is checked using (triplet_A,   triplet_B  )
+     *                                                                                 (triplet_B^*, triplet_A^*)
+     */
+    template <typename S = Scalar>
+    enable_if_t<std::is_same<S, complex>::value, MatrixX<complex>> restrictedUnrestrictedExternal() const {
+
+        // Calculate the necessary partial stability matrices.
+        const auto triplet_A = this->tripletA();
+        const auto triplet_B = this->tripletB();
+
+        // Determine the dimensions of the total stability matrix.
+        const auto K = triplet_A.dimension(0);
+        const auto dim = 2 * K;
+
+        // Create the total stability matrix as specified above in the documentation.
+        Matrix triplet_H {dim, dim};
+
+        triplet_H.topLeftCorner(K, K) = triplet_A;
+        triplet_H.topRightCorner(K, K) = triplet_B;
+        triplet_H.bottomLeftCorner(K, K) = triplet_B.conjugate();
+        triplet_H.bottomRightCorner(K, K) = triplet_A.conjugate();
+
+        return triplet_H;
+    }
+
+
+    /*
+     *  MARK: Checking the stability
+     */
+
+    /**
+     *  @return a boolean, telling us whether or not the real or complex valued internal stability matrix belongs to a stable or unstable set of parameters.
+     */
+    const bool isInternallyStable(const double threshold = -1.0e-5) const {
+
+        // The first step is to calculate the correct stability matrix: This method checks the internal stability of a real or complex valued wavefunction.
+        const auto stability_matrix = this->internal();
+
+        // Check whether or not the stability matrix is positive semi-definite. This indicates stability.
+        return stability_matrix.isPositiveSemiDefinite(threshold);
+    }
+
+
+    /**
+     *  @return a boolean, telling us whether or not the real or complex valued restricted->unrestricted stability matrix belongs to a stable or unstable set of parameters.
+     */
+    const bool isTripletStable(const double threshold = -1.0e-5) const {
+
+        // The first step is to calculate the correct stability matrix: This method checks the restricted->unrestricted stability of a real or complex valued wavefunction.
+        const auto stability_matrix = this->restrictedUnrestrictedExternal();
+
+        // Check whether or not the stability matrix is positive semi-definite. This indicates stability.
+        return stability_matrix.isPositiveSemiDefinite(threshold);
+    }
+
+
+    /**
+     *  @return a boolean, telling us whether or not the real->complex stability matrix belongs to a stable or unstable set of parameters.
+     */
+    template <typename S = Scalar>
+    enable_if_t<std::is_same<S, double>::value, bool> isComplexConjugateStable(const double threshold = -1.0e-5) const {
+
+        // The first step is to calculate the correct stability matrix: This method checks the real->complex stability of a real valued wavefunction.
+        const auto stability_matrix = this->restrictedUnrestrictedExternal();
+
+        // Check whether or not the stability matrix is positive semi-definite. This indicates stability.
+        return stability_matrix.isPositiveSemiDefinite(threshold);
+    }
+
+
+    /**
+     *  @return a vector containing 2 booleans.
+     * 
+     *  @note The first value will tell us whether or not the real->complex stability matrix belongs to a stable or unstable set of parameters. The second one does the same for the real valued restricted->unrestricted stability matrix.
+     */
+    template <typename S = Scalar>
+    enable_if_t<std::is_same<S, double>::value, std::vector<bool>> isExternallyStable(const double threshold = -1.0e-5) const {
+
+        // Since we have to check 2 stabilities, we have to return 2 booleans. Hence why we create a vector.
+        std::vector<bool> stabilities;
+
+        // Check both external stabilities and add the results to the vector.
+        stabilities.push_back(this->isComplexConjugateStable());
+        stabilities.push_back(this->isTripletStable()));
+
+        return stabilities;
+    }
+
+
+    /**
+     *  @return a boolean, telling us whether or not the complex valued external stability matrices belongs to a stable or unstable set of parameters.
+     */
+    template <typename S = Scalar>
+    enable_if_t<std::is_same<S, complex>::value, bool> isExternallyStable(const double threshold = -1.0e-5) const {
+        return this->isTripletStable();
+    }
+
+
+    /*
+     *  MARK: printing the stability properties of these stability matrices 
+     */
+
+    /*
+     *  Print the description of the stability properties of a real valued GHF wavefunction.
+     * 
+     *  @note   This method runs the stability calculation before printing the results.
+     */
+    template <typename S = Scalar>
+    enable_if_t<std::is_same<S, double>::value, void> printStabilityDescription() const {
+
+        // First check the internal stability
+        if (this->isInternallyStable() == true) {
+            std::cout << "The real valued RHF wavefunction is internally stable." << std::endl;
+        } else {
+            std::cout << "The real valued RHF wavefunction contains an internal instability." << std::endl;
+        }
+
+        // Next check the real->complex external stability
+        if (this->isComplexConjugateStable() == true) {
+            std::cout << "The real valued RHF wavefunction is stable within the real RHF space." << std::endl;
+        } else {
+            std::cout << "The real valued RHF wavefunction contains a real->complex instability." << std::endl;
+        }
+
+        // Finally check the restricted->unrestricted external stability
+        if (this->isComplexTripletStable() == true) {
+            std::cout << "The real valued RHF wavefunction is stable within the real RHF/UHF space." << std::endl;
+        } else {
+            std::cout << "The real valued RHF wavefunction contains a restricted->unrestricted instability." << std::endl;
+        }
+    }
+
+
+    /*
+     *  Print the description of the stability properties of a complex valued GHF wavefunction.
+     * 
+     *  @note   This method runs the stability calculation before printing the results.
+     */
+    template <typename S = Scalar>
+    enable_if_t<std::is_same<S, complex>::value, void> printStabilityDescription() const {
+
+        // First check the internal stability
+        if (this->isInternallyStable() == true) {
+            std::cout << "The complex valued RHF wavefunction is internally stable." << std::endl;
+        } else {
+            std::cout << "The complex valued RHF wavefunction contains an internal instability." << std::endl;
+        }
+
+        // First check the internal stability
+        if (this->isExternallyStable() == true) {
+            std::cout << "The complex valued RHF wavefunction is stable within the complex RHF/UHF space." << std::endl;
+        } else {
+            std::cout << "The complex valued RHF wavefunction contains a restricted->unrestricted instability." << std::endl;
+        }
+    }
+};
+
+}  // namespace GQCP

--- a/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
+++ b/gqcp/include/QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp
@@ -116,7 +116,7 @@ public:
      *  @note The real->complex external stability condition of the real RHF method is checked using singlet_A - singlet_B.
      */
     template <typename S = Scalar>
-    enable_if_t<std::is_same<S, double>::value, MatrixX<double>> realComplexExternal() const { return this->singletA() - this->singletB(); }
+    enable_if_t<std::is_same<S, double>::value, MatrixX<double>> realComplex() const { return this->singletA() - this->singletB(); }
 
 
     /**
@@ -125,7 +125,7 @@ public:
      *  @note The restricted->unrestricted external stability condition of the real RHF method is checked using triplet_A + triplet_B.
      */
     template <typename S = Scalar>
-    enable_if_t<std::is_same<S, double>::value, MatrixX<double>> restrictedUnrestrictedExternal() const { return this->tripletA() + this->tripletB(); }
+    enable_if_t<std::is_same<S, double>::value, MatrixX<double>> restrictedUnrestricted() const { return this->tripletA() + this->tripletB(); }
 
 
     /**
@@ -164,7 +164,7 @@ public:
      *                                                                                 (triplet_B^*, triplet_A^*)
      */
     template <typename S = Scalar>
-    enable_if_t<std::is_same<S, complex>::value, MatrixX<complex>> restrictedUnrestrictedExternal() const {
+    enable_if_t<std::is_same<S, complex>::value, MatrixX<complex>> restrictedUnrestricted() const {
 
         // Calculate the necessary partial stability matrices.
         const auto triplet_A = this->tripletA();
@@ -209,7 +209,7 @@ public:
     const bool isTripletStable(const double threshold = -1.0e-5) const {
 
         // The first step is to calculate the correct stability matrix: This method checks the restricted->unrestricted stability of a real or complex valued wavefunction.
-        const auto stability_matrix = this->restrictedUnrestrictedExternal();
+        const auto stability_matrix = this->restrictedUnrestricted();
 
         // Check whether or not the stability matrix is positive semi-definite. This indicates stability.
         return stability_matrix.isPositiveSemiDefinite(threshold);
@@ -223,7 +223,7 @@ public:
     enable_if_t<std::is_same<S, double>::value, bool> isComplexConjugateStable(const double threshold = -1.0e-5) const {
 
         // The first step is to calculate the correct stability matrix: This method checks the real->complex stability of a real valued wavefunction.
-        const auto stability_matrix = this->restrictedUnrestrictedExternal();
+        const auto stability_matrix = this->realComplex();
 
         // Check whether or not the stability matrix is positive semi-definite. This indicates stability.
         return stability_matrix.isPositiveSemiDefinite(threshold);
@@ -282,7 +282,7 @@ public:
 
         // The real->complex external stability on vector position 0.
         if (external_stabilities[0] == true) {
-            std::cout << "The real valued RHF wavefunction is stable within the real RHF space." << std::endl;
+            std::cout << "The real valued RHF wavefunction is stable within the real/complex RHF space." << std::endl;
         } else {
             std::cout << "The real valued RHF wavefunction contains a real->complex instability." << std::endl;
         }

--- a/gqcp/include/gqcp.hpp
+++ b/gqcp/include/gqcp.hpp
@@ -255,6 +255,7 @@
 #include "QCModel/HF/GHF.hpp"
 #include "QCModel/HF/RHF.hpp"
 #include "QCModel/HF/StabilityMatrices/GHFStabilityMatrix.hpp"
+#include "QCModel/HF/StabilityMatrices/RHFStabilityMatrix.hpp"
 #include "QCModel/HF/UHF.hpp"
 #include "QuantumChemical/DoublySpinResolvedBase.hpp"
 #include "QuantumChemical/Spin.hpp"

--- a/gqcp/tests/QCMethod/HF/GHF/QCMethod_GHF_stability_test.cpp
+++ b/gqcp/tests/QCMethod/HF/GHF/QCMethod_GHF_stability_test.cpp
@@ -121,20 +121,20 @@ BOOST_AUTO_TEST_CASE(H3_stability_test_2) {
  * 
  *  The system of interest is a H2-chain, 1 bohr apart and the reference implementation was done by @xdvriend.
  */
-BOOST_AUTO_TEST_CASE(H2_stability_test) {
+BOOST_AUTO_TEST_CASE(H3_stability_test_3) {
 
     // Set up a general spinor basis to obtain a spin-blocked second-quantized molecular Hamiltonian.
-    const auto molecule = GQCP::Molecule::HChain(2, 1.0);  // H2-Chain 1 bohr apart
+    const auto molecule = GQCP::Molecule::HRingFromDistance(3, 1.8897);  // H3-triangle, 1 angstrom apart
     const auto N = molecule.numberOfElectrons();
 
-    const GQCP::GSpinorBasis<double, GQCP::GTOShell> g_spinor_basis {molecule, "STO-3G"};
+    const GQCP::GSpinorBasis<double, GQCP::GTOShell> g_spinor_basis {molecule, "6-31G"};
     const auto S = g_spinor_basis.overlap().parameters();
 
     const auto sq_hamiltonian = GQCP::GSQHamiltonian<double>::Molecular(g_spinor_basis, molecule);
 
     // Perform a GHF SCF calculation
     auto environment = GQCP::GHFSCFEnvironment<double>::WithCoreGuess(N, sq_hamiltonian, S);
-    auto solver = GQCP::GHFSCFSolver<double>::Plain(1.0e-08, 3000);
+    auto solver = GQCP::GHFSCFSolver<double>::Plain(1.0e-05, 5000);
     const auto qc_structure = GQCP::QCMethod::GHF<double>().optimize(solver, environment);
     auto ghf_parameters = qc_structure.groundStateParameters();
 
@@ -144,11 +144,11 @@ BOOST_AUTO_TEST_CASE(H2_stability_test) {
 
     // This method should be internally stable.
     const auto internal_stability = stability_matrices.isInternallyStable();
-    BOOST_CHECK(internal_stability == true);
+    BOOST_CHECK(internal_stability == false);
 
     // This wavefunction should also be externally stable.
     const auto external_stability = stability_matrices.isExternallyStable();
-    BOOST_CHECK(external_stability == true);
+    BOOST_CHECK(external_stability == false);
 
     // Check that the stability properties can be printed
     stability_matrices.printStabilityDescription();

--- a/gqcp/tests/QCMethod/HF/GHF/QCMethod_GHF_stability_test.cpp
+++ b/gqcp/tests/QCMethod/HF/GHF/QCMethod_GHF_stability_test.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(H3_stability_test_1) {
 
     // This wavefunction should also be externally unstable.
     const auto external_stability = stability_matrices.isExternallyStable();
-    BOOST_CHECK(internal_stability == false);
+    BOOST_CHECK(external_stability == false);
 
     // Check that the stability properties can be printed
     stability_matrices.printStabilityDescription();
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(H3_stability_test_2) {
 
     // This wavefunction should also be externally stable.
     const auto external_stability = stability_matrices.isExternallyStable();
-    BOOST_CHECK(internal_stability == true);
+    BOOST_CHECK(external_stability == true);
 
     // Check that the stability properties can be printed
     stability_matrices.printStabilityDescription();
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(H2_stability_test) {
 
     // This wavefunction should also be externally stable.
     const auto external_stability = stability_matrices.isExternallyStable();
-    BOOST_CHECK(internal_stability == true);
+    BOOST_CHECK(external_stability == true);
 
     // Check that the stability properties can be printed
     stability_matrices.printStabilityDescription();

--- a/gqcp/tests/QCMethod/HF/RHF/CMakeLists.txt
+++ b/gqcp/tests/QCMethod/HF/RHF/CMakeLists.txt
@@ -1,4 +1,5 @@
 list(APPEND test_target_sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/QCMethod_RHF_stability_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/QCMethod_RHF_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RHFSCFEnvironment_test.cpp
 )

--- a/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_stability_test.cpp
+++ b/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_stability_test.cpp
@@ -53,8 +53,7 @@ BOOST_AUTO_TEST_CASE(h2o_sto3g_stability) {
 
     // This wavefunction should also be externally stable.
     const auto external_stability = stability_matrices.isExternallyStable();
-    BOOST_CHECK(external_stability[0] == true);
-    BOOST_CHECK(external_stability[1] == true);
+    BOOST_CHECK(external_stability == true);
 
     // Check that the stability properties can be printed
     stability_matrices.printStabilityDescription();
@@ -86,10 +85,13 @@ BOOST_AUTO_TEST_CASE(h4_sto3g_stability) {
     const auto internal_stability = stability_matrices.isInternallyStable();
     BOOST_CHECK(internal_stability == true);
 
-    // This wavefunction should also be externally stable.
+    // This wavefunction should be externally unstable.
     const auto external_stability = stability_matrices.isExternallyStable();
-    BOOST_CHECK(external_stability[0] == false);
-    BOOST_CHECK(external_stability[1] == false);
+    BOOST_CHECK(external_stability == false);
+
+    // Both external stability subcases are checked individually as well.
+    BOOST_CHECK(stability_matrices.isTripletStable() == false);
+    BOOST_CHECK(stability_matrices.isComplexConjugateStable() == false);
 
     // Check that the stability properties can be printed
     stability_matrices.printStabilityDescription();

--- a/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_stability_test.cpp
+++ b/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_stability_test.cpp
@@ -58,3 +58,37 @@ BOOST_AUTO_TEST_CASE(h2o_sto3g_stability) {
     // Check that the stability properties can be printed
     stability_matrices.printStabilityDescription();
 }
+
+/**
+ *  Check if our plain RHF SCF solver finds results (energy, orbital energies and coefficient matrix) that are equal to results from HORTON.
+ */
+BOOST_AUTO_TEST_CASE(h4_sto3g_stability) {
+
+    // Do our own RHF calculation
+    const auto molecule = GQCP::Molecule::HRingFromDistance(4, 1.0);  // H3-triangle, 1 bohr apart
+
+    const GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spinor_basis {molecule, "STO-3G"};
+    const auto sq_hamiltonian = GQCP::RSQHamiltonian<double>::Molecular(spinor_basis, molecule);  // in an AO basis
+    const GQCP::DiagonalRHFFockMatrixObjective<double> objective {sq_hamiltonian, 1.0e-05};
+
+    auto rhf_environment = GQCP::RHFSCFEnvironment<double>::WithCoreGuess(molecule.numberOfElectrons(), sq_hamiltonian, spinor_basis.overlap().parameters());
+    auto plain_rhf_scf_solver = GQCP::RHFSCFSolver<double>::Plain(1.0e-06, 1000);
+    const auto qc_structure = GQCP::QCMethod::RHF<double>().optimize(objective, plain_rhf_scf_solver, rhf_environment);
+    auto rhf_parameters = qc_structure.groundStateParameters();
+
+    // We can now check the stability of the ground state parameters.
+    // Calculate the stability matrices.
+    const auto stability_matrices = rhf_parameters.calculateStabilityMatrices(sq_hamiltonian);
+
+    // This method should be internally stable.
+    const auto internal_stability = stability_matrices.isInternallyStable();
+    BOOST_CHECK(internal_stability == true);
+
+    // This wavefunction should also be externally stable.
+    const auto external_stability = stability_matrices.isExternallyStable();
+    BOOST_CHECK(external_stability[0] == false);
+    BOOST_CHECK(external_stability[1] == false);
+
+    // Check that the stability properties can be printed
+    stability_matrices.printStabilityDescription();
+}

--- a/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_stability_test.cpp
+++ b/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_stability_test.cpp
@@ -1,0 +1,60 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#define BOOST_TEST_MODULE "QCMethod_RHF_stability_test"
+
+#include <boost/test/unit_test.hpp>
+
+#include "Operator/SecondQuantized/SQHamiltonian.hpp"
+#include "QCMethod/HF/RHF/DiagonalRHFFockMatrixObjective.hpp"
+#include "QCMethod/HF/RHF/RHF.hpp"
+#include "QCMethod/HF/RHF/RHFSCFSolver.hpp"
+#include "QCModel/HF/StabilityMatrices/RHFStabilityMatrices.hpp"
+
+
+/**
+ *  Check if our plain RHF SCF solver finds results (energy, orbital energies and coefficient matrix) that are equal to results from HORTON.
+ */
+BOOST_AUTO_TEST_CASE(h2o_sto3g_stability) {
+
+    // Do our own RHF calculation
+    const auto water = GQCP::Molecule::ReadXYZ("data/h2o.xyz");
+    const GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spinor_basis {water, "STO-3G"};
+    const auto sq_hamiltonian = GQCP::RSQHamiltonian<double>::Molecular(spinor_basis, water);  // in an AO basis
+    const GQCP::DiagonalRHFFockMatrixObjective<double> objective {sq_hamiltonian};
+
+    auto rhf_environment = GQCP::RHFSCFEnvironment<double>::WithCoreGuess(water.numberOfElectrons(), sq_hamiltonian, spinor_basis.overlap().parameters());
+    auto plain_rhf_scf_solver = GQCP::RHFSCFSolver<double>::Plain();
+    const auto qc_structure = GQCP::QCMethod::RHF<double>().optimize(objective, plain_rhf_scf_solver, rhf_environment);
+    auto rhf_parameters = qc_structure.groundStateParameters();
+
+    // We can now check the stability of the ground state parameters.
+    // Calculate the stability matrices.
+    const auto stability_matrices = rhf_parameters.calculateStabilityMatrices(sq_hamiltonian);
+
+    // This method should be internally stable.
+    const auto internal_stability = stability_matrices.isInternallyStable();
+    BOOST_CHECK(internal_stability == true);
+
+    // This wavefunction should also be externally stable.
+    const auto external_stability = stability_matrices.isExternallyStable();
+    BOOST_CHECK(external_stability[0] == true);
+    BOOST_CHECK(external_stability[1] == true);
+
+    // Check that the stability properties can be printed
+    stability_matrices.printStabilityDescription();
+}

--- a/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_stability_test.cpp
+++ b/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_stability_test.cpp
@@ -27,7 +27,8 @@
 
 
 /**
- *  Check if our plain RHF SCF solver finds results (energy, orbital energies and coefficient matrix) that are equal to results from HORTON.
+ *  The RHF solution of H_2O should be stable both internally and externally.
+ *  This test checks whether the RHF stability analysis confirms this.
  */
 BOOST_AUTO_TEST_CASE(h2o_sto3g_stability) {
 
@@ -60,7 +61,8 @@ BOOST_AUTO_TEST_CASE(h2o_sto3g_stability) {
 }
 
 /**
- *  Check if our plain RHF SCF solver finds results (energy, orbital energies and coefficient matrix) that are equal to results from HORTON.
+ *  The RHF solution of a equilateral H_4 ring is internally stable, but externally unstable. (As confirmed by the implementation of @xdvriend.)
+ *  This test checks whether the RHF stability analysis confirms this.
  */
 BOOST_AUTO_TEST_CASE(h4_sto3g_stability) {
 


### PR DESCRIPTION
**Short description**
This is the second PR that tackles the Hartree-Fock Stability checks. In this one, the restricted Hartree-Fock stability conditions are implemented. 

**Related issues**
- closes #788 

**Additional context**
As well as implementing the RHF stability conditions, this PR fixes some minor mistakes in the GHF stability analysis I encountered along the way.
**Don't forget:**

- [x] if new files are created: update the Doxygen file, the collective gqcp.hpp header and the CMake files
