### PR TITLE
Add unit tests for complex Hartree-Fock

### DIFF
--- a/gqcp/include/QCModel/HF/RHF.hpp
+++ b/gqcp/include/QCModel/HF/RHF.hpp
@@ -728,9 +728,9 @@ public:
 
         // To calculate G, we must perform two double contractions:
         //      1. (mu nu|rho lambda) P(lambda rho),
-        const Tensor<Scalar, 2> direct_contraction = g.template einsum<2>("ijkl,lk->ij", D.matrix());
+        const Tensor<Scalar, 2> direct_contraction = g.template einsum<2>("ijkl,kl->ij", D.matrix());
         //      2. -0.5 (mu lambda|rho nu) P(lambda rho).
-        const Tensor<Scalar, 2> exchange_contraction = -0.5 * g.template einsum<2>("ilkj,lk->ij", D.matrix());
+        const Tensor<Scalar, 2> exchange_contraction = -0.5 * g.template einsum<2>("ijkl,kj->il", D.matrix());
 
         // The previous contractions are Tensor<Scalar, 2> instances. In order to calculate the total G matrix, we will convert them back into GQCP::Matrix<Scalar>.
         auto G1 = direct_contraction.asMatrix();

--- a/gqcp/tests/QCMethod/HF/GHF/QCMethod_GHF_test.cpp
+++ b/gqcp/tests/QCMethod/HF/GHF/QCMethod_GHF_test.cpp
@@ -334,13 +334,12 @@ BOOST_AUTO_TEST_CASE(h3_sto3g_complex) {
     auto ghf_environment = GQCP::GHFSCFEnvironment<GQCP::complex>::WithComplexlyTransformedCoreGuess(molecule.numberOfElectrons(), sq_hamiltonian, spinor_basis.overlap());
     auto plain_ghf_scf_solver = GQCP::GHFSCFSolver<GQCP::complex>::Plain(1.0e-04, 1000);
     const auto qc_structure = GQCP::QCMethod::GHF<GQCP::complex>().optimize(plain_ghf_scf_solver, ghf_environment);
-    auto ghf_parameters = qc_structure.groundStateParameters();
     auto ghf_ground_state_energy = qc_structure.groundStateEnergy();
     auto nuc_rep = GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()).value();
 
-    // Initialize a reference energy.
+    // Initialize a reference energy. (From the code of @xdvriend.)
     const double reference_energy = -1.34044;
 
-    // Both external stability subcases are checked individually as well.
+    // Check if the converged energy matches the reference energy.
     BOOST_CHECK(std::abs((ghf_ground_state_energy + nuc_rep) - reference_energy) < 1.0e-08);
 }

--- a/gqcp/tests/QCMethod/HF/GHF/QCMethod_GHF_test.cpp
+++ b/gqcp/tests/QCMethod/HF/GHF/QCMethod_GHF_test.cpp
@@ -341,5 +341,5 @@ BOOST_AUTO_TEST_CASE(h3_sto3g_complex) {
     const double reference_energy = -1.34044;
 
     // Check if the converged energy matches the reference energy.
-    BOOST_CHECK(std::abs((ghf_ground_state_energy + nuc_rep) - reference_energy) < 1.0e-08);
+    BOOST_CHECK(std::abs((ghf_ground_state_energy + nuc_rep) - reference_energy) < 1.0e-06);
 }

--- a/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_stability_test.cpp
+++ b/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_stability_test.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(h2o_sto3g_stability) {
 BOOST_AUTO_TEST_CASE(h4_sto3g_stability) {
 
     // Do our own RHF calculation.
-    const auto molecule = GQCP::Molecule::HRingFromDistance(4, 1.0);  // H3-triangle, 1 bohr apart.
+    const auto molecule = GQCP::Molecule::HRingFromDistance(4, 1.0);  // H4-ring, 1 bohr apart.
 
     const GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spinor_basis {molecule, "6-31G"};
     const auto sq_hamiltonian = spinor_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));  // In an AO basis.

--- a/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_test.cpp
+++ b/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_test.cpp
@@ -25,6 +25,7 @@
 #include "QCMethod/HF/RHF/DiagonalRHFFockMatrixObjective.hpp"
 #include "QCMethod/HF/RHF/RHF.hpp"
 #include "QCMethod/HF/RHF/RHFSCFSolver.hpp"
