### PR TITLE
Update Dockerfile to remove build folder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,8 @@ RUN mkdir build && cd build && cmake .. \
     -DBUILD_PYTHON_BINDINGS=TRUE 
 RUN cd build && make -j2 VERBOSE=1 && env CTEST_OUTPUT_ON_FAILURE=1 make test && make install
 
+RUN cd .. && rm -rf build
+
 RUN ldconfig
 
 ENTRYPOINT bash


### PR DESCRIPTION
**Short description**

@guacke Since I use the GQCP Docker environment as a starting point for my GQCD Docker environment, I want to remove the redundant `build` folder after installation as my own Dockerfile needs a `build` folder as well.

**To do**

- [ ] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [ ] Add other smaller task to be completed as a Markdown task list
