### PR TITLE
[CMake] Refactor gqcp_version to a static library instead of header-only.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,6 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/version.cpp.in version/version.cpp)
 # Compile the version as its own library where, if needed, other targets can be linked to.
 # Common practice: this to avoid unneccessary recompiling whenever version details change.
 add_library(gqcp_version STATIC ${CMAKE_CURRENT_BINARY_DIR}/version/version.cpp)
-target_include_directories(gqcp_version 
-    PUBLIC 
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/version>
-        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/version>
-)
 target_compile_features(gqcp_version PUBLIC cxx_std_14)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,11 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/version.cpp.in version/version.cpp)
 # Common practice: this to avoid unneccessary recompiling whenever version details change.
 add_library(gqcp_version STATIC ${CMAKE_CURRENT_BINARY_DIR}/version/version.cpp)
 target_compile_features(gqcp_version PUBLIC cxx_std_14)
-
+target_include_directories(gqcp_version
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/version>
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/version>
+)
 
 # List the supported options
 option(BUILD_TESTS "Build the C++ library tests" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,16 +10,20 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(GQCP VERSION 0.0.1 LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)  # make CMake look into the ./cmake/ folder for configuration files
 
+# Add the versioning as a separate library. Whenever the version changes, only the version.cpp source file will be recompiled 
+# and only gqcp needs to be relinked. This way, gqcp does not need to be recompiled if the version should be modified.
 # Add configuration file containing version of current library.
 configure_file(${CMAKE_SOURCE_DIR}/cmake/version.hpp.in version/version.hpp)
+configure_file(${CMAKE_SOURCE_DIR}/cmake/version.cpp.in version/version.cpp)
 # Compile the version as its own library where, if needed, other targets can be linked to.
 # Common practice: this to avoid unneccessary recompiling whenever version details change.
-add_library(gqcp_version INTERFACE)
+add_library(gqcp_version STATIC ${CMAKE_CURRENT_BINARY_DIR}/version/version.cpp)
 target_include_directories(gqcp_version 
-    INTERFACE 
+    PUBLIC 
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/version>
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/version>
 )
+target_compile_features(gqcp_version PUBLIC cxx_std_14)
 
 
 # List the supported options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ include(GNUInstallDirs)
 install(
     TARGETS gqcp_version
     EXPORT gqcp-targets
-    PUBLIC_HEADER DESTINATION include/version
+    ARCHIVE DESTINATION include/version
 )
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)  # make CMake look into
 # Add configuration file containing version of current library.
 configure_file(${CMAKE_SOURCE_DIR}/cmake/version.hpp.in version/version.hpp)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/version.cpp.in version/version.cpp)
