### PR TITLE
Add spinResolved and spinUnresolved classes for an `operator string`

### DIFF
--- a/gqcp/include/ONVBasis/SpinResolvedOperatorString.hpp
+++ b/gqcp/include/ONVBasis/SpinResolvedOperatorString.hpp
@@ -65,13 +65,47 @@ public:
         auto pair_vector = std::vector<std::pair<size_t, GQCP::Spin>> {};
 
         // Create the pairs and fill the pair vector.
-        for (int i = 1; i < index_vector.size(); i++) {
+        for (int i = 0; i < index_vector.size(); i++) {
             auto pair = std::pair<size_t, GQCP::Spin> {index_vector[i], spin_vector[i]};
             pair_vector.push_back(pair);
         }
 
         this->index_spin_pairs = pair_vector;
     };
+
+
+    /*
+     *  MARK: General information
+     */
+
+    /**
+     *  Retrieve the operator indices from the `SpinUnresolvedOPeratorString`.
+     */
+    std::vector<size_t> operatorIndices() const {
+        // for each pair in the operator string, save the index and return the vector containing them.
+        auto index_vector = std::vector<size_t> {};
+
+        for (int i = 0; i < this->index_spin_pairs.size(); i++) {
+            index_vector.push_back(this->index_spin_pairs[i].first);
+        }
+
+        return index_vector;
+    }
+
+
+    /**
+     *  Retrieve the operator indices from the `SpinUnresolvedOPeratorString`.
+     */
+    std::vector<GQCP::Spin> operatorSpins() const {
+        // for each pair in the operator string, save the index and return the vector containing them.
+        auto spin_vector = std::vector<GQCP::Spin> {};
+
+        for (int i = 0; i < this->index_spin_pairs.size(); i++) {
+            spin_vector.push_back(this->index_spin_pairs[i].second);
+        }
+
+        return spin_vector;
+    }
 };
 
 

--- a/gqcp/include/ONVBasis/SpinResolvedOperatorString.hpp
+++ b/gqcp/include/ONVBasis/SpinResolvedOperatorString.hpp
@@ -1,0 +1,78 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+
+#include "QuantumChemical/Spin.hpp"
+
+
+namespace GQCP {
+
+
+/**
+ *  A spin resolved operator string.
+
+ *  An spin resolved operator string represents a string of either annihilation or creation operators by its indices. The indices can belong to either alpha or beta operators.
+ *  For example, an operator string represented by indices <1a, 1b, 2a, 3b> represents either:
+ *      a_1_alpha^\dagger a_1_beta^\dagger a_2_alpha^\dagger a_3_beta^\dagger
+ *  or
+ *      a_1_alpha a_1_beta a_2_alpha a_3_beta.
+ *  
+ *  An operator string is always represented by pairs, containing the indices of the operators on the one hand and the spin (alpha or beta) on the other. Whether it denotes annihilation or creation operators depends on the context in which an operator string is used.
+ *  The operator strings are different from ONV's. Instead of representing the way orbitals are occupied, they purely represent the order of certain operators.
+ */
+class SpinResolvedOperatorString {
+private:
+    // The vector representing the indices of the annihilation or creation operators in the operator string. Each index is paired with a certain spin.
+    std::vector<std::pair<size_t, GQCP::Spin>> index_spin_pairs;
+
+public:
+    /*
+     * MARK: Constructors
+     */
+
+    /**
+     *  Construct a `SpinResolvedOperatorString` from the vector of indices that it encapsulates, together with a vector containing the spins of the individual operators.
+     * 
+     *  @param index_vector                The vector containing the alpha operator indices.
+     *  @param spin_vector                 The vector containing the spins associated with each individual operator index.
+     * 
+     * Note: The index vector element zero will be matched with the spin vector element zero, the index vector element one will be matched with spin vector element one and so on.
+     */
+    SpinResolvedOperatorString(const std::vector<size_t>& index_vector, const std::vector<GQCP::Spin>& spin_vector) {
+
+        // Throw an exceptioon if the vector dimensions don't match.
+        if (index_vector.size() != spin_vector.size()) {
+            throw std::invalid_argument("SpinUnresolvedOperatorString(const std::vector<size_t>& index_vector, const std::vector<GQCP::Spin>& spin_vector): The dimensions of the argument vectors don't match. They should be the same.");
+        }
+
+        // Initialize the empty spin pair vector.
+        auto pair_vector = std::vector<std::pair<size_t, GQCP::Spin>> {};
+
+        // Create the pairs and fill the pair vector.
+        for (int i = 1; i < index_vector.size(); i++) {
+            auto pair = std::pair<size_t, GQCP::Spin> {index_vector[i], spin_vector[i]};
+            pair_vector.push_back(pair);
+        }
+
+        this->index_spin_pairs = pair_vector;
+    };
+};
+
+
+}  // namespace GQCP

