### PR TITLE
Provide tutorial on calculating GTO overlap integrals

### DIFF
--- a/gqcp/include/Basis/Integrals/CMakeLists.txt
+++ b/gqcp/include/Basis/Integrals/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(gqcp
         BaseOneElectronIntegralEngine.hpp
         BaseTwoElectronIntegralBuffer.hpp
         BaseTwoElectronIntegralEngine.hpp
+        FunctionalPrimitiveEngine.hpp
         IntegralCalculator.hpp
         IntegralEngine.hpp
         McMurchieDavidsonCoefficient.hpp

--- a/gqcp/include/Basis/Integrals/FunctionalPrimitiveEngine.hpp
+++ b/gqcp/include/Basis/Integrals/FunctionalPrimitiveEngine.hpp
@@ -1,0 +1,84 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "Mathematical/Functions/CartesianGTO.hpp"
+
+#include <functional>
+
+
+namespace GQCP {
+
+
+/**
+ *  A custom primitive engine that can calculate one-electron integrals over Cartesian GTOs according to a custom implementation. It is limited to calculating integrals over scalar operators.
+ * 
+ *  @param _IntegralScalar          The scalar representation of one of the primitive integrals.
+ */
+template <typename _IntegralScalar>
+class FunctionalPrimitiveEngine {
+public:
+    // The scalar representation of one of the primitive integrals.
+    using IntegralScalar = _IntegralScalar;
+
+    // The number of components of the operator over which the primitive engine can calculate integrals.
+    static constexpr auto Components = 1;
+
+private:
+    // A user-supplied custom function that can calculate primitive integrals over two Cartesian GTOs.
+    std::function<IntegralScalar(const CartesianGTO&, const CartesianGTO&)> function;
+
+
+public:
+    /*
+     *  MARK: Constructors
+     */
+
+    /**
+     *  @param function             A user-supplied custom function that can calculate primitive integrals over two Cartesian GTOs.
+     */
+    FunctionalPrimitiveEngine(const std::function<IntegralScalar(const CartesianGTO&, const CartesianGTO&)>& function) :
+        function {function} {}
+
+
+    /*
+     *  MARK: Integral calculation
+     */
+
+    /**
+     *  Prepare this engine's internal state such that it is able to calculate integrals over the given component of the operator.
+     * 
+     *  @param component                The index of the component of the operator.
+     * 
+     *  @note Since this kind of primitive engine is limited to 1-component operators (i.e. scalar operators), this method has no effect.
+     */
+    void prepareStateForComponent(const size_t component) {}
+
+    /**
+     *  Calculate the primitive integral over two `CartesianGTO`s.
+     * 
+     *  @param left             The Cartesian GTO of the bra side.
+     *  @param right            The Cartesian GTO of the ket site.
+     * 
+     *  @return The value of the integral over the two given `CartesianGTO`s.
+     */
+    IntegralScalar calculate(const CartesianGTO& left, const CartesianGTO& right) const { return this->function(left, right); }
+};
+
+
+}  // namespace GQCP

--- a/gqcp/include/Basis/Integrals/McMurchieDavidsonCoefficient.hpp
+++ b/gqcp/include/Basis/Integrals/McMurchieDavidsonCoefficient.hpp
@@ -49,7 +49,7 @@ public:
 
     /**
      *  @param K                One of the Cartesian components of the center of the left Cartesian GTO.
-     *  @param a                The Gaussian exponent of the left Cartesian GTO
+     *  @param a                The Gaussian exponent of the left Cartesian GTO.
      *  @param L                One of the Cartesian components of the center of the right Cartesian GTO.
      *  @param b                The Gaussian exponent of the right Cartesian GTO.
      */

--- a/gqcp/include/Basis/Integrals/McMurchieDavidsonCoefficient.hpp
+++ b/gqcp/include/Basis/Integrals/McMurchieDavidsonCoefficient.hpp
@@ -29,58 +29,70 @@ namespace GQCP {
  */
 class McMurchieDavidsonCoefficient {
 private:
-    double K;  // one of the components of the center of the left Cartesian GTO
-    double L;  // one of the components of the center of the left Cartesian GTO
+    // One of the Cartesian components of the center of the left Cartesian GTO.
+    double K;
 
-    double alpha;  // the Gaussian exponent of the left Cartesian GTO
-    double beta;   // the Gaussian exponent of the right Cartesian GTO
+    // One of the Cartesian components of the center of the right Cartesian GTO.
+    double L;
+
+    // The Gaussian exponent of the left Cartesian GTO.
+    double a;
+
+    // The Gaussian exponent of the right Cartesian GTO.
+    double b;
 
 
 public:
-    // CONSTRUCTORS
-
-    /**
-     *  @param K                one of the components of the center of the left Cartesian GTO
-     *  @param alpha            the Gaussian exponent of the left Cartesian GTO
-     *  @param L                one of the components of the center of the left Cartesian GTO
-     *  @param beta             the Gaussian exponent of the right Cartesian GTO
+    /*
+     *  MARK: Constructors
      */
-    McMurchieDavidsonCoefficient(const double K, const double alpha, const double L, const double beta);
-
-
-    // OPERATORS
 
     /**
-     *  @param i            the Cartesian exponent of the left Cartesian GTO
-     *  @param j            the Cartesian exponent of the right Cartesian GTO
-     *  @param t            the degree of the Hermite Gaussian
+     *  @param K                One of the Cartesian components of the center of the left Cartesian GTO.
+     *  @param a                The Gaussian exponent of the left Cartesian GTO
+     *  @param L                One of the Cartesian components of the center of the right Cartesian GTO.
+     *  @param b                The Gaussian exponent of the right Cartesian GTO.
+     */
+    McMurchieDavidsonCoefficient(const double K, const double a, const double L, const double b);
+
+
+    /*
+     *  MARK: McMurchie-Davidson behavior
+     */
+
+    /**
+     *  @param i                The Cartesian exponent of the left Cartesian GTO.
+     *  @param j                The Cartesian exponent of the right Cartesian GTO.
+     *  @param t                The degree of the Hermite Gaussian.
      * 
-     *  @return the value for the McMurchie-Davidson expansion coefficient E^{i,j}_t
+     *  @return The value for the McMurchie-Davidson expansion coefficient E^{i,j}_t.
      */
     double operator()(const int i, const int j, const int t) const;
 
 
-    // PUBLIC METHODS
+    /*
+     *  MARK: Gaussian overlap behavior
+     */
 
     /**
-     *  @return the center of mass of the Gaussian overlap distribution
+     *  @return The center of mass of the Gaussian overlap distribution.
      */
     double centerOfMass() const;
 
     /**
-     *  @return (one component of) the distance vector between the left and right Cartesian Gaussian (left - right)
-     */
-    double distance() const { return this->K - this->L; }
-
-    /**
-     *  @return the reduced exponent of the Gaussian overlap distribution
+     *  @return The reduced exponent of the Gaussian overlap distribution.
      */
     double reducedExponent() const;
 
     /**
-     *  @return the total exponent of the Gaussian overlap distribution
+     *  @return The total exponent of the Gaussian overlap distribution.
      */
-    double totalExponent() const { return alpha + beta; }
+    double totalExponent() const { return a + b; }
+
+    /**
+     *  @return One component of the distance vector between the left and right Cartesian Gaussian (left - right).
+     */
+    double distance() const { return this->K - this->L; }
 };
 
 

--- a/gqcp/include/gqcp.hpp
+++ b/gqcp/include/gqcp.hpp
@@ -22,6 +22,7 @@
 #include "Basis/Integrals/BaseOneElectronIntegralEngine.hpp"
 #include "Basis/Integrals/BaseTwoElectronIntegralBuffer.hpp"
 #include "Basis/Integrals/BaseTwoElectronIntegralEngine.hpp"
+#include "Basis/Integrals/FunctionalPrimitiveEngine.hpp"
 #include "Basis/Integrals/IntegralCalculator.hpp"
 #include "Basis/Integrals/IntegralEngine.hpp"
 #include "Basis/Integrals/Interfaces/LibcintInterfacer.hpp"

--- a/gqcp/src/Basis/Integrals/McMurchieDavidsonCoefficient.cpp
+++ b/gqcp/src/Basis/Integrals/McMurchieDavidsonCoefficient.cpp
@@ -27,7 +27,7 @@ namespace GQCP {
 
 /**
  *  @param K                One of the Cartesian components of the center of the left Cartesian GTO.
- *  @param a                The Gaussian exponent of the left Cartesian GTO
+ *  @param a                The Gaussian exponent of the left Cartesian GTO.
  *  @param L                One of the Cartesian components of the center of the right Cartesian GTO.
  *  @param b                The Gaussian exponent of the right Cartesian GTO.
  */

--- a/gqcp/src/Basis/Integrals/McMurchieDavidsonCoefficient.cpp
+++ b/gqcp/src/Basis/Integrals/McMurchieDavidsonCoefficient.cpp
@@ -22,33 +22,32 @@ namespace GQCP {
 
 
 /*
- *  CONSTRUCTORS
+ *  MARK: Constructors
  */
 
 /**
- *  @param K                one of the components of the center of the left Cartesian GTO
- *  @param alpha            the Gaussian exponent of the left Cartesian GTO
- *  @param L                one of the components of the center of the left Cartesian GTO
- *  @param beta             the Gaussian exponent of the right Cartesian GTO
+ *  @param K                One of the Cartesian components of the center of the left Cartesian GTO.
+ *  @param a                The Gaussian exponent of the left Cartesian GTO
+ *  @param L                One of the Cartesian components of the center of the right Cartesian GTO.
+ *  @param b                The Gaussian exponent of the right Cartesian GTO.
  */
-McMurchieDavidsonCoefficient::McMurchieDavidsonCoefficient(const double K, const double alpha, const double L, const double beta) :
+McMurchieDavidsonCoefficient::McMurchieDavidsonCoefficient(const double K, const double a, const double L, const double b) :
     K {K},
     L {L},
-    alpha {alpha},
-    beta {beta} {}
+    a {a},
+    b {b} {}
 
 
 /*
- *  OPERATORS
+ *  MARK: McMurchie-Davidson behavior
  */
 
-
 /**
- *  @param i            the Cartesian exponent of the left Cartesian GTO
- *  @param j            the Cartesian exponent of the right Cartesian GTO
- *  @param t            the degree of the Hermite Gaussian
+ *  @param i                The Cartesian exponent of the left Cartesian GTO.
+ *  @param j                The Cartesian exponent of the right Cartesian GTO.
+ *  @param t                The degree of the Hermite Gaussian.
  * 
- *  @return the value for the McMurchie-Davidson expansion coefficient E^{i,j}_t
+ *  @return The value for the McMurchie-Davidson expansion coefficient E^{i,j}_t.
  */
 double McMurchieDavidsonCoefficient::operator()(const int i, const int j, const int t) const {
 
@@ -67,36 +66,36 @@ double McMurchieDavidsonCoefficient::operator()(const int i, const int j, const 
     else if (j == 0) {
         return 1.0 / (2 * this->totalExponent()) * this->operator()(i - 1, j, t - 1) +
                (t + 1) * this->operator()(i - 1, j, t + 1) -
-               this->beta / this->totalExponent() * this->distance() * this->operator()(i - 1, j, t);
+               this->b / this->totalExponent() * this->distance() * this->operator()(i - 1, j, t);
     }
 
-    else {  // do the recurrence for E^{i, j+1}_t
+    else {  // Do the recurrence for E^{i, j+1}_t.
         return 1.0 / (2 * this->totalExponent()) * this->operator()(i, j - 1, t - 1) +
                (t + 1) * this->operator()(i, j - 1, t + 1) +
-               this->alpha / this->totalExponent() * this->distance() * this->operator()(i, j - 1, t);
+               this->a / this->totalExponent() * this->distance() * this->operator()(i, j - 1, t);
     }
 }
 
 
 /*
- *  PUBLIC METHODS
+ *  MARK: Gaussian overlap behavior
  */
 
 /**
- *  @return the center of mass of the Gaussian overlap distribution
+ *  @return The center of mass of the Gaussian overlap distribution.
  */
 double McMurchieDavidsonCoefficient::centerOfMass() const {
 
-    return (this->alpha * this->K + this->beta * L) / this->totalExponent();
+    return (this->a * this->K + this->b * L) / this->totalExponent();
 }
 
 
 /**
- *  @return the reduced exponent of the Gaussian overlap distribution
+ *  @return The reduced exponent of the Gaussian overlap distribution.
  */
 double McMurchieDavidsonCoefficient::reducedExponent() const {
 
-    return (this->alpha * this->beta) / this->totalExponent();
+    return (this->a * this->b) / this->totalExponent();
 }
 
 

--- a/gqcpy/gqcpy.cpp
+++ b/gqcpy/gqcpy.cpp
@@ -27,7 +27,10 @@ namespace gqcpy {
 
 
 // Basis - Integrals
+void bindFunctionalPrimitiveEngine(py::module& module);
+void bindFunctionalOneElectronIntegralEngine(py::module& module);
 void bindMcMurchieDavidsonCoefficient(py::module& module);
+void bindIntegralEngine(py::module& module);
 
 
 // Basis - MullikenPartitioning
@@ -38,6 +41,8 @@ void bindUMullikenPartitioningComponent(py::module& module);
 
 // Basis - ScalarBasis
 void bindGTOShell(py::module& module);
+void bindScalarBasis(py::module& module);
+void bindShellSet(py::module& module);
 
 
 // Basis - SpinorBasis
@@ -72,6 +77,12 @@ void bindSpinResolved2DM(py::module& module);
 void bindAlgorithms(py::module& module);
 void bindFunctionalSteps(py::module& module);
 void bindIterativeAlgorithms(py::module& module);
+
+
+// Mathematical - Functions
+void bindCartesianDirection(py::module& module);
+void bindCartesianExponents(py::module& module);
+void bindCartesianGTO(py::module& module);
 
 
 // Mathematical - Grid
@@ -229,7 +240,10 @@ void bindVersion(py::module& module);
 PYBIND11_MODULE(gqcpy, module) {
 
     // Basis - Integrals
+    gqcpy::bindFunctionalPrimitiveEngine(module);
+    gqcpy::bindFunctionalOneElectronIntegralEngine(module);
     gqcpy::bindMcMurchieDavidsonCoefficient(module);
+    gqcpy::bindIntegralEngine(module);
 
 
     // Basis - MullikenPartitioning
@@ -240,6 +254,8 @@ PYBIND11_MODULE(gqcpy, module) {
 
     // Basis - ScalarBasis
     gqcpy::bindGTOShell(module);
+    gqcpy::bindScalarBasis(module);
+    gqcpy::bindShellSet(module);
 
 
     // Basis - SpinorBasis
@@ -274,6 +290,12 @@ PYBIND11_MODULE(gqcpy, module) {
     gqcpy::bindAlgorithms(module);
     gqcpy::bindFunctionalSteps(module);
     gqcpy::bindIterativeAlgorithms(module);
+
+
+    // Mathematical - Functions
+    gqcpy::bindCartesianDirection(module);
+    gqcpy::bindCartesianExponents(module);
+    gqcpy::bindCartesianGTO(module);
 
 
     // Mathematical - Grid

--- a/gqcpy/gqcpy.cpp
+++ b/gqcpy/gqcpy.cpp
@@ -26,6 +26,10 @@ namespace py = pybind11;
 namespace gqcpy {
 
 
+// Basis - Integrals
+void bindMcMurchieDavidsonCoefficient(py::module& module);
+
+
 // Basis - MullikenPartitioning
 void bindRMullikenPartitioning(py::module& module);
 void bindUMullikenPartitioning(py::module& module);
@@ -223,6 +227,10 @@ void bindVersion(py::module& module);
  *  The actual Python binding into the gqcpy Python module.
  */
 PYBIND11_MODULE(gqcpy, module) {
+
+    // Basis - Integrals
+    gqcpy::bindMcMurchieDavidsonCoefficient(module);
+
 
     // Basis - MullikenPartitioning
     gqcpy::bindRMullikenPartitioning(module);

--- a/gqcpy/src/Basis/CMakeLists.txt
+++ b/gqcpy/src/Basis/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(Integrals)
 add_subdirectory(MullikenPartitioning)
 add_subdirectory(ScalarBasis)
 add_subdirectory(SpinorBasis)

--- a/gqcpy/src/Basis/Integrals/CMakeLists.txt
+++ b/gqcpy/src/Basis/Integrals/CMakeLists.txt
@@ -1,0 +1,5 @@
+list(APPEND python_bindings_sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/McMurchieDavidsonCoefficient_bindings.cpp
+)
+
+set(python_bindings_sources ${python_bindings_sources} PARENT_SCOPE)

--- a/gqcpy/src/Basis/Integrals/CMakeLists.txt
+++ b/gqcpy/src/Basis/Integrals/CMakeLists.txt
@@ -1,5 +1,8 @@
 list(APPEND python_bindings_sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/FunctionalPrimitiveEngine_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/IntegralCalculator_bindings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/McMurchieDavidsonCoefficient_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/OneElectronIntegralEngine_bindings.cpp
 )
 
 set(python_bindings_sources ${python_bindings_sources} PARENT_SCOPE)

--- a/gqcpy/src/Basis/Integrals/FunctionalPrimitiveEngine_bindings.cpp
+++ b/gqcpy/src/Basis/Integrals/FunctionalPrimitiveEngine_bindings.cpp
@@ -1,0 +1,59 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Basis/Integrals/FunctionalPrimitiveEngine.hpp"
+#include "Utilities/aliases.hpp"
+#include "gqcpy/include/interfaces.hpp"
+
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+
+
+namespace gqcpy {
+
+
+// Provide some shortcuts for frequent namespaces.
+namespace py = pybind11;
+using namespace GQCP;
+
+
+/**
+ *  Register `FunctionalPrimitiveEngine_d` and `FunctionalPrimitiveEngine_cd` to the gqcpy module and expose a part of their C++ interface to Python.
+ * 
+ *  @param module           The Pybind11 module in which `FunctionalPrimitiveEngine_d` and `FunctionalPrimitiveEngine_cd` should be registered.
+ */
+void bindFunctionalPrimitiveEngine(py::module& module) {
+
+    // Define the Python class for `FunctionalPrimitiveEngine_d`.
+    py::class_<FunctionalPrimitiveEngine<double>> py_FunctionalPrimitiveEngine_d {module, "FunctionalPrimitiveEngine_d", "A custom primitive engine that can real-valued calculate one-electron integrals over Cartesian GTOs according to a custom implementation."};
+
+    py_FunctionalPrimitiveEngine_d
+        .def(py::init<const std::function<double(const CartesianGTO&, const CartesianGTO&)>&>(),
+             py::arg("function"));
+
+
+    // Define the Python class for `FunctionalPrimitiveEngine_cd`.
+    py::class_<FunctionalPrimitiveEngine<complex>>
+        py_FunctionalPrimitiveEngine_cd {module, "FunctionalPrimitiveEngine_cd", "A custom primitive engine that can calculate complex-valued one-electron integrals over Cartesian GTOs according to a custom implementation.."};
+
+    py_FunctionalPrimitiveEngine_cd
+        .def(py::init<const std::function<complex(const CartesianGTO&, const CartesianGTO&)>&>(),
+             py::arg("function"));
+}
+
+
+}  // namespace gqcpy

--- a/gqcpy/src/Basis/Integrals/IntegralCalculator_bindings.cpp
+++ b/gqcpy/src/Basis/Integrals/IntegralCalculator_bindings.cpp
@@ -1,0 +1,54 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Basis/Integrals/FunctionalPrimitiveEngine.hpp"
+#include "Basis/Integrals/IntegralCalculator.hpp"
+#include "Basis/ScalarBasis/GTOShell.hpp"
+#include "Basis/ScalarBasis/ShellSet.hpp"
+#include "Utilities/aliases.hpp"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+
+namespace gqcpy {
+
+
+// Provide some shortcuts for frequent namespaces.
+namespace py = pybind11;
+using namespace GQCP;
+
+
+/**
+ *  Register `IntegralCalculator.calculate` to the gqcpy module.
+ * 
+ *  @param module           The Pybind11 module in which `IntegralCalculator.calculate` should be registered.
+ */
+void bindIntegralEngine(py::module& module) {
+
+    auto py_module_IntegralCalculator = module.def_submodule("IntegralCalculator");
+
+    py_module_IntegralCalculator.def(
+        "calculate",
+        [](OneElectronIntegralEngine<FunctionalPrimitiveEngine<double>>& engine, const ShellSet<GTOShell>& left_shell_set, const ShellSet<GTOShell>& right_shell_set) {
+            return IntegralCalculator::calculate(engine, left_shell_set, right_shell_set)[0];
+        },
+        "Calculate all one-electron integrals over the basis functions inside the given shell sets.");
+}
+
+
+}  // namespace gqcpy

--- a/gqcpy/src/Basis/Integrals/McMurchieDavidsonCoefficient_bindings.cpp
+++ b/gqcpy/src/Basis/Integrals/McMurchieDavidsonCoefficient_bindings.cpp
@@ -1,0 +1,56 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Basis/Integrals/McMurchieDavidsonCoefficient.hpp"
+
+#include <pybind11/pybind11.h>
+
+
+namespace gqcpy {
+
+
+// Provide some shortcuts for frequent namespaces.
+namespace py = pybind11;
+using namespace GQCP;
+
+
+/**
+ *  Register `McMurchieDavidsonCoefficient` to the gqcpy module and expose a part of its C++ interface to Python.
+ * 
+ *  @param module           The Pybind11 module in which `McMurchieDavidsonCoefficient` should be registered.
+ */
+void bindMcMurchieDavidsonCoefficient(py::module& module) {
+
+    // Define the Python class for `GTransformation_d`.
+    py::class_<McMurchieDavidsonCoefficient<double>> py_McMurchieDavidsonCoefficient {module, "McMurchieDavidsonCoefficient", "An implementation of the McMurchie-Davidson expansion coefficients through recurrence relations."};
+
+    py_McMurchieDavidsonCoefficient
+        .def(py::init<const double, const double, const double, const double>(),
+             py::arg("K"),
+             py::arg("a"),
+             py::arg("L"),
+             py::arg("b"))
+
+        .def("__call__",
+             py::arg("i"),
+             py::arg("j"),
+             py::arg("t"),
+             "Return the value for the McMurchie-Davidson expansion coefficient E^{i,j}_t.");
+}
+
+
+}  // namespace gqcpy

--- a/gqcpy/src/Basis/Integrals/McMurchieDavidsonCoefficient_bindings.cpp
+++ b/gqcpy/src/Basis/Integrals/McMurchieDavidsonCoefficient_bindings.cpp
@@ -36,7 +36,7 @@ using namespace GQCP;
 void bindMcMurchieDavidsonCoefficient(py::module& module) {
 
     // Define the Python class for `GTransformation_d`.
-    py::class_<McMurchieDavidsonCoefficient<double>> py_McMurchieDavidsonCoefficient {module, "McMurchieDavidsonCoefficient", "An implementation of the McMurchie-Davidson expansion coefficients through recurrence relations."};
+    py::class_<McMurchieDavidsonCoefficient> py_McMurchieDavidsonCoefficient {module, "McMurchieDavidsonCoefficient", "An implementation of the McMurchie-Davidson expansion coefficients through recurrence relations."};
 
     py_McMurchieDavidsonCoefficient
         .def(py::init<const double, const double, const double, const double>(),
@@ -46,6 +46,7 @@ void bindMcMurchieDavidsonCoefficient(py::module& module) {
              py::arg("b"))
 
         .def("__call__",
+             &McMurchieDavidsonCoefficient::operator(),
              py::arg("i"),
              py::arg("j"),
              py::arg("t"),

--- a/gqcpy/src/Basis/Integrals/OneElectronIntegralEngine_bindings.cpp
+++ b/gqcpy/src/Basis/Integrals/OneElectronIntegralEngine_bindings.cpp
@@ -1,0 +1,57 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Basis/Integrals/FunctionalPrimitiveEngine.hpp"
+#include "Basis/Integrals/OneElectronIntegralEngine.hpp"
+#include "Utilities/aliases.hpp"
+
+#include <pybind11/pybind11.h>
+
+
+namespace gqcpy {
+
+
+// Provide some shortcuts for frequent namespaces.
+namespace py = pybind11;
+using namespace GQCP;
+
+
+/**
+ *  Register `FunctionalOneElectronIntegralEngine_d` and `FunctionalOneElectronIntegralEngine_cd` to the gqcpy module and expose a part of their C++ interface to Python.
+ * 
+ *  @param module           The Pybind11 module in which `FunctionalOneElectronIntegralEngine_d` and `FunctionalOneElectronIntegralEngine_cd` should be registered.
+ */
+void bindFunctionalOneElectronIntegralEngine(py::module& module) {
+
+    // Define the Python class for `FunctionalOneElectronIntegralEngine_d`.
+    py::class_<OneElectronIntegralEngine<FunctionalPrimitiveEngine<double>>> py_FunctionalOneElectronIntegralEngine_d {module, "FunctionalOneElectronIntegralEngine_d", "A custom one-electron integral engine that can calculate real-valued calculate one-electron integrals over Cartesian GTO shells according to a custom implementation."};
+
+    py_FunctionalOneElectronIntegralEngine_d
+        .def(py::init<const FunctionalPrimitiveEngine<double>&>(),
+             py::arg("primitive_engine"));
+
+
+    // Define the Python class for `FunctionalOneElectronIntegralEngine_cd`.
+    py::class_<OneElectronIntegralEngine<FunctionalPrimitiveEngine<complex>>> py_FunctionalOneElectronIntegralEngine_cd {module, "FunctionalOneElectronIntegralEngine_cd", "A custom one-electron integral engine that can calculate complex-valued calculate one-electron integrals over Cartesian GTO shells according to a custom implementation."};
+
+    py_FunctionalOneElectronIntegralEngine_cd
+        .def(py::init<const FunctionalPrimitiveEngine<complex>&>(),
+             py::arg("primitive_engine"));
+}
+
+
+}  // namespace gqcpy

--- a/gqcpy/src/Basis/ScalarBasis/CMakeLists.txt
+++ b/gqcpy/src/Basis/ScalarBasis/CMakeLists.txt
@@ -1,5 +1,7 @@
 list(APPEND python_bindings_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/GTOShell_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ScalarBasis_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ShellSet_bindings.cpp
 )
 
 set(python_bindings_sources ${python_bindings_sources} PARENT_SCOPE)

--- a/gqcpy/src/Basis/ScalarBasis/ScalarBasis_bindings.cpp
+++ b/gqcpy/src/Basis/ScalarBasis/ScalarBasis_bindings.cpp
@@ -1,0 +1,46 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Basis/ScalarBasis/GTOShell.hpp"
+#include "Basis/ScalarBasis/ScalarBasis.hpp"
+
+#include <pybind11/pybind11.h>
+
+
+namespace gqcpy {
+
+
+// Provide some shortcuts for frequent namespaces.
+namespace py = pybind11;
+using namespace GQCP;
+
+
+/**
+ *  Register `ScalarBasis` to the gqcpy module and expose a part of its C++ interface to Python.
+ * 
+ *  @param module           The Pybind11 module in which `ScalarBasis` should be registered.
+ */
+void bindScalarBasis(py::module& module) {
+    py::class_<ScalarBasis<GTOShell>>(module, "ScalarBasis", "A class that represents a scalar basis: it represents a collection of scalar basis functions.")
+
+        .def("shellSet",
+             &ScalarBasis<GTOShell>::shellSet,
+             "The collection of shells that represents this scalar basis.");
+}
+
+
+}  // namespace gqcpy

--- a/gqcpy/src/Basis/ScalarBasis/ShellSet_bindings.cpp
+++ b/gqcpy/src/Basis/ScalarBasis/ShellSet_bindings.cpp
@@ -1,0 +1,42 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Basis/ScalarBasis/GTOShell.hpp"
+#include "Basis/ScalarBasis/ShellSet.hpp"
+
+#include <pybind11/pybind11.h>
+
+
+namespace gqcpy {
+
+
+// Provide some shortcuts for frequent namespaces.
+namespace py = pybind11;
+using namespace GQCP;
+
+
+/**
+ *  Register `ShellSet` to the gqcpy module and expose a part of its C++ interface to Python.
+ * 
+ *  @param module           The Pybind11 module in which `ShellSet` should be registered.
+ */
+void bindShellSet(py::module& module) {
+    py::class_<ShellSet<GTOShell>>(module, "ShellSet", "A class that represents a set of GTO shells.");
+}
+
+
+}  // namespace gqcpy

--- a/gqcpy/src/Basis/SpinorBasis/RSpinOrbitalBasis_bindings.cpp
+++ b/gqcpy/src/Basis/SpinorBasis/RSpinOrbitalBasis_bindings.cpp
@@ -70,10 +70,17 @@ void bindRSpinOrbitalBasisInterface(Class& py_class) {
     py_class
         .def(
             "numberOfSpatialOrbitals",
-            [](RSpinOrbitalBasis<Scalar, GTOShell>& spin_orbital_basis) {
+            [](const RSpinOrbitalBasis<Scalar, GTOShell>& spin_orbital_basis) {
                 return spin_orbital_basis.numberOfSpatialOrbitals();
             },
-            "Return the number of different spatial orbitals that are used in this spinor basis.");
+            "Return the number of different spatial orbitals that are used in this spinor basis.")
+            
+            
+        .def("scalarBasis",
+            [](const RSpinOrbitalBasis<Scalar, GTOShell>& spin_orbital_basis) {
+                return spin_orbital_basis.scalarBasis();
+            },
+            "Return the underlying scalar basis with respect to which the basis coefficients are expressed.");
 
 
     /*

--- a/gqcpy/src/Mathematical/CMakeLists.txt
+++ b/gqcpy/src/Mathematical/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(Algorithm)
 add_subdirectory(Grid)
+add_subdirectory(Functions)
 add_subdirectory(Optimization)
 
 set(python_bindings_sources ${python_bindings_sources} PARENT_SCOPE)

--- a/gqcpy/src/Mathematical/Functions/CMakeLists.txt
+++ b/gqcpy/src/Mathematical/Functions/CMakeLists.txt
@@ -1,0 +1,7 @@
+list(APPEND python_bindings_sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/CartesianDirection_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CartesianExponents_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CartesianGTO_bindings.cpp
+)
+
+set(python_bindings_sources ${python_bindings_sources} PARENT_SCOPE)

--- a/gqcpy/src/Mathematical/Functions/CartesianDirection_bindings.cpp
+++ b/gqcpy/src/Mathematical/Functions/CartesianDirection_bindings.cpp
@@ -1,0 +1,49 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Mathematical/Functions/CartesianDirection.hpp"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+
+namespace gqcpy {
+
+
+// Provide some shortcuts for frequent namespaces.
+namespace py = pybind11;
+using namespace GQCP;
+
+
+/**
+ *  Register `CartesianDirection` to the gqcpy module and expose a part of its C++ interface to Python.
+ * 
+ *  @param module           The Pybind11 module in which `CartesianDirection` should be registered.
+ */
+void bindCartesianDirection(py::module& module) {
+
+    // Define the Python enum for `CartesianDirection`.
+    py::enum_<CartesianDirection>(module, "CartesianDirection")
+
+        .value("x", CartesianDirection::x)
+        .value("y", CartesianDirection::y)
+        .value("z", CartesianDirection::z)
+        .export_values();
+}
+
+
+}  // namespace gqcpy

--- a/gqcpy/src/Mathematical/Functions/CartesianExponents_bindings.cpp
+++ b/gqcpy/src/Mathematical/Functions/CartesianExponents_bindings.cpp
@@ -43,7 +43,7 @@ void bindCartesianExponents(py::module& module) {
         .def("value",
              &CartesianExponents::value,
              py::arg("direction"),
-             "Return the exponent in the given direction");
+             "Return the exponent in the given direction.");
 }
 
 

--- a/gqcpy/src/Mathematical/Functions/CartesianExponents_bindings.cpp
+++ b/gqcpy/src/Mathematical/Functions/CartesianExponents_bindings.cpp
@@ -1,0 +1,50 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Mathematical/Functions/CartesianExponents.hpp"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+
+namespace gqcpy {
+
+
+// Provide some shortcuts for frequent namespaces.
+namespace py = pybind11;
+using namespace GQCP;
+
+
+/**
+ *  Register `CartesianExponents` to the gqcpy module and expose a part of its C++ interface to Python.
+ * 
+ *  @param module           The Pybind11 module in which `CartesianExponents` should be registered.
+ */
+void bindCartesianExponents(py::module& module) {
+
+    // Define the Python class for `CartesianExponents`.
+    py::class_<CartesianExponents> py_CartesianExponents {module, "CartesianExponents", "A class that represents exponents of the Cartesian functions x, y and z."};
+
+    py_CartesianExponents
+        .def("value",
+             &CartesianExponents::value,
+             py::arg("direction"),
+             "Return the exponent in the given direction");
+}
+
+
+}  // namespace gqcpy

--- a/gqcpy/src/Mathematical/Functions/CartesianGTO_bindings.cpp
+++ b/gqcpy/src/Mathematical/Functions/CartesianGTO_bindings.cpp
@@ -1,0 +1,58 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "Mathematical/Functions/CartesianGTO.hpp"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+
+namespace gqcpy {
+
+
+// Provide some shortcuts for frequent namespaces.
+namespace py = pybind11;
+using namespace GQCP;
+
+
+/**
+ *  Register `CartesianGTO` to the gqcpy module and expose a part of its C++ interface to Python.
+ * 
+ *  @param module           The Pybind11 module in which `CartesianGTO` should be registered.
+ */
+void bindCartesianGTO(py::module& module) {
+
+    // Define the Python class for `CartesianGTO`.
+    py::class_<CartesianGTO> py_CartesianGTO {module, "CartesianGTO", "A Cartesian Gaussian-type orbital (GTO), often referred to as a Cartesian 'primitive'."};
+
+
+    py_CartesianGTO
+        .def("gaussianExponent",
+             &CartesianGTO::gaussianExponent,
+             "Return the Gaussian exponent for this Cartesian GTO.")
+
+        .def("center",
+             &CartesianGTO::center,
+             "Return the center of this Cartesian GTO.")
+
+        .def("cartesianExponents",
+             &CartesianGTO::cartesianExponents,
+             "Return the Cartesian exponents for this Cartesian GTO.");
+}
+
+
+}  // namespace gqcpy

--- a/website/examples/Calculating integrals over GTOs.ipynb
+++ b/website/examples/Calculating integrals over GTOs.ipynb
@@ -1,0 +1,254 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "tamil-anchor",
+   "metadata": {},
+   "source": [
+    "# Calculating integrals over GTOs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "looking-senegal",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Force the local gqcpy to be imported\n",
+    "import sys\n",
+    "sys.path.insert(0, '../../build/gqcpy/')\n",
+    "\n",
+    "import gqcpy\n",
+    "import numpy as np\n",
+    "\n",
+    "np.set_printoptions(precision=5, linewidth=120)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "scientific-chart",
+   "metadata": {},
+   "source": [
+    "In this example, we'll go over the high- and low-level machinery that GQCP offers in order to calculate integrals over Cartesian GTOs. We assume that you're familiar with the mathematical concepts of a _scalar basis_, a _shell_ and a _primitive_."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "logical-shelter",
+   "metadata": {},
+   "source": [
+    "We'll start off by setting up a small molecular system."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "sporting-employer",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "molecule = gqcpy.Molecule([\n",
+    "    gqcpy.Nucleus(1, 0.0, 0.0, 0.0),\n",
+    "    gqcpy.Nucleus(1, 0.0, 0.0, 1.0)\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "anticipated-trailer",
+   "metadata": {},
+   "source": [
+    "## Primitive engines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exact-marking",
+   "metadata": {},
+   "source": [
+    "Before tackling the first type of integrals (the overlap integrals), we'll have to zoom in a bit on how integrals are calculated. Let's dive in:\n",
+    "- Spin-orbitals are expanded in an underlying scalar basis.\n",
+    "- In order to compactify scalar bases, we use shells that group primitives according to their angular momentum.\n",
+    "- Therefore, in every shell, a _set_ of basis functions (of the same angular momentum) is implicitly defined.\n",
+    "- Every basis function is defined as a contraction (i.e. a linear combination, where the coefficients are called _contraction coefficients_) of primitives.\n",
+    "- Here, the primitives are Cartesian GTOs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "plastic-document",
+   "metadata": {},
+   "source": [
+    "In GQCP, we define an _engine_ to be a computational object that is able to calculate integrals over _shells_, while a _primitive engine_ is defined to be a computational entity that can calculate integrals over _primitives_. \n",
+    "\n",
+    "In this example, we're taking the expansion of contracted GTOs in terms of their primitives for granted (using the implementations provided by the combination of `FunctionalOneElectronIntegralEngine` and `IntegralCalculator`), and we'll be focusing on calculating integrals over _primitives_."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "geographic-muslim",
+   "metadata": {},
+   "source": [
+    "Since we really don't want to manually read in a basis set, we'll use `RSpinOrbitalBasis`'s functionality to provide us with a scalar basis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "signal-companion",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spin_orbital_basis = gqcpy.RSpinOrbitalBasis_d(molecule, \"STO-3G\")\n",
+    "scalar_basis = spin_orbital_basis.scalarBasis()\n",
+    "shell_set = scalar_basis.shellSet()  # A shell set is just a collection of shells."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "basic-piano",
+   "metadata": {},
+   "source": [
+    "## Overlap integrals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "unlikely-redhead",
+   "metadata": {},
+   "source": [
+    "Let's get straight into it. Using the McMurchie-Davidson integral scheme, we can calculate the overlap integral over two primitives as follows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "electronic-explosion",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def overlap_function(left, right):\n",
+    "    \n",
+    "    primitive_integral = 1.0\n",
+    "    \n",
+    "    # The overlap integral is separable in its three Cartesian components.\n",
+    "    for direction in [gqcpy.CartesianDirection.x, gqcpy.CartesianDirection.y, gqcpy.CartesianDirection.z]:\n",
+    "        i = left.cartesianExponents().value(direction)\n",
+    "        j = right.cartesianExponents().value(direction)\n",
+    "        \n",
+    "        a = left.gaussianExponent()\n",
+    "        b = right.gaussianExponent()\n",
+    "        p = a + b\n",
+    "\n",
+    "        K = left.center()[direction]\n",
+    "        L = right.center()[direction]\n",
+    "\n",
+    "\n",
+    "        E = gqcpy.McMurchieDavidsonCoefficient(K, a, L, b)\n",
+    "        \n",
+    "        primitive_integral_1D = np.power(np.pi / p, 0.5) * E(i, j, 0)\n",
+    "        primitive_integral *= primitive_integral_1D\n",
+    "\n",
+    "\n",
+    "    return primitive_integral"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "authorized-airfare",
+   "metadata": {},
+   "source": [
+    "We'll wrap this function in to a `FunctionalPrimitiveEngine`, and then supply it as the primitive engine that should be used in a `FunctionalOneElectronIntegralEngine`. We're doing this in order to use GQCP's internal handling of the shells and contractions through the `IntegralCalculator.calculate` call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "unable-logan",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "primitive_overlap_engine = gqcpy.FunctionalPrimitiveEngine_d(overlap_function)\n",
+    "overlap_engine = gqcpy.FunctionalOneElectronIntegralEngine_d(primitive_overlap_engine)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "diagnostic-washer",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1.      0.79659]\n",
+      " [0.79659 1.     ]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "S = gqcpy.IntegralCalculator.calculate(overlap_engine, shell_set, shell_set)\n",
+    "print(S)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "national-platinum",
+   "metadata": {},
+   "source": [
+    "We can verify our results by letting the spin-orbital basis quantize the overlap operator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "guilty-experience",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1.      0.79659]\n",
+      " [0.79659 1.     ]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "S_ref = spin_orbital_basis.quantizeOverlapOperator().parameters()\n",
+    "print(S_ref)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "noticed-hunger",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
**Short description**

In this PR, I'll make sure to open up the Python bindings so we can add a Jupyter Notebook tutorial on our website that enables users to implement their own 'primitive' (non-Coulomb) engines in order to calculate the corresponding integrals. 

**Related issues**

Closes #906.


**To do**

- [x] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [x] Add other smaller task to be completed as a Markdown task list
