### PR TITLE
Fix evaluate bindings.

### DIFF
--- a/gqcpy/src/Operator/SecondQuantized/EvaluableRSQOneElectronOperator_bindings.cpp
+++ b/gqcpy/src/Operator/SecondQuantized/EvaluableRSQOneElectronOperator_bindings.cpp
@@ -43,7 +43,6 @@ void bindEvaluableRSQOneElectronOperatorInterface(Class& py_class) {
 
     // The C++ type corresponding to the Python class.
     using Type = typename Class::type;
-    using Scalar = typename Type::ExpansionScalar;
 
 
     /*


### PR DESCRIPTION
**Short description**

This PR fixes the Python bindings for evaluating current density matrix elements.

**To do**

- [x] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
