### PR TITLE
Add functional header for ONVBasis bindings.

### DIFF
--- a/gqcpy/src/ONVBasis/SpinResolvedONVBasis_bindings.cpp
+++ b/gqcpy/src/ONVBasis/SpinResolvedONVBasis_bindings.cpp
@@ -18,6 +18,7 @@
 #include "ONVBasis/SpinResolvedONVBasis.hpp"
 
 #include <pybind11/eigen.h>
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 
 

--- a/gqcpy/src/ONVBasis/SpinUnresolvedONVBasis_bindings.cpp
+++ b/gqcpy/src/ONVBasis/SpinUnresolvedONVBasis_bindings.cpp
@@ -18,6 +18,7 @@
 #include "ONVBasis/SpinUnresolvedONVBasis.hpp"
 
 #include <pybind11/eigen.h>
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 
 


### PR DESCRIPTION
**Short description**

The `forEach` method does not work without automatic conversion from `pybind`'s `functional.h` header. This PR adds the automatic conversion of Python functions to C++ `std::function`s in `SpinResolved`- and `SpinUnresolvedONVBasis` objects.

**To do**

- [ ] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [ ] Add other smaller task to be completed as a Markdown task list
