### PR TITLE
Implement Python bindings for spin-redistributions on Hubbard.

### DIFF
--- a/gqcp/include/Operator/SecondQuantized/SQHamiltonian.hpp
+++ b/gqcp/include/Operator/SecondQuantized/SQHamiltonian.hpp
@@ -158,16 +158,16 @@ public:
      */
 
     /**
-     *  Create an `SQHamiltonian` from a `HubbardHamiltonian`.
+     *  Create an `RSQHamiltonian` from a `HubbardHamiltonian`.
      * 
      *  @param hubbard_hamiltonian              The Hubbard model Hamiltonian.
      *
-     *  @return An SQHamiltonian generated from the given Hubbard model Hamiltonian.
+     *  @return An `RSQHamiltonian` generated from the given Hubbard model Hamiltonian.
      *
      *  @note This named constructor is only available for real matrix representations.
      */
     template <typename Z1 = Scalar, typename Z2 = SpinorTag>
-    static enable_if_t<std::is_same<Z1, double>::value && std::is_same<Z2, RestrictedSpinorTag>::value, SQHamiltonian<ScalarSQOneElectronOperator, ScalarSQTwoElectronOperator>> FromHubbard(const GQCP::HubbardHamiltonian<double>& hubbard_hamiltonian) {
+    static enable_if_t<std::is_same<Z1, double>::value && std::is_same<Z2, RestrictedSpinorTag>::value, SQHamiltonian<ScalarSQOneElectronOperator, ScalarSQTwoElectronOperator>> FromHubbard(const HubbardHamiltonian<double>& hubbard_hamiltonian) {
 
         const auto h = hubbard_hamiltonian.core();
         const auto g = hubbard_hamiltonian.twoElectron();
@@ -176,7 +176,24 @@ public:
     }
 
 
-    // FIXME: These APIs should be moved to SpinorBasis.
+    /**
+     *  Create a `USQHamiltonian` from an `RSQHamiltonian`.
+     * 
+     *  @param r_hamiltonian            The Hamiltonian expressed in a restricted spin-orbital basis.
+     *
+     *  @return An `USQHamiltonian` generated from the given `RSQHamiltonian`.
+     */
+    template <typename Z = SpinorTag>
+    static enable_if_t<std::is_same<Z, UnrestrictedSpinorTag>::value, SQHamiltonian<ScalarSQOneElectronOperator, ScalarSQTwoElectronOperator>> FromRestricted(const SQHamiltonian<ScalarRSQOneElectronOperator<Scalar>, ScalarRSQTwoElectronOperator<Scalar>>& r_hamiltonian) {
+
+        const auto h_u = ScalarUSQOneElectronOperator<Scalar>::FromRestricted(r_hamiltonian.core());
+        const auto g_u = ScalarUSQTwoElectronOperator<Scalar>::FromRestricted(r_hamiltonian.twoElectron());
+
+        return Self {h_u, g_u};
+    }
+
+
+    // FIXME: The following APIs should be moved to SpinorBasis.
 
     /**
      *  Quantize the molecular Hamiltonian in a restricted spin-orbital basis.

--- a/gqcpy/include/interfaces.hpp
+++ b/gqcpy/include/interfaces.hpp
@@ -144,6 +144,8 @@ void bindSpinResolvedBaseInterface(Class& py_class) {
 
     py_class
 
+        .def(py::init<const ComponentType&, const ComponentType&>())
+
         .def_property(
             "alpha",
             [](const Type& spin_resolved_object) {

--- a/gqcpy/src/Operator/SecondQuantized/SQHamiltonian_bindings.cpp
+++ b/gqcpy/src/Operator/SecondQuantized/SQHamiltonian_bindings.cpp
@@ -144,7 +144,14 @@ void bindSQHamiltonians(py::module& module) {
 
     bindSQHamiltonian<RSQHamiltonian<complex>, RSpinOrbitalBasis<complex, GTOShell>>(module, "RSQHamiltonian_cd", "A (complex) second-quantized Hamiltonian expressed in a restricted spin-orbital basis.");
 
-    bindSQHamiltonian<USQHamiltonian<double>, USpinOrbitalBasis<double, GTOShell>>(module, "USQHamiltonian_d", "A (real) second-quantized Hamiltonian expressed in an unrestricted spin-orbital basis.");
+    auto py_USQHamiltonian_d = bindSQHamiltonian<USQHamiltonian<double>, USpinOrbitalBasis<double, GTOShell>>(module, "USQHamiltonian_d", "A (real) second-quantized Hamiltonian expressed in an unrestricted spin-orbital basis.");
+    py_USQHamiltonian_d
+        .def_static(
+            "FromRestricted",
+            [](const RSQHamiltonian<double>& r_hamiltonian) {
+                return USQHamiltonian<double>::FromRestricted(r_hamiltonian);
+            });
+
     bindSQHamiltonian<USQHamiltonian<complex>, USpinOrbitalBasis<complex, GTOShell>>(module, "USQHamiltonian_cd", "A (complex) second-quantized Hamiltonian expressed in an unrestricted spin-orbital basis.");
 
     bindSQHamiltonian<GSQHamiltonian<double>, GSpinorBasis<double, GTOShell>>(module, "GSQHamiltonian_d", "A (real) second-quantized Hamiltonian expressed in a generalized spinor basis.");

--- a/gqcpy/src/Operator/SecondQuantized/USQOneElectronOperator_bindings.cpp
+++ b/gqcpy/src/Operator/SecondQuantized/USQOneElectronOperator_bindings.cpp
@@ -39,12 +39,12 @@ using namespace GQCP;
 void bindUSQOneElectronOperator(py::module& module) {
 
     // Define the Python classes for `USQOneElectronOperator` and expose its APIs.
-    py::class_<ScalarUSQOneElectronOperator<double>> py_ScalarUSQOneElectronOperator_d {module, "USQOneElectronOperator_d", "A class that represents a (real) 'unrestricted second-quantized one-electron operator'. This type of operator is suitable for the projection of the non-relativistic Hamiltonian onto an unrestricted spinor basis. It holds the matrix representation of its parameters for both spin components."};
+    py::class_<ScalarUSQOneElectronOperator<double>> py_ScalarUSQOneElectronOperator_d {module, "ScalarUSQOneElectronOperator_d", "A class that represents a (real) 'unrestricted second-quantized one-electron operator'. This type of operator is suitable for the projection of the non-relativistic Hamiltonian onto an unrestricted spinor basis. It holds the matrix representation of its parameters for both spin components."};
 
     bindSpinResolvedBaseInterface(py_ScalarUSQOneElectronOperator_d);
     bindSQOneElectronOperatorInterface(py_ScalarUSQOneElectronOperator_d);
 
-    py::class_<ScalarUSQOneElectronOperator<complex>> py_ScalarUSQOneElectronOperator_cd {module, "USQOneElectronOperator_cd", "A class that represents a (complex) 'unrestricted second-quantized one-electron operator'. This type of operator is suitable for the projection of the non-relativistic Hamiltonian onto an unrestricted spinor basis. It holds the matrix representation of its parameters for both spin components."};
+    py::class_<ScalarUSQOneElectronOperator<complex>> py_ScalarUSQOneElectronOperator_cd {module, "ScalarUSQOneElectronOperator_cd", "A class that represents a (complex) 'unrestricted second-quantized one-electron operator'. This type of operator is suitable for the projection of the non-relativistic Hamiltonian onto an unrestricted spinor basis. It holds the matrix representation of its parameters for both spin components."};
 
     bindSpinResolvedBaseInterface(py_ScalarUSQOneElectronOperator_cd);
     bindSQOneElectronOperatorInterface(py_ScalarUSQOneElectronOperator_cd);

--- a/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
+++ b/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
@@ -219,6 +219,13 @@ void bindLinearExpansion<SpinResolvedONVBasis>(py::module& module, const std::st
         // PUBLIC METHODS
 
         .def(
+            "calculateShannonEntropy",
+            [](const LinearExpansion<SpinResolvedONVBasis>& linear_expansion) {
+                return linear_expansion.calculateShannonEntropy();
+            },
+            "Return the Shannon entropy (information content) of the wave function.")
+
+        .def(
             "calculate1DM",
             [](const LinearExpansion<SpinResolvedONVBasis>& linear_expansion) {
                 return linear_expansion.calculate1DM();


### PR DESCRIPTION
See #878.