### PR TITLE
Add constrained CI example notebook to website

### DIFF
--- a/website/_toc.yml
+++ b/website/_toc.yml
@@ -35,6 +35,7 @@
     - file: examples/Integrals-over-GTOs
     - file: examples/London-integrals
     - file: examples/Mean-field-magnetic
+    - file: examples/Mulliken-constrained-CI
 
 - part: "Developer documentation"
   chapters:


### PR DESCRIPTION
**Short description**

For the resubmission of the JCTC paper, we will add an example notebook to the website, clarifying how the calculations can be performed. This PR will add that notebook.

**Related issues**

This PR closes an issue on the [constraining_chemical_wave_functions repository](https://github.com/GQCG-res/constraining_chemical_wave_functions), namely: [issue #166](https://github.com/GQCG-res/constraining_chemical_wave_functions/issues/166).
