### PR TITLE
fix tensor bindings for 2DM's

### DIFF
--- a/gqcpy/include/interfaces.hpp
+++ b/gqcpy/include/interfaces.hpp
@@ -786,7 +786,7 @@ void bindSimple2DMInterface(Class& py_class) {
         .def(
             "tensor",
             [](const Type& d) {
-                return d.tensor().Eigen();
+                return asNumpyArray(d.tensor().Eigen());
             },
             "Return a read-only reference to the matrix representation of this 2-DM.")
 

--- a/gqcpy/src/DensityMatrix/MixedSpinResolved2DMComponent_bindings.cpp
+++ b/gqcpy/src/DensityMatrix/MixedSpinResolved2DMComponent_bindings.cpp
@@ -48,7 +48,7 @@ void bindMixedSpinResolved2DMComponent(py::module& module) {
         .def(
             "tensor",
             [](const MixedSpinResolved2DMComponent<double>& d) {
-                return d.tensor().Eigen();
+                return asNumpyArray(d.tensor().Eigen());
             });
 }
 


### PR DESCRIPTION
**Short description**

This small bug fix solves the issue where we couldn't use the `.tensor()` API in the python bindings to acces 2DMs and their components.

**Related issues**

closes #940 

**To do**

- [x] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
