### PR TITLE
[CMake] GQCP version refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,18 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(GQCP VERSION 0.0.1 LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)  # make CMake look into the ./cmake/ folder for configuration files
 
+# Add configuration file containing version of current library.
+configure_file(${CMAKE_SOURCE_DIR}/cmake/version.hpp.in version/version.hpp)
+# Compile the version as its own library where, if needed, other targets can be linked to.
+# Common practice: this to avoid unneccessary recompiling whenever version details change.
+add_library(gqcp_version INTERFACE)
+target_include_directories(gqcp_version 
+    INTERFACE 
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/version>
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/version>
+        $<INSTALL_INTERFACE:version>
+)
+
 
 # List the supported options
 option(BUILD_TESTS "Build the C++ library tests" OFF)
@@ -103,16 +115,21 @@ endif()
 include(GNUInstallDirs)
 
 install(
+    TARGETS gqcp_version
+    EXPORT gqcp-targets
+    PUBLIC_HEADER DESTINATION version
+)
+
+install(
     TARGETS gqcp
     EXPORT gqcp-targets
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include/gqcp
+    INCLUDES DESTINATION include/gqcp version
 )
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/gqcp/include/ DESTINATION include/gqcp)
-install(FILES ${CMAKE_BINARY_DIR}/gqcp/include/version.hpp DESTINATION include/gqcp)
 
 install(
     EXPORT gqcp-targets

--- a/cmake/version.hpp.in
+++ b/cmake/version.hpp.in
@@ -1,20 +1,20 @@
 // This file is part of GQCG-gqcp.
-// 
+//
 // Copyright (C) 2017-2019  the GQCG developers
-// 
+//
 // GQCG-gqcp is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // GQCG-gqcp is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Lesser General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Lesser General Public License
 // along with GQCG-gqcp.  If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 #pragma once
 
 
@@ -22,7 +22,7 @@
 #include <string>
 
 
-
+// clang-format off
 namespace ${PROJECT_NAME} {
 
 
@@ -31,13 +31,14 @@ namespace ${PROJECT_NAME} {
  */
 struct Version {
 public:
-    static constexpr size_t major = ${PROJECT_VERSION_MAJOR};
-    static constexpr size_t minor = ${PROJECT_VERSION_MINOR};
-    static constexpr size_t patch = ${PROJECT_VERSION_PATCH};
-    static constexpr auto full = "${PROJECT_VERSION}";
+    static constexpr size_t major = ${${PROJECT_NAME}_VERSION_MAJOR};
+    static constexpr size_t minor = ${${PROJECT_NAME}_VERSION_MINOR};
+    static constexpr size_t patch = ${${PROJECT_NAME}_VERSION_PATCH};
+    static constexpr auto full = "${${PROJECT_NAME}_VERSION}";
 
     static constexpr auto git_SHA1 = "${GIT_SHA1}";
 };
 
 
 }  // namespace ${PROJECT_NAME}
+// clang-format on

--- a/gqcp/CMakeLists.txt
+++ b/gqcp/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Entry point for the CMake configuration of the C++ library
 add_library(gqcp SHARED "")
 
+target_link_libraries(gqcp PUBLIC gqcp_version)
+
 target_compile_options(gqcp PUBLIC -m64 -pipe)
 target_compile_options(gqcp PUBLIC "$<IF:$<CONFIG:Debug>,-g,-O2>")
 target_compile_options(gqcp PUBLIC "$<$<CXX_COMPILER_ID:GNU>:-pthread>")
@@ -21,7 +23,6 @@ execute_process(
     ERROR_QUIET
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
-configure_file(${CMAKE_SOURCE_DIR}/cmake/version.hpp.in include/version.hpp)
 
 
 


### PR DESCRIPTION
**Short description**

I have provided some small corrections regarding the version of `GQCP`. See chapter 19 in [Professional CMake](https://crascit.com/professional-cmake/) for extra reading material on common practices regarding version details in projects.

**Related issues**

Link to the open (and possibly closed) issues that are related to this pull request. If this pull request fully closes an issue, please use GitHub's closing keywords. 

**To do**

- [x] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [x] Add other smaller task to be completed as a Markdown task list
