### PR TITLE
Add automatic conversion for functions in Python bindings.

### DIFF
--- a/gqcp/include/ONVBasis/SpinUnresolvedONVBasis.hpp
+++ b/gqcp/include/ONVBasis/SpinUnresolvedONVBasis.hpp
@@ -23,6 +23,7 @@
 #include "ONVBasis/SpinUnresolvedONV.hpp"
 #include "Operator/SecondQuantized/GSQOneElectronOperator.hpp"
 #include "Operator/SecondQuantized/GSQTwoElectronOperator.hpp"
+#include "Operator/SecondQuantized/ModelHamiltonian/HubbardHamiltonian.hpp"
 #include "Operator/SecondQuantized/PureUSQTwoElectronOperatorComponent.hpp"
 #include "Operator/SecondQuantized/SQHamiltonian.hpp"
 #include "Operator/SecondQuantized/USQOneElectronOperatorComponent.hpp"
@@ -273,6 +274,20 @@ public:
      *  @return A dense matrix represention of the Hamiltonian.
      */
     SquareMatrix<double> evaluateOperatorDense(const GSQHamiltonian<double>& hamiltonian) const;
+
+
+    /*
+     *  MARK: Dense restricted operator evaluations
+     */
+
+    /**
+     *  Calculate the dense matrix representation of a Hubbard Hamiltonian in this ONV basis.
+     *
+     *  @param hamiltonian      A Hubbard Hamiltonian expressed in an orthonormal orbital basis.
+     *
+     *  @return A dense matrix represention of the Hamiltonian.
+     */
+    //SquareMatrix<double> evaluateOperatorDense(const HubbardHamiltonian<double>& hamiltonian) const;
 
 
     /*

--- a/gqcpy/src/ONVBasis/SpinResolvedONVBasis_bindings.cpp
+++ b/gqcpy/src/ONVBasis/SpinResolvedONVBasis_bindings.cpp
@@ -18,6 +18,7 @@
 #include "ONVBasis/SpinResolvedONVBasis.hpp"
 
 #include <pybind11/eigen.h>
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 
 

--- a/gqcpy/src/ONVBasis/SpinUnresolvedONVBasis_bindings.cpp
+++ b/gqcpy/src/ONVBasis/SpinUnresolvedONVBasis_bindings.cpp
@@ -18,6 +18,7 @@
 #include "ONVBasis/SpinUnresolvedONVBasis.hpp"
 
 #include <pybind11/eigen.h>
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 
 


### PR DESCRIPTION
**Short description**

This PR adds the automatic conversion of Python functions to C++ `std::function`s in `SpinResolved`- and `SpinUnresolvedONVBasis` objects.

**To do**

- [ ] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [ ] Add other smaller task to be completed as a Markdown task list
