### PR TITLE
Remove build folder after compilation.

### DIFF
--- a/docker/GQCP.docker
+++ b/docker/GQCP.docker
@@ -32,6 +32,7 @@ RUN mkdir build && cd build && cmake .. \
     -DBUILD_TESTS=TRUE \
     -DBUILD_PYTHON_BINDINGS=TRUE 
 RUN cd build && make -j2 VERBOSE=1 && env CTEST_OUTPUT_ON_FAILURE=1 make test && make install
+RUN rm -rf build
 
 RUN ldconfig
 


### PR DESCRIPTION
**Short description**

Packages that depend on the Docker container of `GQCP` might need their own build folder as well so I think we do not need to keep the build folder.

**To do**

- [ ] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [ ] Add other smaller task to be completed as a Markdown task list
