### PR TITLE
Rename the FockOperatorEigenvalue API

### DIFF
--- a/gqcp/include/QCModel/HF/GHF.hpp
+++ b/gqcp/include/QCModel/HF/GHF.hpp
@@ -309,9 +309,9 @@ public:
 
 
     /**
-     *  @return the eigenvalues of the one-electron Fock Operator as a matrix.
+     *  @return a matrix containing all the possible excitation energies of the wavefunction model.
      */
-    GQCP::MatrixX<Scalar> calculateFockOperatorEigenvalues() const {
+    GQCP::MatrixX<Scalar> calculateExcitationEnergies() const {
 
         // Create the orbital space to determine the loops.
         const auto orbital_space = this->orbitalSpace();
@@ -369,8 +369,8 @@ public:
         const auto g = gsq_hamiltonian.twoElectron().transformed(this->coefficientMatrix()).antisymmetrized().parameters();
 
         // The elements F_BA and F_IJ are the eigenvalues of the one-electron Fock operator.
-        // The calculateFockOperatorEigenvalues API can be used to find these values
-        const auto F_values = this->calculateFockOperatorEigenvalues();
+        // The calculateExcitationEnergies API can be used to find these values
+        const auto F_values = this->calculateExcitationEnergies();
 
         // The next step is to create the needed tensor slice.
         // Zero-initialize an occupied-virtual-occupied-virtual object.

--- a/gqcp/include/QCModel/HF/GHF.hpp
+++ b/gqcp/include/QCModel/HF/GHF.hpp
@@ -309,9 +309,11 @@ public:
 
 
     /**
-     *  @return a matrix containing all the possible excitation energies of the wavefunction model.
+     *  @return a matrix containing all the possible excitation energies of the wavefunction model. 
+     * 
+     *  @note       The rows are determined by the number of virtual orbitals, the columns by the number of occupied orbitals.
      */
-    GQCP::MatrixX<Scalar> calculateExcitationEnergies() const {
+    GQCP::MatrixX<Scalar> excitationEnergies() const {
 
         // Create the orbital space to determine the loops.
         const auto orbital_space = this->orbitalSpace();
@@ -369,8 +371,8 @@ public:
         const auto g = gsq_hamiltonian.twoElectron().transformed(this->coefficientMatrix()).antisymmetrized().parameters();
 
         // The elements F_BA and F_IJ are the eigenvalues of the one-electron Fock operator.
-        // The calculateExcitationEnergies API can be used to find these values
-        const auto F_values = this->calculateExcitationEnergies();
+        // The excitationEnergies API can be used to find these values
+        const auto F_values = this->excitationEnergies();
 
         // The next step is to create the needed tensor slice.
         // Zero-initialize an occupied-virtual-occupied-virtual object.

--- a/gqcp/include/QCModel/HF/RHF.hpp
+++ b/gqcp/include/QCModel/HF/RHF.hpp
@@ -319,8 +319,10 @@ public:
 
     /**
      *  @return a matrix containing all the possible excitation energies of the wavefunction model.
+     * 
+     *  @note       The rows are determined by the number of virtual orbitals, the columns by the number of occupied orbitals.
      */
-    GQCP::MatrixX<Scalar> calculateExcitationEnergies() const {
+    GQCP::MatrixX<Scalar> excitationEnergies() const {
 
         // Create the orbital space to determine the loops.
         const auto orbital_space = this->orbitalSpace();
@@ -376,8 +378,8 @@ public:
         const auto g = rsq_hamiltonian.twoElectron().transformed(this->coefficientMatrix());
 
         // The elements (F_R)_AA and (F_R)_IJ are the eigenvalues of the one-electron Fock operator.
-        // The calculateExcitationEnergies API can be used to find these values
-        const auto F_values = this->calculateExcitationEnergies();
+        // The excitationEnergies API can be used to find these values
+        const auto F_values = this->excitationEnergies();
 
         // The next step is to create the needed tensor slice.
         // Zero-initialize an occupied-virtual-occupied-virtual object.
@@ -475,8 +477,8 @@ public:
         const auto g = rsq_hamiltonian.twoElectron().transformed(this->coefficientMatrix());
 
         // The elements (F_R)_AA and (F_R)_IJ are the eigenvalues of the one-electron Fock operator.
-        // The calculateExcitationEnergies API can be used to find these values
-        const auto F_values = this->calculateExcitationEnergies();
+        // The excitationEnergies API can be used to find these values
+        const auto F_values = this->excitationEnergies();
 
         // The next step is to create the needed tensor slice.
         // Zero-initialize an occupied-virtual-occupied-virtual object.

--- a/gqcp/include/QCModel/HF/RHF.hpp
+++ b/gqcp/include/QCModel/HF/RHF.hpp
@@ -318,9 +318,9 @@ public:
 
 
     /**
-     *  @return the eigenvalues of the one-electron Fock Operator as a matrix.
+     *  @return a matrix containing all the possible excitation energies of the wavefunction model.
      */
-    GQCP::MatrixX<Scalar> calculateFockOperatorEigenvalues() const {
+    GQCP::MatrixX<Scalar> calculateExcitationEnergies() const {
 
         // Create the orbital space to determine the loops.
         const auto orbital_space = this->orbitalSpace();
@@ -376,8 +376,8 @@ public:
         const auto g = rsq_hamiltonian.twoElectron().transformed(this->coefficientMatrix());
 
         // The elements (F_R)_AA and (F_R)_IJ are the eigenvalues of the one-electron Fock operator.
-        // The calculateFockOperatorEigenvalues API can be used to find these values
-        const auto F_values = this->calculateFockOperatorEigenvalues();
+        // The calculateExcitationEnergies API can be used to find these values
+        const auto F_values = this->calculateExcitationEnergies();
 
         // The next step is to create the needed tensor slice.
         // Zero-initialize an occupied-virtual-occupied-virtual object.
@@ -475,8 +475,8 @@ public:
         const auto g = rsq_hamiltonian.twoElectron().transformed(this->coefficientMatrix());
 
         // The elements (F_R)_AA and (F_R)_IJ are the eigenvalues of the one-electron Fock operator.
-        // The calculateFockOperatorEigenvalues API can be used to find these values
-        const auto F_values = this->calculateFockOperatorEigenvalues();
+        // The calculateExcitationEnergies API can be used to find these values
+        const auto F_values = this->calculateExcitationEnergies();
 
         // The next step is to create the needed tensor slice.
         // Zero-initialize an occupied-virtual-occupied-virtual object.


### PR DESCRIPTION
**Short description**
I renamed the API to show that it calculates all possible excitation energies and updated the documentation accordingly. 