### PR TITLE
Refactor CMake such that CMAKE_MODULE_PATH no longer has to be set.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,5 +30,5 @@ jobs:
       run: |
         cd tools/link-test
         mkdir build && cd build
-        cmake .. -DCMAKE_MODULE_PATH=/usr/local/miniconda3/cmake
+        cmake .. -DCMAKE_PREFIX_PATH=/usr/local/miniconda3
         make -j2 VERBOSE=1 && ./link

--- a/cmake/gqcp-config.cmake.in
+++ b/cmake/gqcp-config.cmake.in
@@ -1,5 +1,7 @@
 @PACKAGE_INIT@
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
 include(CMakeFindDependencyMacro)
 find_dependency(Git REQUIRED)
 find_dependency(Eigen3 3.3.4 REQUIRED MODULE)


### PR DESCRIPTION
**Short description**

In this PR I aim to get rid of the requirement that `CMAKE_MODULE_PATH` has to be set manually through command line options passed to CMake.