--- a/gqcp/include/ONVBasis/SpinUnresolvedOperatorString.hpp
+++ b/gqcp/include/ONVBasis/SpinUnresolvedOperatorString.hpp
@@ -68,14 +68,16 @@ public:
      */
     bool isZero() const {
 
+        // Initialize a parameter to be updated.
+        auto is_zero = false;
+
         // Check if adjacent index pairs in the operator string are the same. If there are identical adjacent pairs, the operator stringg will always result in zero due to the fermion anti-commutation rules.
-        for (auto left = indices.begin(), right = left + 1, last = indices.end(); right != last; ++left, ++right) {
+        for (auto left = this->indices.begin(), right = left + 1, last = this->indices.end(); right != last; ++left, ++right) {
             if (*left == *right) {
-                return true;
-            } else {
-                return false;
+                is_zero = true;
             }
         }
+        return is_zero;
     }
 };
 

--- a/gqcp/include/ONVBasis/SpinUnresolvedOperatorString.hpp
+++ b/gqcp/include/ONVBasis/SpinUnresolvedOperatorString.hpp
@@ -63,7 +63,7 @@ public:
 
     /**
      * Check whether the operator string in question will result in zero when applied to the wave function.
-     * 
+     *
      * Note: There are different cases when an operator string will result in a zero value. This method checks all of them.
      */
     bool isZero() const {
@@ -72,10 +72,10 @@ public:
         for (auto left = indices.begin(), right = left + 1, last = indices.end(); right != last; ++left, ++right) {
             if (*left == *right) {
                 return true;
+            } else {
+                return false;
             }
         }
-
-        //
     }
 };
 

--- a/gqcp/include/ONVBasis/SpinUnresolvedOperatorString.hpp
+++ b/gqcp/include/ONVBasis/SpinUnresolvedOperatorString.hpp
@@ -36,7 +36,7 @@ namespace GQCP {
 class SpinUnresolvedOperatorString {
 private:
     // The vector representing the indices of the annihilation or creation operators in the operator string.
-    std::vector<size_t> operator_indices;
+    std::vector<size_t> indices;
 
 public:
     /*
@@ -44,12 +44,31 @@ public:
      */
 
     /**
-     *  Construct a `SpinUnresolvedOperatorStrring` from the vector of indices that it encapsulates.
+     *  Construct a `SpinUnresolvedOperatorString` from the vector of indices that it encapsulates.
      * 
      *  @param index_vector                The vector containing the operator indices.
      */
     SpinUnresolvedOperatorString(const std::vector<size_t>& index_vector) :
-        operator_indices {index_vector} {};
+        indices {index_vector} {};
+
+
+    /*
+     *  MARK: General information
+     */
+
+    /**
+     *  Retrieve the operator indices from the `SpinUnresolvedOPeratorString`.
+     */
+    std::vector<size_t> operatorIndices() const { return this->indices; }
+
+    /**
+     * Check whether the operator string in question will result in zero when applied to the wave function.
+     * 
+     * Note: There are different cases when an operator string will result in a zero value. This method checks all of them.
+     */
+    bool isZero() const {
+        return false;
+    }
 };
 
 

--- a/gqcp/include/ONVBasis/SpinUnresolvedOperatorString.hpp
+++ b/gqcp/include/ONVBasis/SpinUnresolvedOperatorString.hpp
@@ -67,7 +67,15 @@ public:
      * Note: There are different cases when an operator string will result in a zero value. This method checks all of them.
      */
     bool isZero() const {
-        return false;
+
+        // Check if adjacent index pairs in the operator string are the same. If there are identical adjacent pairs, the operator stringg will always result in zero due to the fermion anti-commutation rules.
+        for (auto left = indices.begin(), right = left + 1, last = indices.end(); right != last; ++left, ++right) {
+            if (*left == *right) {
+                return true;
+            }
+        }
+
+        //
     }
 };
 

