### PR TITLE
Fix GA conda uploads to Anaconda. Closes #967.

### DIFF
--- a/.github/workflows/ci-cd-conda.yml
+++ b/.github/workflows/ci-cd-conda.yml
@@ -56,9 +56,8 @@ jobs:
         run: |
           conda create -n packaging -c conda-forge python=${{ matrix.py }} conda-build anaconda-client conda-verify
           source activate packaging
-          conda config --set anaconda_upload no
+          conda config --set anaconda_upload yes
           conda-build -c gqcg -c conda-forge -c intel conda --user ${{ secrets.ANACONDA_USER }} --token ${{ secrets.ANACONDA_TOKEN }} --variants "{python: [${{ matrix.py }}] }"
-          anaconda logout
       - name: Deploy conda package
         if: github.event_name == 'push'
         run: |
@@ -66,4 +65,3 @@ jobs:
           source activate packaging
           conda config --set anaconda_upload yes
           conda-build -c gqcg -c conda-forge -c intel conda --user ${{ secrets.ANACONDA_USER }} --token ${{ secrets.ANACONDA_TOKEN }} --variants "{python: [${{ matrix.py }}] }"
-          anaconda logout

--- a/.github/workflows/ci-cd-conda.yml
+++ b/.github/workflows/ci-cd-conda.yml
@@ -65,3 +65,4 @@ jobs:
           source activate packaging
           conda config --set anaconda_upload yes
           conda-build -c gqcg -c conda-forge -c intel conda --user ${{ secrets.ANACONDA_USER }} --token ${{ secrets.ANACONDA_TOKEN }} --variants "{python: [${{ matrix.py }}] }"
+

--- a/.github/workflows/ci-cd-conda.yml
+++ b/.github/workflows/ci-cd-conda.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           conda create -n packaging -c conda-forge python=${{ matrix.py }} conda-build anaconda-client conda-verify
           source activate packaging
-          conda config --set anaconda_upload yes
+          conda config --set anaconda_upload no
           conda-build -c gqcg -c conda-forge -c intel conda --user ${{ secrets.ANACONDA_USER }} --token ${{ secrets.ANACONDA_TOKEN }} --variants "{python: [${{ matrix.py }}] }"
       - name: Deploy conda package
         if: github.event_name == 'push'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 #   - the gqcpy Python bindings to the C++ library (optional)
 
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
-project(GQCP VERSION 1.0.0 LANGUAGES CXX)
+project(GQCP VERSION 0.1.0 LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)  # make CMake look into the ./cmake/ folder for configuration files
 
 # Look for the dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 #   - the gqcpy Python bindings to the C++ library (optional)
 
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
-project(GQCP VERSION 0.0.1 LANGUAGES CXX)
+project(GQCP VERSION 1.0.0 LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)  # make CMake look into the ./cmake/ folder for configuration files
 
 # Look for the dependencies

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "GQCP" %}
-{% set version = "1.0.0" %}
+{% set version = "0.1.0" %}
 
 package:
     name: {{ name|lower }}

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "GQCP" %}
-{% set version = "0.0.1" %}
+{% set version = "1.0.0" %}
 
 package:
     name: {{ name|lower }}

--- a/tools/HEADER
+++ b/tools/HEADER
@@ -1,6 +1,6 @@
 This file is part of GQCG-GQCP.
 
-Copyright (C) 2017-2020  the GQCG developers
+Copyright (C) 2017-2021  the GQCG developers
 
 GQCG-GQCP is free software: you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/tools/conda.recipe/meta.yaml
+++ b/tools/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: GQCP
-  version: 0.0.1
+  version: 1.0.0
 
 
 source:

--- a/tools/conda.recipe/meta.yaml
+++ b/tools/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: GQCP
-  version: 1.0.0
+  version: 0.1.0
 
 
 source:


### PR DESCRIPTION
Anaconda tokens have an expiration date and the Anaconda Client does **not** warn when this token has expired, nor does it notify that the upload has failed. I have updated the token and I am now testing if uploading again works. Update: updating the token indeed fixes the upload.