-# Compile the version as its own library where, if needed, other targets can be linked to.
-# Common practice: this to avoid unneccessary recompiling whenever version details change.
+
 add_library(gqcp_version STATIC ${CMAKE_CURRENT_BINARY_DIR}/version/version.cpp)
 target_compile_features(gqcp_version PUBLIC cxx_std_14)
 target_include_directories(gqcp_version
@@ -25,7 +24,7 @@ target_include_directories(gqcp_version
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/version>
 )
 
-# List the supported options
+# List the supported optionsc
 option(BUILD_TESTS "Build the C++ library tests" OFF)
 option(BUILD_BENCHMARKS "Build the executables used for benchmarking the C++ library" OFF)
 option(BUILD_DOCS "Build the documentation of the C++ library using Doxygen" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(gqcp_version
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/version>
 )
 
-# List the supported optionsc
+# List the supported options.
 option(BUILD_TESTS "Build the C++ library tests" OFF)
 option(BUILD_BENCHMARKS "Build the executables used for benchmarking the C++ library" OFF)
 option(BUILD_DOCS "Build the documentation of the C++ library using Doxygen" OFF)

--- a/cmake/version.cpp.in
+++ b/cmake/version.cpp.in
@@ -1,0 +1,66 @@
+// This file is part of GQCG-gqcp.
+//
+// Copyright (C) 2017-2019  the GQCG developers
+//
+// GQCG-gqcp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-gqcp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-gqcp.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "version.hpp"
+
+
+// clang-format off
+namespace ${PROJECT_NAME} {
+
+
+/**
+*  @return The GQCP major version.
+*/
+size_t Version::major() {
+    return _major;
+}
+
+
+/**
+*  @return The GQCP minor version.
+*/
+size_t Version::minor() {
+    return _minor;
+}
+
+
+/**
+*  @return The GQCP patch version.
+*/
+size_t Version::patch() {
+    return _patch;
+}
+
+
+/**
+*  @return The full GQCP version.
+*/
+std::string Version::full() {
+    return _full;
+}
+
+
+/**
+*  @return The current GQCP commit SHA1.
+*/
+std::string Version::git_SHA1() {
+    return _git_SHA1;
+}
+
+} // namespace ${PROJECT_NAME}
+// clang-format on

--- a/cmake/version.cpp.in
+++ b/cmake/version.cpp.in
@@ -26,7 +26,7 @@ namespace ${PROJECT_NAME} {
 /**
 *  @return The GQCP major version.
 */
-size_t Version::major_version() {
+size_t Version::majorVersion() {
     return _major;
 }
 
@@ -34,7 +34,7 @@ size_t Version::major_version() {
 /**
 *  @return The GQCP minor version.
 */
-size_t Version::minor_version() {
+size_t Version::minorVersion() {
     return _minor;
 }
 
@@ -42,7 +42,7 @@ size_t Version::minor_version() {
 /**
 *  @return The GQCP patch version.
 */
-size_t Version::patch_version() {
+size_t Version::patchVersion() {
     return _patch;
 }
 
@@ -50,7 +50,7 @@ size_t Version::patch_version() {
 /**
 *  @return The full GQCP version.
 */
-std::string Version::full_version() {
+std::string Version::fullVersion() {
     return _full;
 }
 

--- a/cmake/version.cpp.in
+++ b/cmake/version.cpp.in
@@ -27,7 +27,7 @@ namespace ${PROJECT_NAME} {
 *  @return The GQCP major version.
 */
 size_t Version::majorVersion() {
-    return _major;
+    return major_version;
 }
 
 
@@ -35,7 +35,7 @@ size_t Version::majorVersion() {
 *  @return The GQCP minor version.
 */
 size_t Version::minorVersion() {
-    return _minor;
+    return minor_version;
 }
 
 
@@ -43,7 +43,7 @@ size_t Version::minorVersion() {
 *  @return The GQCP patch version.
 */
 size_t Version::patchVersion() {
-    return _patch;
+    return patch_version;
 }
 
 
@@ -51,15 +51,15 @@ size_t Version::patchVersion() {
 *  @return The full GQCP version.
 */
 std::string Version::fullVersion() {
-    return _full;
+    return full_version;
 }
 
 
 /**
 *  @return The current GQCP commit SHA1.
 */
-std::string Version::git_SHA1() {
-    return _git_SHA1;
+std::string Version::gitSHA1() {
+    return git_SHA1;
 }
 
 } // namespace ${PROJECT_NAME}

--- a/cmake/version.cpp.in
+++ b/cmake/version.cpp.in
@@ -26,7 +26,7 @@ namespace ${PROJECT_NAME} {
 /**
 *  @return The GQCP major version.
 */
-size_t Version::major() {
+size_t Version::major_version() {
     return _major;
 }
 
@@ -34,7 +34,7 @@ size_t Version::major() {
 /**
 *  @return The GQCP minor version.
 */
-size_t Version::minor() {
+size_t Version::minor_version() {
     return _minor;
 }
 
@@ -42,7 +42,7 @@ size_t Version::minor() {
 /**
 *  @return The GQCP patch version.
 */
-size_t Version::patch() {
+size_t Version::patch_version() {
     return _patch;
 }
 
@@ -50,7 +50,7 @@ size_t Version::patch() {
 /**
 *  @return The full GQCP version.
 */
-std::string Version::full() {
+std::string Version::full_version() {
     return _full;
 }
 

--- a/cmake/version.hpp.in
+++ b/cmake/version.hpp.in
@@ -27,16 +27,50 @@ namespace ${PROJECT_NAME} {
 
 
 /**
- *  A class that holds version-related info: the version numbers and the corresponding git SHA1
+ *  A class that holds version-related info: the version numbers and the corresponding git SHA1.
  */
 struct Version {
-public:
-    static constexpr size_t major = ${${PROJECT_NAME}_VERSION_MAJOR};
-    static constexpr size_t minor = ${${PROJECT_NAME}_VERSION_MINOR};
-    static constexpr size_t patch = ${${PROJECT_NAME}_VERSION_PATCH};
-    static constexpr auto full = "${${PROJECT_NAME}_VERSION}";
+private:
+    // The GQCP major version.
+    static constexpr size_t _major = ${${PROJECT_NAME}_VERSION_MAJOR};
 
-    static constexpr auto git_SHA1 = "${GIT_SHA1}";
+    // The GQCP minor version.
+    static constexpr size_t _minor = ${${PROJECT_NAME}_VERSION_MINOR};
+
+    // The GQCP patch version.
+    static constexpr size_t _patch = ${${PROJECT_NAME}_VERSION_PATCH};
+
+    // The full GQCP version.
+    static constexpr auto _full = "${${PROJECT_NAME}_VERSION}";
+
+    // The current GQCP commit SHA1.
+    static constexpr auto _git_SHA1 = "${GIT_SHA1}";
+
+public:
+    /**
+     *  @return The GQCP major version.
+     */
+    static size_t major();
+
+    /**
+     *  @return The GQCP minor version.
+     */
+    static size_t minor();
+
+    /**
+     *  @return The GQCP patch version.
+     */
+    static size_t patch();
+
+    /**
+     *  @return The full GQCP version.
+     */
+    static std::string full();
+
+    /**
+     *  @return The current GQCP commit SHA1.
+     */
+    static std::string git_SHA1();
 };
 
 

--- a/cmake/version.hpp.in
+++ b/cmake/version.hpp.in
@@ -50,22 +50,22 @@ public:
     /**
      *  @return The GQCP major version.
      */
-    static size_t major();
+    static size_t major_version();
 
     /**
      *  @return The GQCP minor version.
      */
-    static size_t minor();
+    static size_t minor_version();
 
     /**
      *  @return The GQCP patch version.
      */
-    static size_t patch();
+    static size_t patch_version();
 
     /**
      *  @return The full GQCP version.
      */
-    static std::string full();
+    static std::string full_version();
 
     /**
      *  @return The current GQCP commit SHA1.

--- a/cmake/version.hpp.in
+++ b/cmake/version.hpp.in
@@ -32,19 +32,19 @@ namespace ${PROJECT_NAME} {
 struct Version {
 private:
     // The GQCP major version.
-    static constexpr size_t _major = ${${PROJECT_NAME}_VERSION_MAJOR};
+    static constexpr size_t major_version = ${${PROJECT_NAME}_VERSION_MAJOR};
 
     // The GQCP minor version.
-    static constexpr size_t _minor = ${${PROJECT_NAME}_VERSION_MINOR};
+    static constexpr size_t minor_version = ${${PROJECT_NAME}_VERSION_MINOR};
 
     // The GQCP patch version.
-    static constexpr size_t _patch = ${${PROJECT_NAME}_VERSION_PATCH};
+    static constexpr size_t patch_version = ${${PROJECT_NAME}_VERSION_PATCH};
 
     // The full GQCP version.
-    static constexpr auto _full = "${${PROJECT_NAME}_VERSION}";
+    static constexpr auto full_version = "${${PROJECT_NAME}_VERSION}";
 
     // The current GQCP commit SHA1.
-    static constexpr auto _git_SHA1 = "${GIT_SHA1}";
+    static constexpr auto git_SHA1 = "${GIT_SHA1}";
 
 public:
     /**
@@ -70,7 +70,7 @@ public:
     /**
      *  @return The current GQCP commit SHA1.
      */
-    static std::string git_SHA1();
+    static std::string gitSHA1();
 };
 
 

--- a/cmake/version.hpp.in
+++ b/cmake/version.hpp.in
@@ -50,22 +50,22 @@ public:
     /**
      *  @return The GQCP major version.
      */
-    static size_t major_version();
+    static size_t majorVersion();
 
     /**
      *  @return The GQCP minor version.
      */
-    static size_t minor_version();
+    static size_t minorVersion();
 
     /**
      *  @return The GQCP patch version.
      */
-    static size_t patch_version();
+    static size_t patchVersion();
 
     /**
      *  @return The full GQCP version.
      */
-    static std::string full_version();
+    static std::string fullVersion();
 
     /**
      *  @return The current GQCP commit SHA1.

--- a/gqcpy/__init__.py.in
+++ b/gqcpy/__init__.py.in
@@ -2,5 +2,5 @@
 from.gqcpy import*
 
 #Print version - related information upon import
-print("gqcpy version {} @ {}".format(gqcpy.Version.fullVersion, gqcpy.Version.gitSHA1))
+print("gqcpy version {} @ {}".format(gqcpy.Version.fullVersion(), gqcpy.Version.gitSHA1()))
 // clang-format off

--- a/gqcpy/__init__.py.in
+++ b/gqcpy/__init__.py.in
@@ -1,4 +1,4 @@
-from.gqcpy import*
+from .gqcpy import *
 
-#Print version - related information upon import
+# Print version-related information upon import.
 print("gqcpy version {} @ {}".format(gqcpy.Version.fullVersion(), gqcpy.Version.gitSHA1()))

--- a/gqcpy/__init__.py.in
+++ b/gqcpy/__init__.py.in
@@ -1,6 +1,4 @@
-// clang-format off
 from.gqcpy import*
 
 #Print version - related information upon import
 print("gqcpy version {} @ {}".format(gqcpy.Version.fullVersion(), gqcpy.Version.gitSHA1()))
-// clang-format off

--- a/gqcpy/__init__.py.in
+++ b/gqcpy/__init__.py.in
@@ -1,5 +1,6 @@
-from .gqcpy import *
+// clang-format off
+from.gqcpy import*
 
-
-# Print version-related information upon import
-print("gqcpy version {} @ {}".format(gqcpy.Version.full, gqcpy.Version.git_sha1))
+#Print version - related information upon import
+print("gqcpy version {} @ {}".format(gqcpy.Version.fullVersion, gqcpy.Version.gitSHA1))
+// clang-format off

--- a/gqcpy/version.cpp
+++ b/gqcpy/version.cpp
@@ -21,28 +21,40 @@
 #include <pybind11/stl.h>
 
 
-namespace py = pybind11;
-
-
 namespace gqcpy {
+
+
+// Provide some shortcuts for frequent namespaces.
+namespace py = pybind11;
+using namespace GQCP;
 
 
 void bindVersion(py::module& module) {
     py::class_<GQCP::Version>(module, "Version", "Information on the GQCP version")
-        .def_property_readonly_static(
-            "major", [](py::object) { return GQCP::Version::major; }, "The GQCP major version")
+        .def(
+            "major",
+            &Version::major,
+            "The GQCP major version.")
 
-        .def_property_readonly_static(
-            "minor", [](py::object) { return GQCP::Version::minor; }, "The GQCP minor version")
+        .def(
+            "minor",
+            &Version::minor,
+            "The GQCP minor version.")
 
-        .def_property_readonly_static(
-            "patch", [](py::object) { return GQCP::Version::patch; }, "The GQCP patch version")
+        .def(
+            "patch",
+            &Version::patch,
+            "The GQCP patch version.")
 
-        .def_property_readonly_static(
-            "full", [](py::object) { return GQCP::Version::full; }, "The full GQCP version")
+        .def(
+            "full",
+            &Version::full,
+            "The full GQCP version.")
 
-        .def_property_readonly_static(
-            "git_sha1", [](py::object) { return GQCP::Version::git_SHA1; }, "The current GQCP commit SHA1");
+        .def(
+            "git_sha1",
+            &Version::git_SHA1,
+            "The current GQCP commit SHA1.");
 }
 
 

--- a/gqcpy/version.cpp
+++ b/gqcpy/version.cpp
@@ -32,27 +32,27 @@ using namespace GQCP;
 void bindVersion(py::module& module) {
     py::class_<GQCP::Version>(module, "Version", "Information on the GQCP version")
         .def(
-            "major",
-            &Version::major_version,
+            "majorVersion",
+            &Version::majorVersion,
             "The GQCP major version.")
 
         .def(
-            "minor",
-            &Version::minor_version,
+            "minorVersion",
+            &Version::minorVersion,
             "The GQCP minor version.")
 
         .def(
-            "patch",
-            &Version::patch_version,
+            "patchVersion",
+            &Version::patchVersion,
             "The GQCP patch version.")
 
         .def(
-            "full",
-            &Version::full_version,
+            "fullVersion",
+            &Version::fullVersion,
             "The full GQCP version.")
 
         .def(
-            "git_sha1",
+            "git_SHA1",
             &Version::git_SHA1,
             "The current GQCP commit SHA1.");
 }

--- a/gqcpy/version.cpp
+++ b/gqcpy/version.cpp
@@ -52,8 +52,8 @@ void bindVersion(py::module& module) {
             "The full GQCP version.")
 
         .def(
-            "git_SHA1",
-            &Version::git_SHA1,
+            "gitSHA1",
+            &Version::gitSHA1,
             "The current GQCP commit SHA1.");
 }
 

--- a/gqcpy/version.cpp
+++ b/gqcpy/version.cpp
@@ -33,22 +33,22 @@ void bindVersion(py::module& module) {
     py::class_<GQCP::Version>(module, "Version", "Information on the GQCP version")
         .def(
             "major",
-            &Version::major,
+            &Version::major_version,
             "The GQCP major version.")
 
         .def(
             "minor",
-            &Version::minor,
+            &Version::minor_version,
             "The GQCP minor version.")
 
         .def(
             "patch",
-            &Version::patch,
+            &Version::patch_version,
             "The GQCP patch version.")
 
         .def(
             "full",
-            &Version::full,
+            &Version::full_version,
             "The full GQCP version.")
 
         .def(


### PR DESCRIPTION
**Short description**

Add gqcp_version with compiled source file instead of header file. This way, `gqcp` (and `gqcpy`) does not need to be recompiled if the version should be modified.


**To do**

- [x] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [x] Add other smaller task to be completed as a Markdown task list