--- a/gqcp/include/ONVBasis/SpinUnresolvedOperatorString.hpp
+++ b/gqcp/include/ONVBasis/SpinUnresolvedOperatorString.hpp
@@ -1,0 +1,56 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+
+namespace GQCP {
+
+
+/**
+ *  A spin-unresolved operator string.
+
+ *  An spin-unresolved operator string represents a string of either annihilation or creation operators by its indices.
+ *  For example, an operator string represented by indices <1, 2, 3> represents either:
+ *      a_1^\dagger a_2^\dagger a_3^\dagger
+ *  or
+ *      a_1 a_2 a_3.
+ *  
+ *  An operator string is always represented by the indices of the operators. Whether it denotes annihilation or creation operators depends on the context in which an operator string is used.
+ *  The operator strings are different from ONV's. Instead of representing the way orbitals are occupied, they purely represent the order of certain operators.
+ */
+class SpinUnresolvedOperatorString {
+private:
+    // The vector representing the indices of the annihilation or creation operators in the operator string.
+    std::vector<size_t> operator_indices;
+
+public:
+    /*
+     * MARK: Constructors
+     */
+
+    /**
+     *  Construct a `SpinUnresolvedOperatorStrring` from the vector of indices that it encapsulates.
+     * 
+     *  @param index_vector                The vector containing the operator indices.
+     */
+    SpinUnresolvedOperatorString(const std::vector<size_t>& index_vector) :
+        operator_indices {index_vector} {};
+};
+
+
+}  // namespace GQCP

--- a/gqcp/include/gqcp.hpp
+++ b/gqcp/include/gqcp.hpp
@@ -169,6 +169,7 @@
 #include "ONVBasis/SeniorityZeroONVBasis.hpp"
 #include "ONVBasis/SpinResolvedONV.hpp"
 #include "ONVBasis/SpinResolvedONVBasis.hpp"
+#include "ONVBasis/SpinResolvedOperatorString.hpp"
 #include "ONVBasis/SpinResolvedSelectedONVBasis.hpp"
 #include "ONVBasis/SpinUnresolvedONV.hpp"
 #include "ONVBasis/SpinUnresolvedONVBasis.hpp"

--- a/gqcp/include/gqcp.hpp
+++ b/gqcp/include/gqcp.hpp
@@ -172,6 +172,7 @@
 #include "ONVBasis/SpinResolvedSelectedONVBasis.hpp"
 #include "ONVBasis/SpinUnresolvedONV.hpp"
 #include "ONVBasis/SpinUnresolvedONVBasis.hpp"
+#include "ONVBasis/SpinUnresolvedOperatorString.hpp"
 #include "ONVBasis/SpinUnresolvedSelectedONVBasis.hpp"
 #include "Operator/FirstQuantized/AngularMomentumOperator.hpp"
 #include "Operator/FirstQuantized/BaseFQOperator.hpp"

--- a/gqcp/tests/ONVBasis/CMakeLists.txt
+++ b/gqcp/tests/ONVBasis/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND test_target_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/SpinResolvedSelectedONVBasis_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SpinUnresolvedONV_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SpinUnresolvedONVBasis_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/SpinUnresolvedOperatorString_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SpinUnresolvedSelectedONVBasis_test.cpp
 )
 

--- a/gqcp/tests/ONVBasis/CMakeLists.txt
+++ b/gqcp/tests/ONVBasis/CMakeLists.txt
@@ -1,12 +1,12 @@
 list(APPEND test_target_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/ONVPath_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/OperatorString_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SeniorityZeroONVBasis_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SpinResolvedONV_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SpinResolvedONVBasis_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SpinResolvedSelectedONVBasis_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SpinUnresolvedONV_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SpinUnresolvedONVBasis_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/SpinUnresolvedOperatorString_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SpinUnresolvedSelectedONVBasis_test.cpp
 )
 

--- a/gqcp/tests/ONVBasis/OperatorString_test.cpp
+++ b/gqcp/tests/ONVBasis/OperatorString_test.cpp
@@ -19,17 +19,38 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "ONVBasis/SpinResolvedOperatorString.hpp"
 #include "ONVBasis/SpinUnresolvedOperatorString.hpp"
+#include "QuantumChemical/Spin.hpp"
 
 
 /**
  *  Check whether the SpinUnresolvedOperatorString constructor works.
  */
