### PR TITLE
Bugfix for conda CI.

### DIFF
--- a/.github/workflows/ci-cd-conda.yml
+++ b/.github/workflows/ci-cd-conda.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Build conda package
         if: github.event_name == 'pull_request'
         run: |
+          GIT_BRANCH=${{ github.head_ref }}
+          sed -i -e "s|develop|$GIT_BRANCH|g" conda/meta.yaml
           conda create -n packaging -c conda-forge python=${{ matrix.py }} conda-build anaconda-client conda-verify
           source activate packaging
           conda config --set anaconda_upload no

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -6,7 +6,7 @@ package:
     version: {{ version }}
 source:
     git_url: https://github.com/GQCG/GQCP.git
-    git_tag: develop
+    git_tag: bugfix/conda-ci
 requirements:
     build:
       - benchmark

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -6,7 +6,7 @@ package:
     version: {{ version }}
 source:
     git_url: https://github.com/GQCG/GQCP.git
-    git_tag: bugfix/conda-ci
+    git_tag: develop
 requirements:
     build:
       - benchmark

--- a/gqcp/include/Mathematical/Functions/CartesianExponents.hpp
+++ b/gqcp/include/Mathematical/Functions/CartesianExponents.hpp
@@ -21,6 +21,8 @@
 #include "Mathematical/Functions/CartesianDirection.hpp"
 
 #include <array>
+#include <cstddef>
+#include <string>
 #include <vector>
 
 

--- a/gqcp/include/Mathematical/Representation/DenseVectorizer.hpp
+++ b/gqcp/include/Mathematical/Representation/DenseVectorizer.hpp
@@ -18,6 +18,8 @@
 #pragma once
 
 
+#include <stdexcept>
+
 #include <array>
 #include <cstddef>
 #include <numeric>

--- a/gqcp/include/QuantumChemical/SpinResolvedBase.hpp
+++ b/gqcp/include/QuantumChemical/SpinResolvedBase.hpp
@@ -20,6 +20,8 @@
 
 #include "QuantumChemical/Spin.hpp"
 
+#include <stdexcept>
+
 #include <array>
 #include <vector>
 


### PR DESCRIPTION
**Short description**

This PR tries to solve the include errors in PR #980 and makes sure that the conda CI works for pushes on `develop` **and** on pull requests.

**Related issues**

#980.

**To do**

- [ ] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [ ] Add other smaller task to be completed as a Markdown task list