+#include "Utilities/complex.hpp"
 
 
 /**
@@ -353,4 +354,30 @@ BOOST_AUTO_TEST_CASE(h2_631gdp_diis) {
 
     // Check the electronic energy.
     BOOST_CHECK(std::abs(rhf_environment.electronic_energies.back() - ref_electronic_energy) < 1.0e-06);
+}
+
+/**
+ *  The RHF solution of a equilateral H_4 ring is internally stable, but externally unstable. (As confirmed by the implementation of @xdvriend.)
+ *  This test checks whether the lower lying complex RHF solution can indeed be found.
+ */
+BOOST_AUTO_TEST_CASE(h4_sto3g_complex) {
+
+    // Do our own RHF calculation.
+    const auto molecule = GQCP::Molecule::HRingFromDistance(4, 1.8897259886);  // H4-ring, 1 Angstrom apart.
+
+    const GQCP::RSpinOrbitalBasis<GQCP::complex, GQCP::GTOShell> spinor_basis {molecule, "cc-pvdz"};
+    const auto sq_hamiltonian = spinor_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));  // In an AO basis.
+    const GQCP::DiagonalRHFFockMatrixObjective<GQCP::complex> objective {sq_hamiltonian, 1.0e-04};
+
+    auto rhf_environment = GQCP::RHFSCFEnvironment<GQCP::complex>::WithComplexlyTransformedCoreGuess(molecule.numberOfElectrons(), sq_hamiltonian, spinor_basis.overlap());
+    auto plain_rhf_scf_solver = GQCP::RHFSCFSolver<GQCP::complex>::Plain(1.0e-04, 1000);
+    const auto qc_structure = GQCP::QCMethod::RHF<GQCP::complex>().optimize(objective, plain_rhf_scf_solver, rhf_environment);
+    auto rhf_parameters = qc_structure.groundStateParameters();
+    auto rhf_ground_state_energy = qc_structure.groundStateEnergy();
+    auto nuc_rep = GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()).value();
+
+    const double reference_energy = -1.95675;
+
+    // Both external stability subcases are checked individually as well.
+    BOOST_CHECK(std::abs((rhf_ground_state_energy + nuc_rep) - reference_energy) < 1.0e-06);
 }

--- a/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_test.cpp
+++ b/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_test.cpp
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE(h2_631gdp_diis) {
  *  The real RHF solution of a equilateral H_4 ring is internally stable, but externally unstable, both real->complex and restricted->unrestricted. (As confirmed by the implementation of @xdvriend.)
  *  This test checks whether the lower lying complex RHF solution can indeed be found.
  */
-BOOST_AUTO_TEST_CASE(h4_sto3g_complex) {
+BOOST_AUTO_TEST_CASE(h4_ccpvdz_complex) {
 
     // Do our own RHF calculation.
     const auto molecule = GQCP::Molecule::HRingFromDistance(4, 1.8897259886);  // H4-ring, 1 Angstrom apart.

--- a/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_test.cpp
+++ b/gqcp/tests/QCMethod/HF/RHF/QCMethod_RHF_test.cpp
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(h2_631gdp_diis) {
 }
 
 /**
- *  The RHF solution of a equilateral H_4 ring is internally stable, but externally unstable. (As confirmed by the implementation of @xdvriend.)
+ *  The real RHF solution of a equilateral H_4 ring is internally stable, but externally unstable, both real->complex and restricted->unrestricted. (As confirmed by the implementation of @xdvriend.)
  *  This test checks whether the lower lying complex RHF solution can indeed be found.
  */
 BOOST_AUTO_TEST_CASE(h4_sto3g_complex) {
@@ -376,8 +376,9 @@ BOOST_AUTO_TEST_CASE(h4_sto3g_complex) {
     auto rhf_ground_state_energy = qc_structure.groundStateEnergy();
     auto nuc_rep = GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()).value();
 
+    // Initialize a reference energy. (From the code of @xdvriend.)
     const double reference_energy = -1.95675;
 
-    // Both external stability subcases are checked individually as well.
+    // Check if the converged energy matches the reference energy.
     BOOST_CHECK(std::abs((rhf_ground_state_energy + nuc_rep) - reference_energy) < 1.0e-06);
 }

--- a/gqcp/tests/QCMethod/HF/UHF/QCMethod_UHF_test.cpp
+++ b/gqcp/tests/QCMethod/HF/UHF/QCMethod_UHF_test.cpp
@@ -143,7 +143,6 @@ BOOST_AUTO_TEST_CASE(h3_sto3g_complex) {
     auto uhf_ground_state_energy = qc_structure.groundStateEnergy();
     auto nuc_rep = GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()).value();
 
-    std::cout << uhf_ground_state_energy + nuc_rep << std::endl;
     // Initialize a reference energy. (From the code of @xdvriend.)
     const double reference_energy = -1.33598;
 


### PR DESCRIPTION
**Short description**

Due to a bug found by @lelemmen it was necessary to double check the remaining einsum API's as well as add unit tests for the complex Hartree-Fock methods. 

Another bug was found while doing this, which caused the complex RHF method to not converge. The initial contraction pairs (from before the einsum refactor) were `(3, 0) (2, 1)` for the direct matrix and `(1, 0) (2, 1)`for the exchange matrix, which translates to `ijkl,lk->ij` and `ijkl,jk->il` in einsum notation.  

However, from comparison with UHF and GHF and double checking the theory I noticed that the einsum notation should be `ijkl, kl->ij` and `ijkl, kj->il`, or in contraction pairs `(2, 0) (3, 1)` and `(2, 0) (1, 1)`. 

After applying this change, the complex RHF method converged to the expected lower lying state that I double checked with my python code and stability analysis. 