-BOOST_AUTO_TEST_CASE(test_constructor) {
+BOOST_AUTO_TEST_CASE(test_unresolved_constructor) {
 
     // Initialize the vector which we want to use for our operator string.
     std::vector<size_t> indices = {1, 4, 7, 8};
 
     // Check the constructor.
     BOOST_CHECK_NO_THROW(GQCP::SpinUnresolvedOperatorString operator_string {indices});
+}
+
+/**
+ *  Check whether the SpinResolvedOperatorString constructor works.
+ */
+BOOST_AUTO_TEST_CASE(test_resolved_constructor) {
+
+    // Initialize the vector which we want to use for our operator string indices.
+    std::vector<size_t> indices = {1, 4, 7, 8};
+
+    // Initialize the vector which we want to use for our operator string indices.
+    std::vector<size_t> indices_wrong = {4, 7, 8};
+
+    // Initialize the vector which we want to use for our operator string indices.
+    std::vector<GQCP::Spin> spins = {GQCP::Spin::alpha, GQCP::Spin::beta, GQCP::Spin::alpha, GQCP::Spin::beta};
+
+    // Check the constructor.
+    BOOST_CHECK_THROW(GQCP::SpinResolvedOperatorString operator_string_wrong(indices_wrong, spins), std::invalid_argument);
+    BOOST_CHECK_NO_THROW(GQCP::SpinResolvedOperatorString operator_string_correct(indices, spins));
 }

--- a/gqcp/tests/ONVBasis/OperatorString_test.cpp
+++ b/gqcp/tests/ONVBasis/OperatorString_test.cpp
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
 
-#define BOOST_TEST_MODULE "ONVPath"
+#define BOOST_TEST_MODULE "OperatorString"
 
 #include <boost/test/unit_test.hpp>
 
@@ -53,4 +53,45 @@ BOOST_AUTO_TEST_CASE(test_resolved_constructor) {
     // Check the constructor.
     BOOST_CHECK_THROW(GQCP::SpinResolvedOperatorString operator_string_wrong(indices_wrong, spins), std::invalid_argument);
     BOOST_CHECK_NO_THROW(GQCP::SpinResolvedOperatorString operator_string_correct(indices, spins));
+}
+
+/**
+ *  Check whether the SpinUnresolvedOperatorString stores its information correctly.
+ */
+BOOST_AUTO_TEST_CASE(test_unresolved_indices) {
+
+    // Initialize the vector which we want to use for our operator string.
+    std::vector<size_t> indices = {1, 4, 7, 8};
+
+    // initialize the SpinUnresolvedOperatorString.
+    const auto operator_string = GQCP::SpinUnresolvedOperatorString {indices};
+
+    // Get the indices from the operator string.
+    const auto operator_string_indices = operator_string.operatorIndices();
+
+    // Check whether the indices are stored correctly.
+    BOOST_CHECK_EQUAL_COLLECTIONS(indices.begin(), indices.end(), operator_string_indices.begin(), operator_string_indices.end());
+}
+
+/**
+ *  Check whether the SpinResolvedOperatorString stores its information correctly.
+ */
+BOOST_AUTO_TEST_CASE(test_resolved_indices_spins) {
+
+    // Initialize the vector which we want to use for our operator string.
+    std::vector<size_t> indices = {1, 4, 7, 8};
+
+    // Initialize the vector which we want to use for our operator string indices.
+    std::vector<GQCP::Spin> spins = {GQCP::Spin::alpha, GQCP::Spin::beta, GQCP::Spin::alpha, GQCP::Spin::beta};
+
+    // initialize the SpinUnresolvedOperatorString.
+    const auto operator_string = GQCP::SpinResolvedOperatorString(indices, spins);
+
+    // Get the indices and spins from the operator string.
+    const auto operator_string_indices = operator_string.operatorIndices();
+    const auto operator_string_spins = operator_string.operatorSpins();
+
+    // Check whether the indices are stored correctly.
+    BOOST_CHECK_EQUAL_COLLECTIONS(indices.begin(), indices.end(), operator_string_indices.begin(), operator_string_indices.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(spins.begin(), spins.end(), operator_string_spins.begin(), operator_string_spins.end());
 }

--- a/gqcp/tests/ONVBasis/SpinUnresolvedOperatorString_test.cpp
+++ b/gqcp/tests/ONVBasis/SpinUnresolvedOperatorString_test.cpp
@@ -1,0 +1,35 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#define BOOST_TEST_MODULE "ONVPath"
+
+#include <boost/test/unit_test.hpp>
+
+#include "ONVBasis/SpinUnresolvedOperatorString.hpp"
+
+
+/**
+ *  Check whether the SpinUnresolvedOperatorString constructor works.
+ */
+BOOST_AUTO_TEST_CASE(test_constructor) {
+
+    // Initialize the vector which we want to use for our operator string.
+    std::vector<size_t> indices = {1, 4, 7, 8};
+
+    // Check the constructor.
+    BOOST_CHECK_NO_THROW(GQCP::SpinUnresolvedOperatorString operator_string {indices});
+}


### PR DESCRIPTION
**Short description**

These operator string classes will make working with full CI NDM calculations a lot more feasible and will allow for a clear implementation of the spin resolved NDMElement API.

**Related issues**



**To do**

- [ ] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [ ] Expand the spinUnresolved ìsZero()`API to include all cases where an operator string automatically results in a zero value.
- [ ] Add a `SpinResolve()`API to the spin resolved class which splits the operator string to it's spinUnresolved components and calculates the correct phase factor in the process.
