### PR TITLE
[CMake] Small adjustment for installation ofgqcp and  gqcp_version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ target_include_directories(gqcp_version
     INTERFACE 
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/version>
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/version>
-        $<INSTALL_INTERFACE:version>
 )
 
 
@@ -118,6 +117,7 @@ install(
     TARGETS gqcp_version
     EXPORT gqcp-targets
     PUBLIC_HEADER DESTINATION version
+    INCLUDES DESTINATION version
 )
 
 install(

--- a/gqcp/CMakeLists.txt
+++ b/gqcp/CMakeLists.txt
@@ -32,7 +32,6 @@ add_subdirectory(src)
 
 target_include_directories(gqcp
     PUBLIC
-        #$<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gqcp/include>
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/gqcp/include>
     PRIVATE

--- a/gqcp/CMakeLists.txt
+++ b/gqcp/CMakeLists.txt
@@ -32,7 +32,7 @@ add_subdirectory(src)
 
 target_include_directories(gqcp
     PUBLIC
-        $<INSTALL_INTERFACE:include>
+        #$<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gqcp/include>
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/gqcp/include>
     PRIVATE


### PR DESCRIPTION
**Short description**
It is a recommended practice to set the header search path during `install()` rather than using the `$<INSTALL_INTERFACE:...>` generator expression on the `gqcp_version` target itself. I have removed the redundant install generator expression in `gqcp` as well, since this header path file was already accounted for in the ìnstall()` command.

**To do**

- [x] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [x] Add other smaller task to be completed as a Markdown task list
