### PR TITLE
Implement R/U/G NonOrthogonalStateBasis

### DIFF
--- a/gqcp/include/Basis/BiorthogonalBasis/GLowdinPairingBasis.hpp
+++ b/gqcp/include/Basis/BiorthogonalBasis/GLowdinPairingBasis.hpp
@@ -55,7 +55,7 @@ public:
 
 
 /*
- *  MARK: SpinorBasisTraits
+ *  MARK: LowdinPairingBasisTraits
  */
 
 /**
@@ -71,9 +71,6 @@ struct LowdinPairingBasisTraits<GLowdinPairingBasis<_Scalar>> {
 
     // The second-quantized representation of the overlap operator related to the Löwdin pairing basis.
     using SQOverlapOperator = ScalarGSQOneElectronOperator<Scalar>;
-
-    // The type of matrix naturally associated with a `GLowdinPairingBasis`.
-    using Matrix = MatrixX<Scalar>;
 
     // The type of density matrix naturally associated with a `GLowdinPairingBasis`.
     using DM = G1DM<Scalar>;

--- a/gqcp/include/Basis/BiorthogonalBasis/RLowdinPairingBasis.hpp
+++ b/gqcp/include/Basis/BiorthogonalBasis/RLowdinPairingBasis.hpp
@@ -72,9 +72,6 @@ struct LowdinPairingBasisTraits<RLowdinPairingBasis<_Scalar>> {
     // The second-quantized representation of the overlap operator related to the `RLowdinPairingBasis`.
     using SQOverlapOperator = ScalarRSQOneElectronOperator<Scalar>;
 
-    // The type of matrix naturally associated with the `RLowdinPairingBasis`.
-    using Matrix = MatrixX<Scalar>;
-
     // The type of density matrix naturally associated with the `RLowdinPairingBasis`.
     using DM = Orbital1DM<Scalar>;
 };

--- a/gqcp/include/Basis/BiorthogonalBasis/SimpleLowdinPairingBasis.hpp
+++ b/gqcp/include/Basis/BiorthogonalBasis/SimpleLowdinPairingBasis.hpp
@@ -30,11 +30,11 @@
 namespace GQCP {
 
 /*
- *  MARK: SpinorBasisTraits
+ *  MARK: LowdinPairingBasisTraits
  */
 
 /**
- *  A type that provides compile-time information on spinor bases that is otherwise not accessible through a public class alias.
+ *  A type that provides compile-time information on Löwdin pairing bases that is otherwise not accessible through a public class alias.
  */
 template <typename LowdinPairingBasis>
 struct LowdinPairingBasisTraits {};
@@ -44,7 +44,7 @@ struct LowdinPairingBasisTraits {};
  */
 
 /**
- *  A Löwdin pairing basis formed from two `R/U/GTransformation`s. Two given sets of expansion coefficients are bi-orthogonalised
+ *  A Löwdin pairing basis formed from two `R/U/GTransformation`s. Two given sets of expansion coefficients are bi-orthogonalised.
  *
  *  @tparam _ExpansionScalar        The scalar type used to represent the expansion coefficients of the given non-orthogonal states: real or complex.
  */
@@ -57,17 +57,17 @@ public:
     // The vectors associated with the scalar of the expansion coefficients.
     using Vector = VectorX<Scalar>;
 
+    // The matrices associated with the scalar of the expansion coefficients.
+    using Matrix = MatrixX<Scalar>;
+
     // The type of the derived Lowdin pairing Basis from this parent class.
     using DerivedLowdinPairingBasis = _DerivedLowdinPairingBasis;
 
     // The type of transformation that is naturally related to a `LowdinPairingBasis`. Can be R/U/GTransformation.
     using Transformation = typename LowdinPairingBasisTraits<DerivedLowdinPairingBasis>::Transformation;
 
-    // The second-quantized representation of the overlap operator related to the final spinor basis.
+    // The second-quantized representation of the overlap operator related to the final Löwdin pairing basis.
     using SQOverlapOperator = typename LowdinPairingBasisTraits<DerivedLowdinPairingBasis>::SQOverlapOperator;
-
-    // The matrices associated with the scalar of the expansion coefficients. This can be a regular matrix or a spin resolved matrix.
-    using Matrix = typename LowdinPairingBasisTraits<DerivedLowdinPairingBasis>::Matrix;
 
     // The density matrix associated with a lowdin paring basis.
     using DM = typename LowdinPairingBasisTraits<DerivedLowdinPairingBasis>::DM;
@@ -93,7 +93,7 @@ protected:
     // The expansion coefficients of the occupied biorthogonal states are saved as raw matrices instead of the corresponding `Transformation`s because they are not square.
     std::pair<Matrix, Matrix> occupied_biorthogonal_state_expansions;
 
-    // The overlap operator in AO basis, constructed from the spinor/spin-orbital used to calculate the non-orthogonal states.
+    // The overlap operator in AO basis, constructed from the spinor/spin-orbital basis used to calculate the non-orthogonal states.
     SQOverlapOperator overlap_operator_AO;
 
     // The vector containing the biorthogonal overlaps.
@@ -111,7 +111,7 @@ public:
      *  @param C_ket                            The transformation that represents the expansion coefficients of the ket non-orthogonal state.
      *  @param S_AO                             The overlap operator in AO basis, constructed from the spinor/spin-orbital used to calculate the non-orthogonal states.
      *  @param number_of_occupied_orbitals      The total number of occupied orbitals in the system.
-     *  @param threshold                        The threshold at which a value is verified to be zero or not. Default is 1e-8.
+     *  @param threshold                        The threshold at which a value is verified to be zero or not. The default is 1e-8.
      */
     SimpleLowdinPairingBasis<Scalar, DerivedLowdinPairingBasis>(const Transformation& C_bra, const Transformation& C_ket, const SQOverlapOperator& S_AO, const size_t number_of_occupied_orbitals, const double threshold = 1e-8) :
         non_orthogonal_state_expansions {std::pair<Transformation, Transformation> {C_bra, C_ket}},
@@ -149,7 +149,7 @@ public:
         // All singular values have to be positive. If this is not the case, an exception must be thrown.
         for (int i = 0; i < this->biorthogonal_overlaps.rows(); i++) {
             if (this->biorthogonal_overlaps[i] < 0) {
-                throw std::invalid_argument("GLowdinPairingBasis<Scalar>(const Transformation& C_bra, const Transformation& C_ket, const ScalarGSQOneElectronOperator<Scalar>& S_AO, const size_t number_of_electrons, const double threshold): The given parameters lead to negative singular values.");
+                throw std::invalid_argument("LowdinPairingBasis<Scalar>(const Transformation& C_bra, const Transformation& C_ket, const ScalarGSQOneElectronOperator<Scalar>& S_AO, const size_t number_of_electrons, const double threshold): The given parameters lead to negative singular values.");
             }
         }
 
@@ -185,7 +185,7 @@ public:
 
         // We now check the aforementioned condition.
         if (std::abs(overlap - X_occupied.determinant()) > 1e-12) {
-            throw std::invalid_argument("GLowdinPairingBasis<Scalar>(const Transformation& C_bra, const Transformation& C_ket, const ScalarGSQOneElectronOperator<Scalar>& S_AO, const size_t number_of_electrons, const double threshold): The given parameters lead to a wrong overlap calculation.");
+            throw std::invalid_argument("LowdinPairingBasis<Scalar>(const Transformation& C_bra, const Transformation& C_ket, const ScalarGSQOneElectronOperator<Scalar>& S_AO, const size_t number_of_electrons, const double threshold): The given parameters lead to a wrong overlap calculation.");
         }
     }
 
@@ -385,7 +385,7 @@ public:
      *
      * @return The weighted co-density matrix.
      *
-     * @note This implementation is based on equation 38c from the 2021 pper by Hugh Burton (https://aip.scitation.org/doi/abs/10.1063/5.0045442).
+     * @note This implementation is based on equation 38c from the 2021 paper by Hugh Burton (https://aip.scitation.org/doi/abs/10.1063/5.0045442).
      */
     DM weightedCoDensity() const {
 

--- a/gqcp/include/Basis/BiorthogonalBasis/ULowdinPairingBasis.hpp
+++ b/gqcp/include/Basis/BiorthogonalBasis/ULowdinPairingBasis.hpp
@@ -245,7 +245,7 @@ public:
     /**
      * Determine the indices of the zero overlap values in the biorthogonal overlap vector of each spin component.
      *
-     * @return The indices of the zero overlap values of the spin sigma component.
+     * @return The indices of the zero overlap values paired with the corresponding spin component.
      */
     std::vector<std::pair<size_t, Spin>> zeroOverlapIndices() const {
 

--- a/gqcp/include/Basis/BiorthogonalBasis/ULowdinPairingBasis.hpp
+++ b/gqcp/include/Basis/BiorthogonalBasis/ULowdinPairingBasis.hpp
@@ -242,6 +242,28 @@ public:
     std::vector<size_t> zeroOverlapIndices(const Spin sigma) const { return this->component(sigma).zeroOverlapIndices(); }
 
 
+    /**
+     * Determine the indices of the zero overlap values in the biorthogonal overlap vector of each spin component.
+     *
+     * @return The indices of the zero overlap values of the spin sigma component.
+     */
+    std::vector<std::pair<size_t, Spin>> zeroOverlapIndices() const {
+
+        // We merge the alpha and beta zero-index vectors, but we keep track of the spins of each one.
+        std::vector<std::pair<size_t, Spin>> pair_vector {};
+
+        for (const auto& index : this->zeroOverlapIndices(Spin::alpha)) {
+            pair_vector.push_back(std::pair<size_t, Spin> {index, Spin::alpha});
+        }
+
+        for (const auto& index : this->zeroOverlapIndices(Spin::beta)) {
+            pair_vector.push_back(std::pair<size_t, Spin> {index, Spin::beta});
+        }
+
+        return pair_vector;
+    }
+
+
     /*
      *  MARK: Density matrices
      */

--- a/gqcp/include/Basis/BiorthogonalBasis/ULowdinPairingBasisComponent.hpp
+++ b/gqcp/include/Basis/BiorthogonalBasis/ULowdinPairingBasisComponent.hpp
@@ -72,9 +72,6 @@ struct LowdinPairingBasisTraits<ULowdinPairingBasisComponent<_Scalar>> {
     // The second-quantized representation of the overlap operator related to the `RLowdinPairingBasis`.
     using SQOverlapOperator = ScalarUSQOneElectronOperatorComponent<Scalar>;
 
-    // The second-quantized representation of the overlap operator related to the `RLowdinPairingBasis`.
-    using Matrix = MatrixX<Scalar>;
-
     // The type of density matrix naturally associated with the `RLowdinPairingBasis`.
     using DM = SpinResolved1DMComponent<Scalar>;
 };

--- a/gqcp/include/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis.hpp
@@ -1,0 +1,132 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+
+#include "Basis/BiorthogonalBasis/GLowdinPairingBasis.hpp"
+#include "Basis/NonOrthogonalBasis/SimpleNonOrthogonalStateBasis.hpp"
+#include "Basis/Transformations/GTransformation.hpp"
+#include "Operator/SecondQuantized/GSQOneElectronOperator.hpp"
+#include "Operator/SecondQuantized/GSQTwoElectronOperator.hpp"
+#include "Operator/SecondQuantized/SQHamiltonian.hpp"
+
+
+namespace GQCP {
+
+
+/**
+ *  MARK: GNonOrthogonalStateBasis implementation
+ */
+
+
+/**
+ *  A type used to represent a non-orthogonal basis, generated from a set of generalized basis states.
+ *
+ *  @tparam _Scalar                 The scalar type used for the expansion coefficients of the states: real or complex.
+ */
+template <typename _Scalar>
+class GNonOrthogonalStateBasis:
+    public SimpleNonOrthogonalStateBasis<_Scalar, GNonOrthogonalStateBasis<_Scalar>> {
+public:
+    // The scalar type used for the expansion coefficients of the states: real or complex.
+    using Scalar = _Scalar;
+
+public:
+    /**
+     *  MARK: Constructors
+     */
+
+    // Inherit `SimpleNonOrthogonalStateBasis`'s constructors.
+    using SimpleNonOrthogonalStateBasis<Scalar, GNonOrthogonalStateBasis<Scalar>>::SimpleNonOrthogonalStateBasis;
+};
+
+
+/*
+ *  MARK: NonOrthogonalStateBasisTraits
+ */
+
+/**
+ *  A type that provides compile-time information on non-orthogonal state bases that is otherwise not accessible through a public class alias.
+ */
+template <typename _Scalar>
+struct NonOrthogonalStateBasisTraits<GNonOrthogonalStateBasis<_Scalar>> {
+    // The scalar type used to represent a coefficient of the expansions of the states: real or complex.
+    using Scalar = _Scalar;
+
+    // The type of transformation that is naturally related to a `GNonOrthogonalStateBasis`.
+    using Transformation = GTransformation<Scalar>;
+
+    // The Biorthogonal Löwdin pairing basis associated with the non-orthogonal state basis..
+    using BiorthogonalBasis = GLowdinPairingBasis<Scalar>;
+};
+
+
+/*
+ *  MARK: OperatorTraits
+ */
+
+/**
+ *  A type that provides compile-time information on the operators associated with non-orthogonal state bases that is otherwise not accessible through a public class alias.
+ */
+template <typename _Scalar>
+struct NOSBasisOperatorTraits<GNonOrthogonalStateBasis<_Scalar>> {
+    // The scalar type used to represent a coefficient of the expansions of the states: real or complex.
+    using Scalar = _Scalar;
+
+    // The second quantized representation of the Hamiltonian that is naturally related to a `GNonOrthogonalStateBasis`.
+    using Hamiltonian = GSQHamiltonian<Scalar>;
+
+    // The second-quantized representation of the one-electron operator that is naturally related to a `GNonOrthogonalStateBasis`.
+    using OneElectronOperator = ScalarGSQOneElectronOperator<Scalar>;
+
+    // The second-quantized representation of the two-electron operator that is naturally related to a `GNonOrthogonalStateBasis`.
+    using TwoElectronOperator = ScalarGSQTwoElectronOperator<Scalar>;
+};
+
+
+/*
+ *  MARK: JacobiRotatableTraits
+ */
+
+/**
+ *  A type that provides compile-time information related to the abstract interface `JacobiRotatable`.
+ */
+template <typename _Scalar>
+struct JacobiRotatableTraits<GNonOrthogonalStateBasis<_Scalar>> {
+
+    // The type of Jacobi rotation that is naturally related to a `GNonOrthogonalStateBasis`.
+    using JacobiRotationType = JacobiRotation;
+};
+
+
+/*
+ *  MARK: BasisTransformableTraits
+ */
+
+/**
+ *  A type that provides compile-time information related to the abstract interface `BasisTransformable`.
+ */
+template <typename _Scalar>
+struct BasisTransformableTraits<GNonOrthogonalStateBasis<_Scalar>> {
+
+    // The type of transformation that is naturally related to a `GNonOrthogonalStateBAsis`.
+    using Transformation = GTransformation<_Scalar>;
+};
+
+
+}  // namespace GQCP

--- a/gqcp/include/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis.hpp
@@ -71,7 +71,7 @@ struct NonOrthogonalStateBasisTraits<GNonOrthogonalStateBasis<_Scalar>> {
     // The type of transformation that is naturally related to a `GNonOrthogonalStateBasis`.
     using Transformation = GTransformation<Scalar>;
 
-    // The Biorthogonal Löwdin pairing basis associated with the non-orthogonal state basis..
+    // The biorthogonal Löwdin pairing basis associated with the non-orthogonal state basis.
     using BiorthogonalBasis = GLowdinPairingBasis<Scalar>;
 };
 
@@ -124,7 +124,7 @@ struct JacobiRotatableTraits<GNonOrthogonalStateBasis<_Scalar>> {
 template <typename _Scalar>
 struct BasisTransformableTraits<GNonOrthogonalStateBasis<_Scalar>> {
 
-    // The type of transformation that is naturally related to a `GNonOrthogonalStateBAsis`.
+    // The type of transformation that is naturally related to a `GNonOrthogonalStateBasis`.
     using Transformation = GTransformation<_Scalar>;
 };
 

--- a/gqcp/include/Basis/NonOrthogonalBasis/RNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/RNonOrthogonalStateBasis.hpp
@@ -71,7 +71,7 @@ struct NonOrthogonalStateBasisTraits<RNonOrthogonalStateBasis<_Scalar>> {
     // The type of transformation that is naturally related to a `RNonOrthogonalStateBasis`.
     using Transformation = RTransformation<Scalar>;
 
-    // The Biorthogonal Löwdin pairing basis associated with the non-orthogonal state basis..
+    // The biorthogonal Löwdin pairing basis associated with the non-orthogonal state basis.
     using BiorthogonalBasis = RLowdinPairingBasis<Scalar>;
 };
 
@@ -124,7 +124,7 @@ struct JacobiRotatableTraits<RNonOrthogonalStateBasis<_Scalar>> {
 template <typename _Scalar>
 struct BasisTransformableTraits<RNonOrthogonalStateBasis<_Scalar>> {
 
-    // The type of transformation that is naturally related to a `RNonOrthogonalStateBAsis`.
+    // The type of transformation that is naturally related to a `RNonOrthogonalStateBasis`.
     using Transformation = RTransformation<_Scalar>;
 };
 

--- a/gqcp/include/Basis/NonOrthogonalBasis/RNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/RNonOrthogonalStateBasis.hpp
@@ -18,11 +18,11 @@
 #pragma once
 
 
-#include "Basis/BiorthogonalBasis/GLowdinPairingBasis.hpp"
+#include "Basis/BiorthogonalBasis/RLowdinPairingBasis.hpp"
 #include "Basis/NonOrthogonalBasis/SimpleNonOrthogonalStateBasis.hpp"
-#include "Basis/Transformations/GTransformation.hpp"
-#include "Operator/SecondQuantized/GSQOneElectronOperator.hpp"
-#include "Operator/SecondQuantized/GSQTwoElectronOperator.hpp"
+#include "Basis/Transformations/RTransformation.hpp"
+#include "Operator/SecondQuantized/RSQOneElectronOperator.hpp"
+#include "Operator/SecondQuantized/RSQTwoElectronOperator.hpp"
 #include "Operator/SecondQuantized/SQHamiltonian.hpp"
 
 
@@ -30,7 +30,7 @@ namespace GQCP {
 
 
 /**
- *  MARK: GNonOrthogonalStateBasis implementation
+ *  MARK: RNonOrthogonalStateBasis implementation
  */
 
 
@@ -40,8 +40,8 @@ namespace GQCP {
  *  @tparam _Scalar                 The scalar type used for the expansion coefficients of the states: real or complex.
  */
 template <typename _Scalar>
-class GNonOrthogonalStateBasis:
-    public SimpleNonOrthogonalStateBasis<_Scalar, GNonOrthogonalStateBasis<_Scalar>> {
+class RNonOrthogonalStateBasis:
+    public SimpleNonOrthogonalStateBasis<_Scalar, RNonOrthogonalStateBasis<_Scalar>> {
 public:
     // The scalar type used for the expansion coefficients of the states: real or complex.
     using Scalar = _Scalar;
@@ -52,7 +52,7 @@ public:
      */
 
     // Inherit `SimpleNonOrthogonalStateBasis`'s constructors.
-    using SimpleNonOrthogonalStateBasis<Scalar, GNonOrthogonalStateBasis<Scalar>>::SimpleNonOrthogonalStateBasis;
+    using SimpleNonOrthogonalStateBasis<Scalar, RNonOrthogonalStateBasis<Scalar>>::SimpleNonOrthogonalStateBasis;
 };
 
 
@@ -64,15 +64,15 @@ public:
  *  A type that provides compile-time information on non-orthogonal state bases that is otherwise not accessible through a public class alias.
  */
 template <typename _Scalar>
-struct NonOrthogonalStateBasisTraits<GNonOrthogonalStateBasis<_Scalar>> {
+struct NonOrthogonalStateBasisTraits<RNonOrthogonalStateBasis<_Scalar>> {
     // The scalar type used to represent a coefficient of the expansions of the states: real or complex.
     using Scalar = _Scalar;
 
-    // The type of transformation that is naturally related to a `GNonOrthogonalStateBasis`.
-    using Transformation = GTransformation<Scalar>;
+    // The type of transformation that is naturally related to a `RNonOrthogonalStateBasis`.
+    using Transformation = RTransformation<Scalar>;
 
     // The Biorthogonal Löwdin pairing basis associated with the non-orthogonal state basis..
-    using BiorthogonalBasis = GLowdinPairingBasis<Scalar>;
+    using BiorthogonalBasis = RLowdinPairingBasis<Scalar>;
 };
 
 
@@ -84,18 +84,18 @@ struct NonOrthogonalStateBasisTraits<GNonOrthogonalStateBasis<_Scalar>> {
  *  A type that provides compile-time information on the operators associated with non-orthogonal state bases that is otherwise not accessible through a public class alias.
  */
 template <typename _Scalar>
-struct NOSBasisOperatorTraits<GNonOrthogonalStateBasis<_Scalar>> {
+struct NOSBasisOperatorTraits<RNonOrthogonalStateBasis<_Scalar>> {
     // The scalar type used to represent a coefficient of the expansions of the states: real or complex.
     using Scalar = _Scalar;
 
-    // The second quantized representation of the Hamiltonian that is naturally related to a `GNonOrthogonalStateBasis`.
-    using Hamiltonian = GSQHamiltonian<Scalar>;
+    // The second quantized representation of the Hamiltonian that is naturally related to a `RNonOrthogonalStateBasis`.
+    using Hamiltonian = RSQHamiltonian<Scalar>;
 
-    // The second-quantized representation of the one-electron operator that is naturally related to a `GNonOrthogonalStateBasis`.
-    using OneElectronOperator = ScalarGSQOneElectronOperator<Scalar>;
+    // The second-quantized representation of the one-electron operator that is naturally related to a `RNonOrthogonalStateBasis`.
+    using OneElectronOperator = ScalarRSQOneElectronOperator<Scalar>;
 
-    // The second-quantized representation of the two-electron operator that is naturally related to a `GNonOrthogonalStateBasis`.
-    using TwoElectronOperator = ScalarGSQTwoElectronOperator<Scalar>;
+    // The second-quantized representation of the two-electron operator that is naturally related to a `RNonOrthogonalStateBasis`.
+    using TwoElectronOperator = ScalarRSQTwoElectronOperator<Scalar>;
 };
 
 
@@ -107,9 +107,9 @@ struct NOSBasisOperatorTraits<GNonOrthogonalStateBasis<_Scalar>> {
  *  A type that provides compile-time information related to the abstract interface `JacobiRotatable`.
  */
 template <typename _Scalar>
-struct JacobiRotatableTraits<GNonOrthogonalStateBasis<_Scalar>> {
+struct JacobiRotatableTraits<RNonOrthogonalStateBasis<_Scalar>> {
 
-    // The type of Jacobi rotation that is naturally related to a `GNonOrthogonalStateBasis`.
+    // The type of Jacobi rotation that is naturally related to a `RNonOrthogonalStateBasis`.
     using JacobiRotationType = JacobiRotation;
 };
 
@@ -122,10 +122,10 @@ struct JacobiRotatableTraits<GNonOrthogonalStateBasis<_Scalar>> {
  *  A type that provides compile-time information related to the abstract interface `BasisTransformable`.
  */
 template <typename _Scalar>
-struct BasisTransformableTraits<GNonOrthogonalStateBasis<_Scalar>> {
+struct BasisTransformableTraits<RNonOrthogonalStateBasis<_Scalar>> {
 
-    // The type of transformation that is naturally related to a `GNonOrthogonalStateBAsis`.
-    using Transformation = GTransformation<_Scalar>;
+    // The type of transformation that is naturally related to a `RNonOrthogonalStateBAsis`.
+    using Transformation = RTransformation<_Scalar>;
 };
 
 

--- a/gqcp/include/Basis/NonOrthogonalBasis/SimpleNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/SimpleNonOrthogonalStateBasis.hpp
@@ -115,10 +115,10 @@ public:
     /**
      *  Create a `SimpleNonOrthogonalStateBasis` from any number of non orthogonal states.
      *
-     *  @param basis_state_vector                  The vector containing the non-orthogonal basis states.
+     *  @param basis_state_vector               The vector containing the non-orthogonal basis states.
      *  @param S_AO                             The overlap operator in AO basis, constructed from the spinor/spin-orbital used to calculate the non-orthogonal states.
      *  @param number_of_occupied_orbitals      The total number of occupied orbitals in the system.
-     *  @param threshold                           The threshold at which a value is verified to be zero or not. The default is 1e-8.
+     *  @param threshold                        The threshold at which a value is verified to be zero or not. The default is 1e-8.
      */
     SimpleNonOrthogonalStateBasis<Scalar, DerivedNonOrthogonalStateBasis>(const States& basis_state_vector, const OneElectronOperator& S_AO, const size_t number_of_occupied_orbitals, const double threshold = 1e-8) :
         basis_states {basis_state_vector},

--- a/gqcp/include/Basis/NonOrthogonalBasis/SimpleNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/SimpleNonOrthogonalStateBasis.hpp
@@ -1,0 +1,465 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+
+#include "Basis/Transformations/BasisTransformable.hpp"
+#include "Basis/Transformations/JacobiRotatable.hpp"
+#include "Mathematical/Representation/SquareMatrix.hpp"
+#include "Mathematical/Representation/Tensor.hpp"
+#include "Molecule/Molecule.hpp"
+#include "Operator/FirstQuantized/NuclearRepulsionOperator.hpp"
+#include "Utilities/CRTP.hpp"
+#include "Utilities/Eigen.hpp"
+#include "Utilities/type_traits.hpp"
+
+
+namespace GQCP {
+
+/*
+ *  MARK: SpinorBasisTraits
+ */
+
+/**
+ *  A type that provides compile-time information on non-orthogonal state bases that is otherwise not accessible through a public class alias.
+ */
+template <typename NonOrthogonalStateBasis>
+struct NonOrthogonalStateBasisTraits {};
+
+/**
+ *  A type that provides compile-time information on the operators associated with non-orthogonal state bases that is otherwise not accessible through a public class alias.
+ */
+template <typename NonOrthogonalStateBasis>
+struct NOSBasisOperatorTraits {};
+
+/*
+ *  MARK: SimpleNonOrthogonalStateBasis
+ */
+
+/**
+ *  A basis formed by any number of non-orthogonal states, in the form of `R/U/GTransformations.
+ *
+ *  @tparam _ExpansionScalar        The scalar type used to represent the expansion coefficients of the given non-orthogonal states: real or complex.
+ */
+template <typename _Scalar, typename _DerivedNonOrthogonalStateBasis>
+class SimpleNonOrthogonalStateBasis:
+    public CRTP<_DerivedNonOrthogonalStateBasis>,
+    public BasisTransformable<_DerivedNonOrthogonalStateBasis>,
+    public JacobiRotatable<_DerivedNonOrthogonalStateBasis> {
+
+public:
+    // The scalar type used to represent the expansion coefficients of the given non-orthogonal states: real or complex.
+    using Scalar = _Scalar;
+
+    // The type of the derived Lowdin pairing Basis from this parent class.
+    using DerivedNonOrthogonalStateBasis = _DerivedNonOrthogonalStateBasis;
+
+    // The type of matrix associated with this kind of NonOrthogonalStateBasis.
+    using Matrix = SquareMatrix<Scalar>;
+
+    // The type of transformation that is naturally related to a `NonOrthogonalStateBasis`. Can be R/U/GTransformation.
+    using Transformation = typename NonOrthogonalStateBasisTraits<DerivedNonOrthogonalStateBasis>::Transformation;
+
+    // The biorthogonal basis related to the basis states in this type of non-orthogonal basis (R/U/GLowdinPairingBasis).
+    using BiorthogonalBasis = typename NonOrthogonalStateBasisTraits<DerivedNonOrthogonalStateBasis>::BiorthogonalBasis;
+
+    // The type of Jacobi rotation that is naturally related to the derived non orthogonal-basis.
+    using JacobiRotationType = typename JacobiRotatableTraits<DerivedNonOrthogonalStateBasis>::JacobiRotationType;
+
+    // The second-quantized representation of the Hamiltonian that can be quantized by this basis.
+    using Hamiltonian = typename NOSBasisOperatorTraits<DerivedNonOrthogonalStateBasis>::Hamiltonian;
+
+    // The scalar one-electron operator that can be evaluated by the non-orthogonal basis.
+    using OneElectronOperator = typename NOSBasisOperatorTraits<DerivedNonOrthogonalStateBasis>::OneElectronOperator;
+
+    // The scalar two-electron operator that can be evaluated by the non-orthogonal basis.
+    using TwoElectronOperator = typename NOSBasisOperatorTraits<DerivedNonOrthogonalStateBasis>::TwoElectronOperator;
+
+    // The vector containing the basis state of the associated type of transformations.
+    using States = std::vector<Transformation>;
+
+
+protected:
+    // The vector containing the non-orthogonal basis states.
+    States basis_states;
+
+    // The overlap operator in AO basis, constructed from the spinor/spin-orbital basis.
+    OneElectronOperator overlap_operator_AO;
+
+    // The total number of occupied orbitals.
+    size_t N;
+
+    // The threshold used to determine zero values.
+    double zero_threshold;
+
+
+public:
+    /*
+     *  MARK: Constructors
+     */
+
+    /**
+     *  Create a `SimpleNonOrthogonalStateBasis` from any number of non orthogonal states.
+     *
+     *  @param basis_state_vector                  The vector containing the non-orthogonal basis states.
+     *  @param S_AO                             The overlap operator in AO basis, constructed from the spinor/spin-orbital used to calculate the non-orthogonal states.
+     *  @param number_of_occupied_orbitals      The total number of occupied orbitals in the system.
+     *  @param threshold                           The threshold at which a value is verified to be zero or not. The default is 1e-8.
+     */
+    SimpleNonOrthogonalStateBasis<Scalar, DerivedNonOrthogonalStateBasis>(const States& basis_state_vector, const OneElectronOperator& S_AO, const size_t number_of_occupied_orbitals, const double threshold = 1e-8) :
+        basis_states {basis_state_vector},
+        overlap_operator_AO {S_AO},
+        N {number_of_occupied_orbitals},
+        zero_threshold {threshold} {
+
+        // The basis states must have the same dimensions.
+        for (size_t i = 0; i < basis_state_vector.size(); i++) {
+            if (basis_state_vector[0].dimension() != basis_state_vector[i].dimension()) {
+                throw std::invalid_argument("NonOrthogonalStateBasis<Scalar>(const States& basis_state_vector, const OneElectronOperator& S_AO, const size_t number_of_occupied_orbitals, const double threshold = 1e-8): The given basis states do not have the same dimensions.");
+            }
+        }
+    }
+
+
+    /*
+     *  MARK: Properties
+     */
+
+    /**
+     * Return the i'th basis states in the formed non-orthogonal state basis.
+     *
+     * @param i     The index of the basis state requested.
+     *
+     * @return The i'th basis state..
+     */
+    const Transformation& basisState(size_t i) const { return this->basis_states[i]; }
+
+
+    /**
+     * Return the dimension of the basis states in the formed non-orthogonal state basis.
+     *
+     * @return The dimension of the basis states.
+     *
+     * @note We return the dimension of the first state, as the constructor checks that all states have the same dimension.
+     */
+    const size_t basisStateDimension() const { return this->basis_states[0].dimension(); }
+
+    /**
+     * Return the basis states in the formed non-orthogonal state basis.
+     *
+     * @return The basis states.
+     */
+    const States& basisStates() const { return this->basis_states; }
+
+    /**
+     * Return the number of basis states in the formed non-orthogonal state basis.
+     *
+     * @return The number of basis states.
+     */
+    const size_t numberOfBasisStates() const { return this->basis_states.size(); }
+
+    /**
+     * Return the threshold used to compare values to zero associated with this non-orthogonal state basis.
+     *
+     * @return The threshold at which to evaluate zero values..
+     */
+    const double& threshold() const { return this->zero_threshold; }
+
+
+    /*
+     *  MARK: Conforming to `BasisTransformable`
+     */
+
+    /**
+     *  Apply the basis transformation and return the result.
+     *
+     *  @param T            The basis transformation.
+     *
+     *  @return The basis-transformed object.
+     */
+    DerivedNonOrthogonalStateBasis transformed(const Transformation& T) const override {
+
+        auto result = this->derived();
+
+        for (size_t i = 0; i < result.numberOfBasisStates(); i++) {
+            result.basis_states[i].transform(T);
+        }
+
+        return result;
+    }
+
+    // Allow the `rotate` method from `BasisTransformable`, since there's also a `rotate` from `JacobiRotatable`.
+    using BasisTransformable<DerivedNonOrthogonalStateBasis>::rotate;
+
+    // Allow the `rotated` method from `BasisTransformable`, since there's also a `rotated` from `JacobiRotatable`.
+    using BasisTransformable<DerivedNonOrthogonalStateBasis>::rotated;
+
+
+    /*
+     *  MARK: Conforming to `JacobiRotatable`.
+     */
+
+    /**
+     *  Apply the Jacobi rotation and return the result.
+     *
+     *  @param jacobi_rotation          The Jacobi rotation.
+     *
+     *  @return The Jacobi-rotated object.
+     */
+    DerivedNonOrthogonalStateBasis rotated(const JacobiRotationType& jacobi_rotation) const override {
+
+        const auto J = Transformation::FromJacobi(jacobi_rotation, this->basisStateDimension());
+        return this->rotated(J);
+    }
+
+    // Allow the `rotate` method from `JacobiRotatable`, since there's also a `rotate` from `BasisTransformable`.
+    using JacobiRotatable<DerivedNonOrthogonalStateBasis>::rotate;
+
+
+    /**
+     * MARK: Operator evaluations
+     */
+
+    /**
+     * Evaluate any scalar one-electron operator in this non-orthogonal state basis.
+     *
+     * @param f_op      The scalar one-electron operator to be evaluated.
+     *
+     * @return The matrix representation of this operator expressed in the non-orthogonal state basis.
+     *
+     * @note The given scalar one-electron operator must be expressed in the non-orthogonal AO basis.
+     * @note This implementation is based on equation 59 from the 2021 paper by Hugh Burton (https://aip.scitation.org/doi/abs/10.1063/5.0045442).
+     */
+    Matrix evaluateOneElectronOperator(const OneElectronOperator& f_op) const {
+
+        // We start by initializing a zero matrix of the correct dimension.
+        // Since the matrix is always squared, we only need one parameter to define its dimensions.
+        Matrix evaluated_operator = Matrix::Zero(this->numberOfBasisStates());
+
+        // Secondly, we map the operator parameters to a tensor representation.
+        // This will be necessary to perform the correct contractions.
+        Eigen::TensorMap<Eigen::Tensor<const Scalar, 2>> operator_tensor_map {f_op.parameters().data(), f_op.parameters().rows(), f_op.parameters().cols()};
+        Tensor<Scalar, 2> operator_parameters_tensor = Tensor<Scalar, 2>(operator_tensor_map);
+
+        // Loop over all basis states and calculate each matrix element using the generalized Slater-Condon rules.
+        for (size_t i = 0; i < this->numberOfBasisStates(); i++) {
+            for (size_t j = 0; j < this->numberOfBasisStates(); j++) {
+
+                // The first step is to create a biorthogonal basis from the two states that are being looped over.
+                const BiorthogonalBasis lowdin_pairing_basis {this->basisState(i).matrix(), this->basisState(j).matrix(), this->overlap_operator_AO.parameters(), this->N};
+
+                // Check the number of zeros in the biorthogonal basis, as this influences how the matrix elements are calculated.
+                const auto number_of_zeros = lowdin_pairing_basis.numberOfZeroOverlaps();
+
+                // Use the correct formula, depending on how many zero overlaps there are.
+                // If there are zero overlap values, we perform the following calculation.
+                if (number_of_zeros == 0) {
+
+                    // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap and the weighted co-density matrix from the biorthogonal basis.
+                    const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();
+                    const auto weighted_co_density = lowdin_pairing_basis.weightedCoDensity();
+
+                    // Perform the contraction.
+                    Tensor<Scalar, 0> matrix_element = reduced_overlap * operator_parameters_tensor.template einsum<2>("uv, vu ->", weighted_co_density.matrix());
+                    evaluated_operator(i, j) += matrix_element(0);
+                }
+                // If there is one zero overlap value, we perform the following calculation.
+                else if (number_of_zeros == 1) {
+
+                    // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap.
+                    const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();
+
+                    // Next, calculate the co-density matrix of the orbital corresponding to the zero overlap value.
+                    // We know there is only one zero overlap orbital, so we acces the first index of the vector.
+                    const auto zero_overlap_index = lowdin_pairing_basis.zeroOverlapIndices()[0];
+                    const auto co_density = lowdin_pairing_basis.coDensity(zero_overlap_index);
+
+                    // Perform the contraction.
+                    Tensor<Scalar, 0> matrix_element = reduced_overlap * operator_parameters_tensor.template einsum<2>("uv, vu ->", co_density.matrix());
+                    evaluated_operator(i, j) += matrix_element(0);
+                }
+                // If there are two or more zero overlap values, the matrix element will be zero. No further if-clause is needed.
+            }
+        }
+
+        // Return the matrix representation of the evaluated operator.
+        return evaluated_operator;
+    }
+
+
+    /**
+     * Evaluate any overlap operator in this non-orthogonal state basis.
+     *
+     * @return The matrix representation of this overlap operator expressed in the non-orthogonal state basis.
+     *
+     * @note This method requires no parameters, since the overlap in AO basis is a member of the non-orthogonal state basis.
+     */
+    Matrix evaluateOverlapOperator() const {
+
+        // We start by initializing a zero matrix of the correct dimension.
+        // Since the matrix is always squared, we only need one parameter to define its dimensions.
+        Matrix evaluated_overlap = Matrix::Zero(this->numberOfBasisStates());
+
+        // Loop over all basis states and calculate the correct overlap elements using the biorthogonalized basis of each combination of states.
+        for (size_t i = 0; i < this->numberOfBasisStates(); i++) {
+            for (size_t j = 0; j < this->numberOfBasisStates(); j++) {
+
+                // The first step is to create a biorthogonal basis from the two states that are being looped over.
+                const BiorthogonalBasis lowdin_pairing_basis {this->basisState(i).matrix(), this->basisState(j).matrix(), this->overlap_operator_AO.parameters(), this->N};
+
+                // Fill in the overlaps in the new matrix representation in this non-orthogonal basis.
+                evaluated_overlap(i, j) += lowdin_pairing_basis.totalOverlap();
+            }
+        }
+
+        // Return the overlap matrix.
+        return evaluated_overlap;
+    }
+
+
+    /**
+     * Evaluate any scalar two-electron operator in this non-orthogonal state basis.
+     *
+     * @param g_op      The scalar two-electron operator to be evaluated.
+     *
+     * @return The matrix representation of this operator expressed in the non-orthogonal state basis.
+     *
+     * @note The given scalar two-electron operator must be expressed in the non-orthogonal AO basis.
+     * @note This implementation is based on equation 65 from the 2021 paper by Hugh Burton (https://aip.scitation.org/doi/abs/10.1063/5.0045442).
+     */
+    Matrix evaluateTwoElectronOperator(const TwoElectronOperator& g_op) const {
+
+        // We start by initializing a zero matrix of the correct dimension.
+        // Since the matrix is always squared, we only need one parameter to define its dimensions.
+        Matrix evaluated_operator = Matrix::Zero(this->numberOfBasisStates());
+
+        // Loop over all basis states and calculate each matrix element using the generalized Slater-Condon rules.
+        for (size_t i = 0; i < this->numberOfBasisStates(); i++) {
+            for (size_t j = 0; j < this->numberOfBasisStates(); j++) {
+
+                // The first step is to create a biorthogonal basis from the two states that are being looped over.
+                const BiorthogonalBasis lowdin_pairing_basis {this->basisState(i).matrix(), this->basisState(j).matrix(), this->overlap_operator_AO.parameters(), this->N};
+
+                // Check the number of zeros in the biorthogonal basis, as this influences how the matrix elements are calculated.
+                const auto number_of_zeros = lowdin_pairing_basis.numberOfZeroOverlaps();
+
+                // Use the correct formula, depending on how many zero overlaps there are.
+                // If there are zero overlap values, we perform the following calculation.
+                if (number_of_zeros == 0) {
+
+                    // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap and the weighted co-density matrix from the biorthogonal basis.
+                    const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();
+                    const auto weighted_co_density = lowdin_pairing_basis.weightedCoDensity();
+
+                    // Perform the contractions. We need to perform two contractions (one for the direct component, one for the exchange component).
+                    // In order to perserve readability of the contractions, and keep the exact link with the theory, we split each contraction in two.
+                    Tensor<Scalar, 2> intermediate_contraction_1 = g_op.parameters().template einsum<2>("utvs, tu -> vs", weighted_co_density.matrix());
+                    Tensor<Scalar, 0> direct_element = intermediate_contraction_1.template einsum<2>("vs, sv ->", weighted_co_density.matrix());
+
+                    Tensor<Scalar, 2> intermediate_contraction_2 = g_op.parameters().template einsum<2>("utvs, su -> tv", weighted_co_density.matrix());
+                    Tensor<Scalar, 0> exchange_element = intermediate_contraction_2.template einsum<2>("tv, tv ->", weighted_co_density.matrix());
+
+                    evaluated_operator(i, j) += (0.5 * reduced_overlap * (direct_element(0) - exchange_element(0)));
+                }
+                // If there is one zero overlap value, we perform the following calculation.
+                else if (number_of_zeros == 1) {
+
+                    // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap.
+                    const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();
+
+                    // Next, calculate the weighted co-density matrix and the co-density of the orbital corresponding to the zero overlap value.
+                    // We know there is only one zero overlap orbital, so we acces the first index of the vector.
+                    const auto zero_overlap_index = lowdin_pairing_basis.zeroOverlapIndices()[0];
+                    const auto co_density = lowdin_pairing_basis.coDensity(zero_overlap_index);
+                    const auto weighted_co_density = lowdin_pairing_basis.weightedCoDensity();
+
+                    // Perform the contractions. We need to perform two contractions (one for the direct component, one for the exchange component).
+                    // In order to perserve readability of the contractions, and keep the exact link with the theory, we split each contraction in two.
+                    Tensor<Scalar, 2> intermediate_contraction_1 = g_op.parameters().template einsum<2>("utvs, tu -> vs", co_density.matrix());
+                    Tensor<Scalar, 0> direct_element = intermediate_contraction_1.template einsum<2>("vs, sv ->", weighted_co_density.matrix());
+
+                    Tensor<Scalar, 2> intermediate_contraction_2 = g_op.parameters().template einsum<2>("utvs, su -> tv", co_density.matrix());
+                    Tensor<Scalar, 0> exchange_element = intermediate_contraction_2.template einsum<2>("tv, tv ->", weighted_co_density.matrix());
+
+                    evaluated_operator(i, j) += (reduced_overlap * (direct_element(0) - exchange_element(0)));
+                }
+                // If there are two zero overlap values, we perform the following calculation.
+                else if (number_of_zeros == 2) {
+
+                    // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap.
+                    const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();
+
+                    // Next, calculate the co-density of the orbitals corresponding to the zero overlap values.
+                    // We know there are only two zero overlap orbitals, so we acces the first and second index of the vector.
+                    const auto zero_overlap_index_1 = lowdin_pairing_basis.zeroOverlapIndices()[0];
+                    const auto zero_overlap_index_2 = lowdin_pairing_basis.zeroOverlapIndices()[1];
+                    const auto co_density_1 = lowdin_pairing_basis.coDensity(zero_overlap_index_1);
+                    const auto co_density_2 = lowdin_pairing_basis.coDensity(zero_overlap_index_2);
+
+                    // Perform the contractions. We need to perform two contractions (one for the direct component, one for the exchange component).
+                    // In order to perserve readability of the contractions, and keep the exact link with the theory, we split each contraction in two.
+                    Tensor<Scalar, 2> intermediate_contraction_1 = g_op.parameters().template einsum<2>("utvs, tu -> vs", co_density_1.matrix());
+                    Tensor<Scalar, 0> direct_element = intermediate_contraction_1.template einsum<2>("vs, sv ->", co_density_2.matrix());
+
+                    Tensor<Scalar, 2> intermediate_contraction_2 = g_op.parameters().template einsum<2>("utvs, su -> tv", co_density_1.matrix());
+                    Tensor<Scalar, 0> exchange_element = intermediate_contraction_2.template einsum<2>("tv, tv ->", co_density_2.matrix());
+
+                    evaluated_operator(i, j) += (reduced_overlap * (direct_element(0) - exchange_element(0)));
+                }
+                // If there are more than two zero overlap values, the matrix element will be zero. No further if-clause is needed.
+            }
+        }
+
+        // Return the matrix representation of the evaluated operator.
+        return evaluated_operator;
+    }
+
+
+    /**
+     * Evaluate any Hamiltonian operator in this non-orthogonal state basis.
+     *
+     * @param hamiltonian                       The Hamiltonian operator to be evaluated.
+     * @param nuclear_repulsion_operator        The nuclear repulsion operator associated with the molecule used for these calculations.
+     *
+     * @return The matrix representation of this Hamiltonian expressed in the non-orthogonal state basis.
+     *
+     * @note The given Hamiltonian must be expressed in the non-orthogonal AO basis.
+     * @note In order to express the Hamiltonian in this non-orthogonal state basis, we must take the nuclear repulsion into account as well (see equation (16) in the 2018 paper (https://doi.org/10.1063/1.4999218) by Olsen et. al. for example). This is why we also give the `nuclearRepulsionOperator` as a parameter.
+     */
+    Matrix evaluateHamiltonianOperator(const Hamiltonian& hamiltonian, const NuclearRepulsionOperator& nuclear_repulsion_operator) const {
+
+        // We first require the separate one and two electron operators from the Hamiltonian we want to evaluate.
+        const auto& h = hamiltonian.core();
+        const auto& g = hamiltonian.twoElectron();
+
+        // From the nuclear repulsion operator we need the value.
+        const auto nuc_rep = nuclear_repulsion_operator.value();
+
+        // Evaluate the operators in this basis.
+        // We also need the evaluated overlap in this basis.
+        const auto h_evaluated = this->evaluateOneElectronOperator(h);
+        const auto g_evaluated = this->evaluateTwoElectronOperator(g);
+        const auto s_evaluated = this->evaluateOverlapOperator();
+
+        // Return the Hamiltonian matrix, represented in this non-orthogonal state basis.
+        return h_evaluated + g_evaluated + (nuc_rep * s_evaluated);
+    }
+};
+
+
+}  // namespace GQCP

--- a/gqcp/include/Basis/NonOrthogonalBasis/SimpleNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/SimpleNonOrthogonalStateBasis.hpp
@@ -22,7 +22,6 @@
 #include "Basis/Transformations/JacobiRotatable.hpp"
 #include "Mathematical/Representation/SquareMatrix.hpp"
 #include "Mathematical/Representation/Tensor.hpp"
-#include "Molecule/Molecule.hpp"
 #include "Operator/FirstQuantized/NuclearRepulsionOperator.hpp"
 #include "Utilities/CRTP.hpp"
 #include "Utilities/Eigen.hpp"
@@ -81,7 +80,7 @@ public:
     // The type of Jacobi rotation that is naturally related to the derived non orthogonal-basis.
     using JacobiRotationType = typename JacobiRotatableTraits<DerivedNonOrthogonalStateBasis>::JacobiRotationType;
 
-    // The second-quantized representation of the Hamiltonian that can be quantized by this basis.
+    // The second-quantized representation of the Hamiltonian that can be evaluated in this basis.
     using Hamiltonian = typename NOSBasisOperatorTraits<DerivedNonOrthogonalStateBasis>::Hamiltonian;
 
     // The scalar one-electron operator that can be evaluated by the non-orthogonal basis.

--- a/gqcp/include/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp
@@ -19,13 +19,17 @@
 
 
 #include "Basis/BiorthogonalBasis/ULowdinPairingBasis.hpp"
+#include "Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis.hpp"
 #include "Basis/Transformations/BasisTransformable.hpp"
+#include "Basis/Transformations/GTransformation.hpp"
 #include "Basis/Transformations/JacobiRotatable.hpp"
 #include "Basis/Transformations/UTransformation.hpp"
 #include "Basis/Transformations/UTransformationComponent.hpp"
+#include "Operator/FirstQuantized/NuclearRepulsionOperator.hpp"
 #include "Operator/SecondQuantized/SQHamiltonian.hpp"
 #include "Operator/SecondQuantized/USQOneElectronOperator.hpp"
 #include "Operator/SecondQuantized/USQTwoElectronOperator.hpp"
+#include "QuantumChemical/Spin.hpp"
 #include "Utilities/CRTP.hpp"
 
 
@@ -64,6 +68,9 @@ public:
     using BiorthogonalBasis = ULowdinPairingBasis<Scalar>;
 
     // The second-quantized representation of any one-electron operator operator related to the `UNonOrthogonalStateBasis`.
+    using SQOverlapOperator = ScalarUSQOneElectronOperator<Scalar>;
+
+    // The second-quantized representation of any one-electron operator operator related to the `UNonOrthogonalStateBasis`.
     using OneElectronOperator = ScalarUSQOneElectronOperator<Scalar>;
 
     // The second-quantized representation of any two-electron operator operator related to the `UNonOrthogonalStateBasis`.
@@ -84,7 +91,7 @@ protected:
     States basis_states;
 
     // The overlap operator in AO basis, constructed from the spinor/spin-orbital basis.
-    OneElectronOperator overlap_operator_AO;
+    SQOverlapOperator overlap_operator_AO;
 
     // The total number of occupied alpha orbitals.
     size_t N_a;
@@ -110,7 +117,7 @@ public:
      *  @param number_of_occupied_beta_orbitals          The total number of occupied orbitals in the system.
      *  @param threshold                                 The threshold at which a value is verified to be zero or not. The default is 1e-8.
      */
-    UNonOrthogonalStateBasis<Scalar>(const States& basis_state_vector, const OneElectronOperator& S_AO, const size_t number_of_occupied_alpha_orbitals, const size_t number_of_occupied_beta_orbitals, const double threshold = 1e-8) :
+    UNonOrthogonalStateBasis<Scalar>(const States& basis_state_vector, const SQOverlapOperator& S_AO, const size_t number_of_occupied_alpha_orbitals, const size_t number_of_occupied_beta_orbitals, const double threshold = 1e-8) :
         basis_states {basis_state_vector},
         overlap_operator_AO {S_AO},
         N_a {number_of_occupied_alpha_orbitals},
@@ -120,7 +127,7 @@ public:
         // The basis states must have the same dimensions.
         for (size_t i = 0; i < basis_state_vector.size(); i++) {
             if (basis_state_vector[0].alpha().dimension() != basis_state_vector[i].alpha().dimension()) {
-                throw std::invalid_argument("NonOrthogonalStateBasis<Scalar>(const States& basis_state_vector, const OneElectronOperator& S_AO, const size_t number_of_occupied_orbitals, const double threshold = 1e-8): The given basis states do not have the same dimensions.");
+                throw std::invalid_argument("NonOrthogonalStateBasis<Scalar>(const States& basis_state_vector, const SQOverlapOperator& S_AO, const size_t number_of_occupied_orbitals, const double threshold = 1e-8): The given basis states do not have the same dimensions.");
             }
         }
     }
@@ -171,7 +178,7 @@ public:
     const double& threshold() const { return this->zero_threshold; }
 
 
-    /*
+    /**
      *  MARK: Conforming to `BasisTransformable`
      */
 
@@ -200,7 +207,7 @@ public:
     using BasisTransformable<Self>::rotated;
 
 
-    /*
+    /**
      *  MARK: Conforming to `JacobiRotatable`.
      */
 
@@ -222,10 +229,314 @@ public:
 
     // Allow the `rotate` method from `JacobiRotatable`, since there's also a `rotate` from `BasisTransformable`.
     using JacobiRotatable<Self>::rotate;
+
+
+    /**
+     * MARK: Operator Evaluations
+     */
+
+    /**
+     * Evaluate any Hamiltonian operator in this non-orthogonal state basis.
+     *
+     * @param hamiltonian                       The Hamiltonian operator to be evaluated.
+     * @param nuclear_repulsion_operator        The nuclear repulsion operator associated with the molecule used for these calculations.
+     *
+     * @return The matrix representation of this Hamiltonian expressed in the non-orthogonal state basis.
+     *
+     * @note The given Hamiltonian must be expressed in the non-orthogonal AO basis.
+     * @note In order to express the Hamiltonian in this non-orthogonal state basis, we must take the nuclear repulsion into account as well (see equation (16) in the 2018 paper (https://doi.org/10.1063/1.4999218) by Olsen et. al. for example). This is why we also give the `nuclearRepulsionOperator` as a parameter.
+     */
+    Matrix evaluateHamiltonianOperator(const Hamiltonian& hamiltonian, const NuclearRepulsionOperator& nuclear_repulsion_operator) const {
+
+        // We first require the separate one and two electron operators from the Hamiltonian we want to evaluate.
+        const auto& h = hamiltonian.core();
+        const auto& g = hamiltonian.twoElectron();
+
+        // From the nuclear repulsion operator we need the value.
+        const auto nuc_rep = nuclear_repulsion_operator.value();
+
+        // Evaluate the operators in this basis.
+        // We also need the evaluated overlap in this basis.
+        const auto h_evaluated = this->evaluateOneElectronOperator(h);
+        const auto g_evaluated = this->evaluateTwoElectronOperator(g);
+        const auto s_evaluated = this->evaluateOverlapOperator();
+
+        // Return the Hamiltonian matrix, represented in this non-orthogonal state basis.
+        return h_evaluated + g_evaluated + (nuc_rep * s_evaluated);
+    }
+
+
+    /**
+     * Evaluate any scalar one-electron operator in this non-orthogonal state basis.
+     *
+     * @param f_op      The scalar one-electron operator to be evaluated.
+     *
+     * @return The matrix representation of this operator expressed in the non-orthogonal state basis.
+     *
+     * @note The given scalar one-electron operator must be expressed in the non-orthogonal AO basis.
+     * @note This implementation is based on equation 59 from the 2021 paper by Hugh Burton (https://aip.scitation.org/doi/abs/10.1063/5.0045442).
+     */
+    Matrix evaluateOneElectronOperator(const OneElectronOperator& f_op) const {
+
+        // We start by initializing a zero matrix of the correct dimension.
+        // Since the matrix is always squared, we only need one parameter to define its dimensions.
+        Matrix evaluated_operator = Matrix::Zero(this->numberOfBasisStates());
+
+        // Secondly, we map the operator parameters to a tensor representation.
+        // This will be necessary to perform the correct contractions.
+        Eigen::TensorMap<Eigen::Tensor<const Scalar, 2>> operator_tensor_map_alpha {f_op.alpha().parameters().data(), f_op.alpha().parameters().rows(), f_op.alpha().parameters().cols()};
+        Tensor<Scalar, 2> operator_parameters_tensor_alpha = Tensor<Scalar, 2>(operator_tensor_map_alpha);
+
+        Eigen::TensorMap<Eigen::Tensor<const Scalar, 2>> operator_tensor_map_beta {f_op.beta().parameters().data(), f_op.beta().parameters().rows(), f_op.beta().parameters().cols()};
+        Tensor<Scalar, 2> operator_parameters_tensor_beta = Tensor<Scalar, 2>(operator_tensor_map_beta);
+
+        // Loop over all basis states and calculate each matrix element using the generalized Slater-Condon rules.
+        for (size_t i = 0; i < this->numberOfBasisStates(); i++) {
+            for (size_t j = 0; j < this->numberOfBasisStates(); j++) {
+
+                // The first step is to create a biorthogonal basis from the two states that are being looped over.
+                const BiorthogonalBasis lowdin_pairing_basis {this->basisState(i), this->basisState(j), this->overlap_operator_AO, this->N_a, this->N_b};
+
+                // Check the number of zeros in the biorthogonal basis, as this influences how the matrix elements are calculated.
+                const auto number_of_zeros = lowdin_pairing_basis.numberOfZeroOverlaps();
+
+                // Use the correct formula, depending on how many zero overlaps there are.
+                // If there are zero overlap values, we perform the following calculation.
+                if (number_of_zeros == 0) {
+
+                    // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap and the weighted co-density matrix from the biorthogonal basis.
+                    const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();
+                    const auto weighted_co_density_alpha = lowdin_pairing_basis.weightedCoDensity().alpha();
+                    const auto weighted_co_density_beta = lowdin_pairing_basis.weightedCoDensity().beta();
+
+                    // Perform the contraction.
+                    Tensor<Scalar, 0> matrix_element_alpha = operator_parameters_tensor_alpha.template einsum<2>("uv, vu ->", weighted_co_density_alpha.matrix());
+                    Tensor<Scalar, 0> matrix_element_beta = operator_parameters_tensor_beta.template einsum<2>("uv, vu ->", weighted_co_density_beta.matrix());
+
+                    evaluated_operator(i, j) += reduced_overlap * (matrix_element_alpha(0) + matrix_element_beta(0));
+                }
+                // If there is one zero overlap value, we perform the following calculation.
+                else if (number_of_zeros == 1) {
+
+                    // Determine whether the zero stems from the alpha or the beta component.
+                    auto zero_spin = Spin::alpha;
+                    if (lowdin_pairing_basis.numberOfZeroOverlaps(Spin::beta) > lowdin_pairing_basis.numberOfZeroOverlaps(Spin::alpha)) {
+                        zero_spin = Spin::beta;
+                    }
+
+                    // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap.
+                    const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap(zero_spin);
+
+                    // Next, calculate the co-density matrix of the orbital corresponding to the zero overlap value.
+                    // We know there is only one zero overlap orbital, so we acces the first index of the vector.
+                    const auto zero_overlap_index = lowdin_pairing_basis.zeroOverlapIndices(zero_spin)[0];
+                    const auto co_density = lowdin_pairing_basis.coDensity(zero_overlap_index).component(zero_spin);
+
+                    auto matrix_element = 0.0;
+
+                    // Perform the contraction.
+                    if (zero_spin == Spin::alpha) {
+                        Tensor<Scalar, 0> element = operator_parameters_tensor_alpha.template einsum<2>("uv, vu ->", co_density.matrix());
+                        matrix_element += element(0);
+                    } else {
+                        Tensor<Scalar, 0> element = operator_parameters_tensor_beta.template einsum<2>("uv, vu ->", co_density.matrix());
+                        matrix_element += element(0);
+                    }
+
+                    evaluated_operator(i, j) += reduced_overlap * matrix_element;
+                }
+                // If there are two or more zero overlap values, the matrix element will be zero. No further if-clause is needed.
+            }
+        }
+
+        // Return the matrix representation of the evaluated operator.
+        return evaluated_operator;
+    }
+
+
+    /**
+     * Evaluate any overlap operator in this non-orthogonal state basis.
+     *
+     * @return The matrix representation of this overlap operator expressed in the non-orthogonal state basis.
+     *
+     * @note This method requires no parameters, since the overlap in AO basis is a member of the non-orthogonal state basis.
+     */
+    Matrix evaluateOverlapOperator() const {
+
+        // We start by initializing a zero matrix of the correct dimension.
+        // Since the matrix is always squared, we only need one parameter to define its dimensions.
+        Matrix evaluated_overlap = Matrix::Zero(this->numberOfBasisStates());
+
+        // Loop over all basis states and calculate the correct overlap elements using the biorthogonalized basis of each combination of states.
+        for (size_t i = 0; i < this->numberOfBasisStates(); i++) {
+            for (size_t j = 0; j < this->numberOfBasisStates(); j++) {
+
+                // The first step is to create a biorthogonal basis from the two states that are being looped over.
+                const BiorthogonalBasis lowdin_pairing_basis {this->basisState(i), this->basisState(j), this->overlap_operator_AO, this->N_a, this->N_b};
+
+                // Fill in the overlaps in the new matrix representation in this non-orthogonal basis.
+                evaluated_overlap(i, j) += lowdin_pairing_basis.totalOverlap();
+            }
+        }
+
+        // Return the overlap matrix.
+        return evaluated_overlap;
+    }
+
+
+    /**
+     * Evaluate any scalar two-electron operator in this non-orthogonal state basis.
+     *
+     * @param g_op      The scalar two-electron operator to be evaluated.
+     *
+     * @return The matrix representation of this operator expressed in the non-orthogonal state basis.
+     *
+     * @note The given scalar two-electron operator must be expressed in the non-orthogonal AO basis.
+     * @note This implementation is based on equation 65 from the 2021 paper by Hugh Burton (https://aip.scitation.org/doi/abs/10.1063/5.0045442).
+     * @note This implementation only works for two electron operators where the mixed components are equal to zero.
+     */
+    Matrix evaluateTwoElectronOperator(const TwoElectronOperator& g_op) const {
+
+        // We start by initializing a zero matrix of the correct dimension.
+        // Since the matrix is always squared, we only need one parameter to define its dimensions.
+        Matrix evaluated_operator = Matrix::Zero(this->numberOfBasisStates());
+
+        // Loop over all basis states and calculate each matrix element using the generalized Slater-Condon rules.
+        for (size_t i = 0; i < this->numberOfBasisStates(); i++) {
+            for (size_t j = 0; j < this->numberOfBasisStates(); j++) {
+
+                // The first step is to create a biorthogonal basis from the two states that are being looped over.
+                const BiorthogonalBasis lowdin_pairing_basis {this->basisState(i), this->basisState(j), this->overlap_operator_AO, this->N_a, this->N_b};
+
+                // Check the number of zeros in the biorthogonal basis, as this influences how the matrix elements are calculated.
+                const auto number_of_zeros = lowdin_pairing_basis.numberOfZeroOverlaps();
+
+                // Use the correct formula, depending on how many zero overlaps there are.
+                // If there are zero overlap values, we perform the following calculation.
+                if (number_of_zeros == 0) {
+
+                    // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap and the weighted co-density matrix from the biorthogonal basis.
+                    const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();
+                    const auto weighted_co_density = lowdin_pairing_basis.weightedCoDensity();
+
+                    // Perform the contractions. We need to perform two contractions (one for the direct component, one for the exchange component).
+                    // In order to perserve readability of the contractions, and keep the exact link with the theory, we split each contraction in two.
+                    Matrix intermediate_direct_contraction_1 = g_op.alphaAlpha().parameters().template einsum<2>("utvs, tu -> vs", weighted_co_density.alpha().matrix()).asMatrix();
+                    Matrix intermediate_direct_contraction_2 = g_op.betaBeta().parameters().template einsum<2>("utvs, tu -> vs", weighted_co_density.beta().matrix()).asMatrix();
+
+                    // The complete first direct contraction can the be written as follows.
+                    Matrix direct_alpha_beta = intermediate_direct_contraction_1 + intermediate_direct_contraction_2;
+
+                    // We return the representation to a tensor, in order to perform the final contractions.
+                    Eigen::TensorMap<Eigen::Tensor<const Scalar, 2>> tensor_map {direct_alpha_beta.data(), direct_alpha_beta.rows(), direct_alpha_beta.cols()};
+                    Tensor<Scalar, 2> direct_alpha_beta_tensor = Tensor<Scalar, 2>(tensor_map);
+
+                    // We can now calculate the alpha and beta contributions with the next set of contractions.
+                    Tensor<Scalar, 0> direct_element_a = direct_alpha_beta_tensor.template einsum<2>("vs, sv ->", weighted_co_density.alpha().matrix());
+                    Tensor<Scalar, 0> direct_element_b = direct_alpha_beta_tensor.template einsum<2>("vs, sv ->", weighted_co_density.beta().matrix());
+
+                    const auto direct_element = direct_element_a(0) + direct_element_b(0);
+
+                    // Next, we calculate the exchange elements.
+                    Tensor<Scalar, 2> intermediate_exchange_contraction_1 = g_op.alphaAlpha().parameters().template einsum<2>("utvs, su -> tv", weighted_co_density.alpha().matrix());
+                    Tensor<Scalar, 0> exchange_element_a = intermediate_exchange_contraction_1.template einsum<2>("tv, tv ->", weighted_co_density.alpha().matrix());
+
+                    Tensor<Scalar, 2> intermediate_exchange_contraction_2 = g_op.betaBeta().parameters().template einsum<2>("utvs, su -> tv", weighted_co_density.beta().matrix());
+                    Tensor<Scalar, 0> exchange_element_b = intermediate_exchange_contraction_2.template einsum<2>("tv, tv ->", weighted_co_density.beta().matrix());
+
+                    // We can now add the total contrinution to the corresponding metrix element.
+                    evaluated_operator(i, j) += 0.5 * reduced_overlap * (direct_element - exchange_element_a(0) - exchange_element_b(0));
+                }
+                // If there is one zero overlap value, we perform the following calculation.
+                else if (number_of_zeros == 1) {
+
+                    // Determine whether the zero stems from the alpha or the beta component.
+                    auto zero_spin = Spin::alpha;
+                    auto non_zero_spin = Spin::beta;
+
+                    if (lowdin_pairing_basis.numberOfZeroOverlaps(Spin::beta) > lowdin_pairing_basis.numberOfZeroOverlaps(Spin::alpha)) {
+                        zero_spin = Spin::beta;
+                        non_zero_spin = Spin::alpha;
+                    }
+
+                    // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap.
+                    const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();
+
+                    // Next, calculate the weighted co-density matrix and the co-density of the orbital corresponding to the zero overlap value.
+                    // We know there is only one zero overlap orbital, so we acces the first index of the vector.
+                    const auto zero_overlap_index = lowdin_pairing_basis.zeroOverlapIndices(zero_spin)[0];
+                    const auto co_density = lowdin_pairing_basis.coDensity(zero_overlap_index).component(zero_spin);
+                    const auto weighted_co_density = lowdin_pairing_basis.weightedCoDensity();
+
+                    // Perform the contractions. We need to perform two contractions (one for the direct component, one for the exchange component).
+                    // In order to perserve readability of the contractions, and keep the exact link with the theory, we split each contraction in two.
+                    Tensor<Scalar, 2> intermediate_direct_contraction_1 = g_op.alphaAlpha().parameters().template einsum<2>("utvs, tu -> vs", co_density.matrix());
+                    Tensor<Scalar, 0> direct_element_a = intermediate_direct_contraction_1.template einsum<2>("vs, sv ->", weighted_co_density.alpha().matrix());
+
+                    Tensor<Scalar, 2> intermediate_direct_contraction_2 = g_op.betaBeta().parameters().template einsum<2>("utvs, tu -> vs", co_density.matrix());
+                    Tensor<Scalar, 0> direct_element_b = intermediate_direct_contraction_2.template einsum<2>("vs, sv ->", weighted_co_density.beta().matrix());
+
+                    auto direct_element = direct_element_a(0) + direct_element_b(0);
+
+                    Tensor<Scalar, 2> intermediate_exchange_contraction = g_op.pureComponent(zero_spin).parameters().template einsum<2>("utvs, su -> tv", co_density.matrix());
+                    Tensor<Scalar, 0> exchange_element = intermediate_exchange_contraction.template einsum<2>("tv, tv ->", weighted_co_density.component(zero_spin).matrix());
+
+                    evaluated_operator(i, j) += (reduced_overlap * (direct_element - exchange_element(0)));
+                }
+                // If there are two zero overlap values, we perform the following calculation.
+                else if (number_of_zeros == 2) {
+
+                    // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap.
+                    const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();
+
+                    // First we merge the alpha and beta index vectors which denote the zero overlaps.
+                    // Next, calculate the co-density of the orbitals corresponding to the zero overlap values.
+                    const auto zero_overlap_index_1 = lowdin_pairing_basis.zeroOverlapIndices()[0].first;
+                    const auto zero_overlap_index_2 = lowdin_pairing_basis.zeroOverlapIndices()[1].first;
+                    const auto co_density_1 = lowdin_pairing_basis.coDensity(zero_overlap_index_1);
+
+                    Matrix active_co_density = Matrix::Zero(co_density_1.alpha().matrix().dimension());
+
+                    if (lowdin_pairing_basis.zeroOverlapIndices()[0].second == Spin::alpha) {
+                        active_co_density += lowdin_pairing_basis.coDensity(zero_overlap_index_2).alpha().matrix();
+                    } else {
+                        active_co_density += lowdin_pairing_basis.coDensity(zero_overlap_index_2).beta().matrix();
+                    }
+
+                    // Perform the contractions. We need to perform two contractions (one for the direct component, one for the exchange component).
+                    // In order to perserve readability of the contractions, and keep the exact link with the theory, we split each contraction in two.
+                    Tensor<Scalar, 2> intermediate_direct_contraction_1 = g_op.alphaAlpha().parameters().template einsum<2>("utvs, tu -> vs", co_density_1.alpha().matrix());
+                    Tensor<Scalar, 0> direct_element_a = intermediate_direct_contraction_1.template einsum<2>("vs, sv ->", active_co_density);
+
+                    Tensor<Scalar, 2> intermediate_direct_contraction_2 = g_op.betaBeta().parameters().template einsum<2>("utvs, tu -> vs", co_density_1.beta().matrix());
+                    Tensor<Scalar, 0> direct_element_b = intermediate_direct_contraction_2.template einsum<2>("vs, sv ->", active_co_density);
+
+                    auto direct_element = direct_element_a(0) + direct_element_b(0);
+
+                    auto exchange_element = 0.0;
+                    if (lowdin_pairing_basis.zeroOverlapIndices()[0].second == Spin::alpha) {
+                        Tensor<Scalar, 2> intermediate_exchange_contraction = g_op.pureComponent(Spin::alpha).parameters().template einsum<2>("utvs, su -> tv", co_density_1.alpha().matrix());
+                        Tensor<Scalar, 0> element = intermediate_exchange_contraction.template einsum<2>("tv, tv ->", active_co_density);
+                        exchange_element += element(0);
+                    } else {
+                        Tensor<Scalar, 2> intermediate_exchange_contraction = g_op.pureComponent(Spin::beta).parameters().template einsum<2>("utvs, su -> tv", co_density_1.beta().matrix());
+                        Tensor<Scalar, 0> element = intermediate_exchange_contraction.template einsum<2>("tv, tv ->", active_co_density);
+                        exchange_element += element(0);
+                    }
+
+                    evaluated_operator(i, j) += (reduced_overlap * (direct_element - exchange_element));
+                }
+                // If there are more than two zero overlap values, the matrix element will be zero. No further if-clause is needed.
+            }
+        }
+
+        // Return the matrix representation of the evaluated operator.
+        return evaluated_operator;
+    }
 };
 
 
-/*
+/**
  *  MARK: JacobiRotatableTraits
  */
 
@@ -240,7 +551,7 @@ struct JacobiRotatableTraits<UNonOrthogonalStateBasis<_Scalar>> {
 };
 
 
-/*
+/**
  *  MARK: BasisTransformableTraits
  */
 

--- a/gqcp/include/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp
@@ -475,7 +475,7 @@ public:
                     // We can now calculate the next contraction of the equation.
                     GQCP::Tensor<Scalar, 0> direct_element = direct_alpha_beta_tensor.template einsum<2>("ut, ut ->", co_density.matrix());
 
-// We calculate the exchange contractions analogously.
+                    // We calculate the exchange contractions analogously.
                     Tensor<Scalar, 2> intermediate_exchange_contraction = g_op.pureComponent(zero_spin).parameters().template einsum<2>("utvs, tv -> us", weighted_co_density.component(zero_spin).matrix());
                     Tensor<Scalar, 0> exchange_element = intermediate_exchange_contraction.template einsum<2>("us, us ->", co_density.matrix());
 
@@ -512,7 +512,7 @@ public:
                     // We can now calculate the next contraction of the equation..
                     Tensor<Scalar, 0> direct_element = direct_alpha_beta_tensor.template einsum<2>("vs, sv ->", active_co_density.matrix());
 
-// We calculate the exchange contractions analogously.
+                    // We calculate the exchange contractions analogously.
                     Tensor<Scalar, 2> intermediate_exchange_contraction = g_op.pureComponent(zero_overlap_spin_1).parameters().template einsum<2>("utvs, su -> tv", co_density_1.component(zero_overlap_spin_1).matrix());
                     Tensor<Scalar, 0> exchange_element = intermediate_exchange_contraction.template einsum<2>("tv, tv ->", active_co_density.matrix());
 

--- a/gqcp/include/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp
@@ -1,0 +1,258 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+
+#include "Basis/BiorthogonalBasis/ULowdinPairingBasis.hpp"
+#include "Basis/Transformations/BasisTransformable.hpp"
+#include "Basis/Transformations/JacobiRotatable.hpp"
+#include "Basis/Transformations/UTransformation.hpp"
+#include "Basis/Transformations/UTransformationComponent.hpp"
+#include "Operator/SecondQuantized/SQHamiltonian.hpp"
+#include "Operator/SecondQuantized/USQOneElectronOperator.hpp"
+#include "Operator/SecondQuantized/USQTwoElectronOperator.hpp"
+#include "Utilities/CRTP.hpp"
+
+
+namespace GQCP {
+
+
+/*
+ *  MARK: UNonOrthogonalStateBasis
+ */
+
+/**
+ *  A basis formed by any number of non-orthogonal states, in the form of `UTransformation`s.
+ *
+ *  @tparam _ExpansionScalar        The scalar type used to represent the expansion coefficients of the given non-orthogonal states: real or complex.
+ */
+template <typename _Scalar>
+class UNonOrthogonalStateBasis:
+    public CRTP<UNonOrthogonalStateBasis<_Scalar>>,
+    public BasisTransformable<UNonOrthogonalStateBasis<_Scalar>>,
+    public JacobiRotatable<UNonOrthogonalStateBasis<_Scalar>> {
+
+public:
+    // The scalar type used to represent the expansion coefficients of the given non-orthogonal states: real or complex.
+    using Scalar = _Scalar;
+
+    // The type of matrix associated with this kind of NonOrthogonalStateBasis.
+    using Matrix = SquareMatrix<Scalar>;
+
+    // The type of transformation that is naturally related to a `NonOrthogonalStateBasis`.
+    using Transformation = UTransformation<Scalar>;
+
+    // The type of non-orthogonal state basis this is.
+    using Self = UNonOrthogonalStateBasis<Scalar>;
+
+    // The biorthogonal basis related to the basis states in this type of non-orthogonal basis.
+    using BiorthogonalBasis = ULowdinPairingBasis<Scalar>;
+
+    // The second-quantized representation of any one-electron operator operator related to the `UNonOrthogonalStateBasis`.
+    using OneElectronOperator = ScalarUSQOneElectronOperator<Scalar>;
+
+    // The second-quantized representation of any two-electron operator operator related to the `UNonOrthogonalStateBasis`.
+    using TwoElectronOperator = ScalarUSQTwoElectronOperator<Scalar>;
+
+    // The second-quantized representation of the Hamiltonian that can be evaluated in this basis.
+    using Hamiltonian = USQHamiltonian<Scalar>;
+
+    // The type of Jacobi rotation that is naturally related to the derived non orthogonal-basis.
+    using JacobiRotationType = typename JacobiRotatableTraits<Self>::JacobiRotationType;
+
+    // The vector containing the basis state of the associated type of transformations.
+    using States = std::vector<Transformation>;
+
+
+protected:
+    // The vector containing the non-orthogonal basis states.
+    States basis_states;
+
+    // The overlap operator in AO basis, constructed from the spinor/spin-orbital basis.
+    OneElectronOperator overlap_operator_AO;
+
+    // The total number of occupied alpha orbitals.
+    size_t N_a;
+
+    // The total number of occupied beta orbitals.
+    size_t N_b;
+
+    // The threshold used to determine zero values.
+    double zero_threshold;
+
+
+public:
+    /*
+     *  MARK: Constructors
+     */
+
+    /**
+     *  Create a `UNonOrthogonalStateBasis` from any number of non orthogonal states.
+     *
+     *  @param basis_state_vector                        The vector containing the non-orthogonal basis states.
+     *  @param S_AO                                      The overlap operator in AO basis, constructed from the spinor/spin-orbital used to calculate the non-orthogonal states.
+     *  @param number_of_occupied_alpha_orbitals         The total number of occupied orbitals in the system.
+     *  @param number_of_occupied_beta_orbitals          The total number of occupied orbitals in the system.
+     *  @param threshold                                 The threshold at which a value is verified to be zero or not. The default is 1e-8.
+     */
+    UNonOrthogonalStateBasis<Scalar>(const States& basis_state_vector, const OneElectronOperator& S_AO, const size_t number_of_occupied_alpha_orbitals, const size_t number_of_occupied_beta_orbitals, const double threshold = 1e-8) :
+        basis_states {basis_state_vector},
+        overlap_operator_AO {S_AO},
+        N_a {number_of_occupied_alpha_orbitals},
+        N_b {number_of_occupied_beta_orbitals},
+        zero_threshold {threshold} {
+
+        // The basis states must have the same dimensions.
+        for (size_t i = 0; i < basis_state_vector.size(); i++) {
+            if (basis_state_vector[0].alpha().dimension() != basis_state_vector[i].alpha().dimension()) {
+                throw std::invalid_argument("NonOrthogonalStateBasis<Scalar>(const States& basis_state_vector, const OneElectronOperator& S_AO, const size_t number_of_occupied_orbitals, const double threshold = 1e-8): The given basis states do not have the same dimensions.");
+            }
+        }
+    }
+
+
+    /*
+     *  MARK: Properties
+     */
+
+    /**
+     * Return the i'th basis states in the formed non-orthogonal state basis.
+     *
+     * @param i     The index of the basis state requested.
+     *
+     * @return The i'th basis state..
+     */
+    const Transformation& basisState(size_t i) const { return this->basis_states[i]; }
+
+
+    /**
+     * Return the dimension of the basis states in the formed non-orthogonal state basis.
+     *
+     * @return The dimension of the basis states.
+     *
+     * @note We return the dimension of the first state, as the constructor checks that all states have the same dimension. We also assume the alpha and beta part have the same dimension.
+     */
+    const size_t basisStateDimension() const { return this->basis_states[0].alpha().dimension(); }
+
+    /**
+     * Return the basis states in the formed non-orthogonal state basis.
+     *
+     * @return The basis states.
+     */
+    const States& basisStates() const { return this->basis_states; }
+
+    /**
+     * Return the number of basis states in the formed non-orthogonal state basis.
+     *
+     * @return The number of basis states.
+     */
+    const size_t numberOfBasisStates() const { return this->basis_states.size(); }
+
+    /**
+     * Return the threshold used to compare values to zero associated with this non-orthogonal state basis.
+     *
+     * @return The threshold at which to evaluate zero values..
+     */
+    const double& threshold() const { return this->zero_threshold; }
+
+
+    /*
+     *  MARK: Conforming to `BasisTransformable`
+     */
+
+    /**
+     *  Apply the basis transformation and return the result.
+     *
+     *  @param T            The basis transformation.
+     *
+     *  @return The basis-transformed object.
+     */
+    Self transformed(const Transformation& T) const override {
+
+        auto result = this->derived();
+
+        for (size_t i = 0; i < result.numberOfBasisStates(); i++) {
+            result.basis_states[i].transform(T);
+        }
+
+        return result;
+    }
+
+    // Allow the `rotate` method from `BasisTransformable`, since there's also a `rotate` from `JacobiRotatable`.
+    using BasisTransformable<Self>::rotate;
+
+    // Allow the `rotated` method from `BasisTransformable`, since there's also a `rotated` from `JacobiRotatable`.
+    using BasisTransformable<Self>::rotated;
+
+
+    /*
+     *  MARK: Conforming to `JacobiRotatable`.
+     */
+
+    /**
+     *  Apply the Jacobi rotation and return the result.
+     *
+     *  @param jacobi_rotation          The Jacobi rotation.
+     *
+     *  @return The Jacobi-rotated object.
+     */
+    Self rotated(const JacobiRotationType& jacobi_rotation) const override {
+
+        const auto Ja = UTransformationComponent<Scalar>::FromJacobi(jacobi_rotation, this->basisStateDimension());
+        const auto Jb = UTransformationComponent<Scalar>::FromJacobi(jacobi_rotation, this->basisStateDimension());
+        Transformation J {Ja, Jb};
+
+        return this->rotated(J);
+    }
+
+    // Allow the `rotate` method from `JacobiRotatable`, since there's also a `rotate` from `BasisTransformable`.
+    using JacobiRotatable<Self>::rotate;
+};
+
+
+/*
+ *  MARK: JacobiRotatableTraits
+ */
+
+/**
+ *  A type that provides compile-time information related to the abstract interface `JacobiRotatable`.
+ */
+template <typename _Scalar>
+struct JacobiRotatableTraits<UNonOrthogonalStateBasis<_Scalar>> {
+
+    // The type of Jacobi rotation that is naturally related to a `RNonOrthogonalStateBasis`.
+    using JacobiRotationType = JacobiRotation;
+};
+
+
+/*
+ *  MARK: BasisTransformableTraits
+ */
+
+/**
+ *  A type that provides compile-time information related to the abstract interface `BasisTransformable`.
+ */
+template <typename _Scalar>
+struct BasisTransformableTraits<UNonOrthogonalStateBasis<_Scalar>> {
+
+    // The type of transformation that is naturally related to a `RNonOrthogonalStateBAsis`.
+    using Transformation = UTransformation<_Scalar>;
+};
+
+
+}  // namespace GQCP

--- a/gqcp/include/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp
@@ -451,13 +451,7 @@ public:
                 else if (number_of_zeros == 1) {
 
                     // Determine whether the zero stems from the alpha or the beta component.
-                    auto zero_spin = Spin::alpha;
-                    auto non_zero_spin = Spin::beta;
-
-                    if (lowdin_pairing_basis.numberOfZeroOverlaps(Spin::beta) > lowdin_pairing_basis.numberOfZeroOverlaps(Spin::alpha)) {
-                        zero_spin = Spin::beta;
-                        non_zero_spin = Spin::alpha;
-                    }
+                    auto zero_spin = lowdin_pairing_basis.zeroOverlapIndices()[0].second;
 
                     // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap.
                     const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();

--- a/gqcp/include/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp
+++ b/gqcp/include/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp
@@ -127,7 +127,7 @@ public:
         // The basis states must have the same dimensions.
         for (size_t i = 0; i < basis_state_vector.size(); i++) {
             if (basis_state_vector[0].alpha().dimension() != basis_state_vector[i].alpha().dimension()) {
-                throw std::invalid_argument("NonOrthogonalStateBasis<Scalar>(const States& basis_state_vector, const SQOverlapOperator& S_AO, const size_t number_of_occupied_orbitals, const double threshold = 1e-8): The given basis states do not have the same dimensions.");
+                throw std::invalid_argument("UNonOrthogonalStateBasis<Scalar>(const States& basis_state_vector, const SQOverlapOperator& S_AO, const size_t number_of_occupied_alpha_orbitals, const size_t number_of_occupied_beta_orbital, const double threshold = 1e-8): The given basis states do not have the same dimensions.");
             }
         }
     }
@@ -319,7 +319,7 @@ public:
                 else if (number_of_zeros == 1) {
 
                     // Determine whether the zero stems from the alpha or the beta component.
-                    auto zero_spin = lowdin_pairing_basis.zeroOverlapIndices()[0].second;
+                    const auto zero_spin = lowdin_pairing_basis.zeroOverlapIndices()[0].second;
 
                     // In order to calcluate the matrix element, we need the reduced overlap.
                     const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();
@@ -448,7 +448,7 @@ public:
                 else if (number_of_zeros == 1) {
 
                     // Determine whether the zero stems from the alpha or the beta component.
-                    auto zero_spin = lowdin_pairing_basis.zeroOverlapIndices()[0].second;
+                    const auto zero_spin = lowdin_pairing_basis.zeroOverlapIndices()[0].second;
 
                     // In order to calcluate the matrix element when there are no zero overlap values, we need the reduced overlap.
                     const auto reduced_overlap = lowdin_pairing_basis.reducedOverlap();
@@ -472,9 +472,10 @@ public:
                     Eigen::TensorMap<Eigen::Tensor<const Scalar, 2>> tensor_map {direct_alpha_beta.data(), direct_alpha_beta.rows(), direct_alpha_beta.cols()};
                     Tensor<Scalar, 2> direct_alpha_beta_tensor = Tensor<Scalar, 2>(tensor_map);
 
-                    // We can now calculate the alpha and beta contributions with the next set of contractions.
+                    // We can now calculate the next contraction of the equation.
                     GQCP::Tensor<Scalar, 0> direct_element = direct_alpha_beta_tensor.template einsum<2>("ut, ut ->", co_density.matrix());
 
+// We calculate the exchange contractions analogously.
                     Tensor<Scalar, 2> intermediate_exchange_contraction = g_op.pureComponent(zero_spin).parameters().template einsum<2>("utvs, tv -> us", weighted_co_density.component(zero_spin).matrix());
                     Tensor<Scalar, 0> exchange_element = intermediate_exchange_contraction.template einsum<2>("us, us ->", co_density.matrix());
 
@@ -508,9 +509,10 @@ public:
                     Eigen::TensorMap<Eigen::Tensor<const Scalar, 2>> tensor_map {direct_alpha_beta.data(), direct_alpha_beta.rows(), direct_alpha_beta.cols()};
                     Tensor<Scalar, 2> direct_alpha_beta_tensor = Tensor<Scalar, 2>(tensor_map);
 
-                    // We can now calculate the alpha and beta contributions with the next set of contractions.
+                    // We can now calculate the next contraction of the equation..
                     Tensor<Scalar, 0> direct_element = direct_alpha_beta_tensor.template einsum<2>("vs, sv ->", active_co_density.matrix());
 
+// We calculate the exchange contractions analogously.
                     Tensor<Scalar, 2> intermediate_exchange_contraction = g_op.pureComponent(zero_overlap_spin_1).parameters().template einsum<2>("utvs, su -> tv", co_density_1.component(zero_overlap_spin_1).matrix());
                     Tensor<Scalar, 0> exchange_element = intermediate_exchange_contraction.template einsum<2>("tv, tv ->", active_co_density.matrix());
 

--- a/gqcp/include/QuantumChemical/DoublySpinResolvedBase.hpp
+++ b/gqcp/include/QuantumChemical/DoublySpinResolvedBase.hpp
@@ -129,7 +129,7 @@ public:
     /**
      *  @param sigma     The spin sigma for which the pure component is asked.
      *
-     *  @return A read-only reference to the alpha-alpha object.
+     *  @return A read-only reference to the pure alpha-alpha or beta-beta object.
      */
     const Pure& pureComponent(const Spin& sigma) const {
 
@@ -143,7 +143,7 @@ public:
     /**
      *  @param sigma     The spin sigma for which the pure component is asked.
      *
-     *  @return A writable reference to the alpha-alpha object.
+     *  @return A writable reference to the pure alpha-alpha or beta-beta object.
      */
     Pure& pureComponent(const Spin& sigma) {
 

--- a/gqcp/include/QuantumChemical/DoublySpinResolvedBase.hpp
+++ b/gqcp/include/QuantumChemical/DoublySpinResolvedBase.hpp
@@ -27,7 +27,7 @@ namespace GQCP {
 
 /**
  *  A utility type encapsulating four objects, each for every combination of alpha and beta.
- * 
+ *
  *  @param _Pure        The type that represents a 'pure' combination of spin components, i.e. the alpha-alpha or beta-beta type.
  *  @param _Mixed       The type that represents a 'mixed' combination of spin components, i.e. the alpha-beta or beta-alpha type.
  *  @param _Derived     The type that derives from this type, given as a template argument, enabling CRTP and compile-time polymorphism.
@@ -69,7 +69,7 @@ public:
 
     /**
      *  Construct a doubly spin-resolved instance from its constituent objects.
-     * 
+     *
      *  @param aa       The alpha-alpha-object.
      *  @param ab       The alpha-beta object.
      *  @param ba       The beta-alpha object.
@@ -125,6 +125,34 @@ public:
      *  @return A writable reference to the beta-beta object.
      */
     Pure& betaBeta() { return this->bb; }
+
+    /**
+     *  @param sigma     The spin sigma for which the pure component is asked.
+     *
+     *  @return A read-only reference to the alpha-alpha object.
+     */
+    const Pure& pureComponent(const Spin& sigma) const {
+
+        if (sigma == Spin::alpha) {
+            return this->aa;
+        } else {
+            return this->bb;
+        }
+    }
+
+    /**
+     *  @param sigma     The spin sigma for which the pure component is asked.
+     *
+     *  @return A writable reference to the alpha-alpha object.
+     */
+    Pure& pureComponent(const Spin& sigma) {
+
+        if (sigma == Spin::alpha) {
+            return this->aa;
+        } else {
+            return this->bb;
+        }
+    }
 };
 
 

--- a/gqcp/include/gqcp.hpp
+++ b/gqcp/include/gqcp.hpp
@@ -64,6 +64,8 @@
 #include "Basis/MullikenPartitioning/RMullikenPartitioning.hpp"
 #include "Basis/MullikenPartitioning/UMullikenPartitioning.hpp"
 #include "Basis/MullikenPartitioning/UMullikenPartitioningComponent.hpp"
+#include "Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis.hpp"
+#include "Basis/NonOrthogonalBasis/SimpleNonOrthogonalStateBasis.hpp"
 #include "Basis/ScalarBasis/GTOBasisSet.hpp"
 #include "Basis/ScalarBasis/GTOShell.hpp"
 #include "Basis/ScalarBasis/LondonGTOShell.hpp"

--- a/gqcp/tests/Basis/CMakeLists.txt
+++ b/gqcp/tests/Basis/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(BiorthogonalBasis)
 add_subdirectory(Integrals)
+add_subdirectory(NonOrthogonalBasis)
 add_subdirectory(ScalarBasis)
 add_subdirectory(SpinorBasis)
 add_subdirectory(Transformations)

--- a/gqcp/tests/Basis/NonOrthogonalBasis/CMakeLists.txt
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/CMakeLists.txt
@@ -1,6 +1,7 @@
 list(APPEND test_target_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/GNonOrthogonalStateBasis_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RNonOrthogonalStateBasis_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/UNonOrthogonalStateBasis_test.cpp
 )
 
 set(test_target_sources ${test_target_sources} PARENT_SCOPE)

--- a/gqcp/tests/Basis/NonOrthogonalBasis/CMakeLists.txt
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND test_target_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/GNonOrthogonalStateBasis_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RNonOrthogonalStateBasis_test.cpp
 )
 
 set(test_target_sources ${test_target_sources} PARENT_SCOPE)

--- a/gqcp/tests/Basis/NonOrthogonalBasis/CMakeLists.txt
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/CMakeLists.txt
@@ -1,0 +1,5 @@
+list(APPEND test_target_sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/GNonOrthogonalStateBasis_test.cpp
+)
+
+set(test_target_sources ${test_target_sources} PARENT_SCOPE)

--- a/gqcp/tests/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis_test.cpp
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis_test.cpp
@@ -27,7 +27,6 @@
 
 /**
  *  Test whether or not the constructor of a non-orthogonal state basis throws when this is expected.
- *  This test checks the `GNonOrthogonalStateBasis` case, however as both the `R` and the `G` case test the functionality of the `SimpleNonOrthogonalStateBasis`, the restricted case won't be tested separately.
  */
 BOOST_AUTO_TEST_CASE(constructor) {
     // This test case is taken from a python prototype from @lelemmen and @johdvos.
@@ -38,55 +37,54 @@ BOOST_AUTO_TEST_CASE(constructor) {
     const GQCP::GSpinorBasis<double, GQCP::GTOShell> g_spinor_basis {molecule, "6-31G"};
     const auto S = g_spinor_basis.overlap();
 
-    // Initialize two non-orthogonal "Generalised states".
-    GQCP::SquareMatrix<double> C_bra {8};
+    // Initialize some non-orthogonal "Generalised states".
+    GQCP::SquareMatrix<double> state_1 {8};
     // clang-format off
-    C_bra << -0.07443693,  0.12036042, -0.13557067,  0.15517005,  0.13315100,  -0.03074946, -0.92997876, -0.93718779,
-             -0.07874922,  0.15086478, -0.68085546,  0.77423311,  0.08712373,   0.25266303,  0.848079  ,  0.89108911,
-             -0.24580188,  0.26338108,  0.09556297, -0.12178159,  0.91319299,   0.90475733, -0.03994767,  0.12839983,
-             -0.38944259,  0.4101685 ,  0.45214166, -0.58335985, -0.90125958,  -0.93270816, -0.16410814, -0.32074956,
-             -0.26338108, -0.24580188, -0.12178159, -0.09556297, -0.90475733,   0.91319299, -0.12839983, -0.03994767,
-             -0.4101685 , -0.38944259, -0.58335985, -0.45214166,  0.93270817,  -0.90125958,  0.32074956, -0.16410814,
-             -0.12036042, -0.07443693,  0.15517005,  0.13557067,  0.03074946,   0.13315101,  0.93718779, -0.92997876,
-             -0.15086478, -0.07874922,  0.77423311,  0.68085546, -0.25266303,   0.08712373, -0.89108911,  0.84807900;
+    state_1 << -0.07443693,  0.12036042, -0.13557067,  0.15517005,  0.13315100,  -0.03074946, -0.92997876, -0.93718779,
+               -0.07874922,  0.15086478, -0.68085546,  0.77423311,  0.08712373,   0.25266303,  0.848079  ,  0.89108911,
+               -0.24580188,  0.26338108,  0.09556297, -0.12178159,  0.91319299,   0.90475733, -0.03994767,  0.12839983,
+               -0.38944259,  0.4101685 ,  0.45214166, -0.58335985, -0.90125958,  -0.93270816, -0.16410814, -0.32074956,
+               -0.26338108, -0.24580188, -0.12178159, -0.09556297, -0.90475733,   0.91319299, -0.12839983, -0.03994767,
+               -0.4101685 , -0.38944259, -0.58335985, -0.45214166,  0.93270817,  -0.90125958,  0.32074956, -0.16410814,
+               -0.12036042, -0.07443693,  0.15517005,  0.13557067,  0.03074946,   0.13315101,  0.93718779, -0.92997876,
+               -0.15086478, -0.07874922,  0.77423311,  0.68085546, -0.25266303,   0.08712373, -0.89108911,  0.84807900;
     // clang-format on
-    GQCP::SquareMatrix<double> C_ket_right {8};
+    GQCP::SquareMatrix<double> state_2 {8};
     // clang-format off
-    C_ket_right <<  0.25851329, -0.14539151, -0.17177142, -0.01126487,  0.81289875, -0.77260907,  0.50167389, -0.44422385,
-                    0.36593356, -0.28669343, -0.84796858, -0.13503625, -0.62437698,  0.96771154, -0.55231929,  0.30317456,
-                    0.25853403,  0.14539669,  0.17176599, -0.01126146,  0.81450567,  0.7709918 , -0.501289  , -0.44451308,
-                    0.36597032,  0.28670189,  0.847938  , -0.13501526, -0.62639487, -0.96647128,  0.5520554 ,  0.30349133,
-                    0.10076798, -0.23874662,  0.04823423,  0.17685836,  0.42013282, -0.48352714, -0.79642816,  0.8239984 ,
-                    0.16561668, -0.35007843,  0.19502141,  0.90182842, -0.55545195,  0.39170258,  0.56753639, -0.94408827,
-                   -0.10075937, -0.23872464,  0.0482368 , -0.17686313, -0.42104909, -0.4826058 , -0.79588057, -0.82460595,
-                   -0.16560552, -0.35003836,  0.19503259, -0.9018579 ,  0.55619574,  0.39048771,  0.56690551,  0.94451894;
+    state_2 <<  0.25851329, -0.14539151, -0.17177142, -0.01126487,  0.81289875, -0.77260907,  0.50167389, -0.44422385,
+                0.36593356, -0.28669343, -0.84796858, -0.13503625, -0.62437698,  0.96771154, -0.55231929,  0.30317456,
+                0.25853403,  0.14539669,  0.17176599, -0.01126146,  0.81450567,  0.7709918 , -0.501289  , -0.44451308,
+                0.36597032,  0.28670189,  0.847938  , -0.13501526, -0.62639487, -0.96647128,  0.5520554 ,  0.30349133,
+                0.10076798, -0.23874662,  0.04823423,  0.17685836,  0.42013282, -0.48352714, -0.79642816,  0.8239984 ,
+                0.16561668, -0.35007843,  0.19502141,  0.90182842, -0.55545195,  0.39170258,  0.56753639, -0.94408827,
+               -0.10075937, -0.23872464,  0.0482368 , -0.17686313, -0.42104909, -0.4826058 , -0.79588057, -0.82460595,
+               -0.16560552, -0.35003836,  0.19503259, -0.9018579 ,  0.55619574,  0.39048771,  0.56690551,  0.94451894;
     // clang-format on
-    GQCP::SquareMatrix<double> C_ket_wrong {7};
+    GQCP::SquareMatrix<double> state_3 {7};
     // clang-format off
-    C_ket_wrong <<  0.25851329, -0.14539151, -0.17177142, -0.01126487,  0.81289875, -0.77260907,  0.50167389,
-                    0.36593356, -0.28669343, -0.84796858, -0.13503625, -0.62437698,  0.96771154, -0.55231929,
-                    0.25853403,  0.14539669,  0.17176599, -0.01126146,  0.81450567,  0.7709918 , -0.501289  ,
-                    0.36597032,  0.28670189,  0.847938  , -0.13501526, -0.62639487, -0.96647128,  0.5520554 ,
-                    0.10076798, -0.23874662,  0.04823423,  0.17685836,  0.42013282, -0.48352714, -0.79642816,
-                    0.16561668, -0.35007843,  0.19502141,  0.90182842, -0.55545195,  0.39170258,  0.56753639,
-                   -0.10075937, -0.23872464,  0.0482368 , -0.17686313, -0.42104909, -0.4826058 , -0.79588057;
+    state_3 <<  0.25851329, -0.14539151, -0.17177142, -0.01126487,  0.81289875, -0.77260907,  0.50167389,
+                0.36593356, -0.28669343, -0.84796858, -0.13503625, -0.62437698,  0.96771154, -0.55231929,
+                0.25853403,  0.14539669,  0.17176599, -0.01126146,  0.81450567,  0.7709918 , -0.501289  ,
+                0.36597032,  0.28670189,  0.847938  , -0.13501526, -0.62639487, -0.96647128,  0.5520554 ,
+                0.10076798, -0.23874662,  0.04823423,  0.17685836,  0.42013282, -0.48352714, -0.79642816,
+                0.16561668, -0.35007843,  0.19502141,  0.90182842, -0.55545195,  0.39170258,  0.56753639,
+               -0.10075937, -0.23872464,  0.0482368 , -0.17686313, -0.42104909, -0.4826058 , -0.79588057;
     // clang-format on
     // Transform the matrices to the correct transformation type.
-    const auto bra_expansion = GQCP::GTransformation<double> {C_bra};
-    const auto ket_expansion_right = GQCP::GTransformation<double> {C_ket_right};
-    const auto ket_expansion_wrong = GQCP::GTransformation<double> {C_ket_wrong};
+    const auto state1_expansion = GQCP::GTransformation<double> {state_1};
+    const auto state2_expansion = GQCP::GTransformation<double> {state_2};
+    const auto state3_expansion = GQCP::GTransformation<double> {state_3};
 
     using NonOrthogonalStateBasisType = GQCP::GNonOrthogonalStateBasis<double>;
     // Check that the constructor doesn't throw an exception when the right dimensions of states are used.
-    BOOST_CHECK_NO_THROW(NonOrthogonalStateBasisType basis(std::vector<GQCP::GTransformation<double>> {bra_expansion, ket_expansion_right}, S, molecule.numberOfElectrons()));
+    BOOST_CHECK_NO_THROW(NonOrthogonalStateBasisType basis(std::vector<GQCP::GTransformation<double>> {state1_expansion, state2_expansion}, S, molecule.numberOfElectrons()));
     // Check that the constructor throws an exception when the wrong dimensions of states are used.
-    BOOST_CHECK_THROW(NonOrthogonalStateBasisType basis_wrong(std::vector<GQCP::GTransformation<double>> {bra_expansion, ket_expansion_wrong}, S, molecule.numberOfElectrons()), std::invalid_argument);
+    BOOST_CHECK_THROW(NonOrthogonalStateBasisType basis_wrong(std::vector<GQCP::GTransformation<double>> {state1_expansion, state3_expansion}, S, molecule.numberOfElectrons()), std::invalid_argument);
 }
 
 
 /**
  *  Test whether the non-orthogonal state basis evaluates the Hamiltonian correctly. All other evaluations (one- and two-electron operators) are used within the Hamiltonian functionality.
- *  This test checks the `GNonOrthogonalStateBasis` case, however as both the `R` and the `G` case test the functionality of the `SimpleNonOrthogonalStateBasis`, the restricted case won't be tested separately.
  */
 BOOST_AUTO_TEST_CASE(operator_evaluations) {
     // This test case is taken from a python prototype from @lelemmen and @johdvos.
@@ -97,7 +95,7 @@ BOOST_AUTO_TEST_CASE(operator_evaluations) {
     const GQCP::GSpinorBasis<double, GQCP::GTOShell> g_spinor_basis {molecule, "6-31G"};
     const auto S = g_spinor_basis.overlap();
 
-    // Initialize two non-orthogonal "Generalised states".
+    // Initialize some non-orthogonal "Generalised states".
     GQCP::SquareMatrix<double> basis_state_1 {8};
     // clang-format off
     basis_state_1 << -0.07443693,  0.12036042, -0.13557067,  0.15517005,  0.13315100,  -0.03074946, -0.92997876, -0.93718779,
@@ -132,12 +130,12 @@ BOOST_AUTO_TEST_CASE(operator_evaluations) {
                        0.15037797,  0.32967347,  0.2391655 , -0.91376119,  0.47081908,  0.32796701,  0.60109455,  0.98115454;
     // clang-format on
     // Transform the matrices to the correct transformation type.
-    const auto bra_expansion = GQCP::GTransformation<double> {basis_state_1};
-    const auto ket_expansion_right = GQCP::GTransformation<double> {basis_state_2};
-    const auto ket_expansion_wrong = GQCP::GTransformation<double> {basis_state_3};
+    const auto state1 = GQCP::GTransformation<double> {basis_state_1};
+    const auto state2 = GQCP::GTransformation<double> {basis_state_2};
+    const auto state3 = GQCP::GTransformation<double> {basis_state_3};
 
     // Create a vector out of these three basis states.
-    std::vector<GQCP::GTransformation<double>> basis_vector {basis_state_1, basis_state_2, basis_state_3};
+    std::vector<GQCP::GTransformation<double>> basis_vector {state1, state2, state3};
 
     // Create a non-orthogonal state basis, using the basis state vector, the overlap operator in AO basis and the number of occupied orbitals.
     const auto NOS_basis = GQCP::GNonOrthogonalStateBasis<double> {basis_vector, S, molecule.numberOfElectrons()};
@@ -149,7 +147,7 @@ BOOST_AUTO_TEST_CASE(operator_evaluations) {
     // The Hamiltonian evaluated in non-orthogonal basis requires the nuclear repuslion to be taken into account.
     const auto non_orthogonal_hamiltonian = NOS_basis.evaluateHamiltonianOperator(hamiltonian_AO, GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()));
 
-    // Set up a reference Hamiltonian.
+    // Set up a reference Hamiltonian. Data taken from the implementation of @lelemmen and @johdvos.
     // The dimension of the Hamiltonian is equal to the number of basis states used.
     GQCP::SquareMatrix<double> reference_hamiltonian {3};
     // clang-format off

--- a/gqcp/tests/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis_test.cpp
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis_test.cpp
@@ -1,0 +1,163 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#define BOOST_TEST_MODULE "GNonOrthogonalStateBasis_test"
+
+#include <boost/test/unit_test.hpp>
+
+#include "Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis.hpp"
+#include "Basis/SpinorBasis/GSpinorBasis.hpp"
+#include "Basis/Transformations/GTransformation.hpp"
+#include "Molecule/Molecule.hpp"
+
+
+/**
+ *  Test whether or not the constructor of a non-orthogonal state basis throws when this is expected.
+ *  This test checks the `GNonOrthogonalStateBasis` case, however as both the `R` and the `G` case test the functionality of the `SimpleNonOrthogonalStateBasis`, the restricted case won't be tested separately.
+ */
+BOOST_AUTO_TEST_CASE(constructor) {
+    // This test case is taken from a python prototype from @lelemmen and @johdvos.
+    // It was for H2, at 2.5au internuclear distance for the 6-31G basis set.
+    const auto molecule = GQCP::Molecule::HChain(2, 2.5, 0);  // H2, 2.5 bohr apart.
+
+    // The general spinor basis is also needed, as we require the overlap operator in AO basis.
+    const GQCP::GSpinorBasis<double, GQCP::GTOShell> g_spinor_basis {molecule, "6-31G"};
+    const auto S = g_spinor_basis.overlap();
+
+    // Initialize two non-orthogonal "Generalised states".
+    GQCP::SquareMatrix<double> C_bra {8};
+    // clang-format off
+    C_bra << -0.07443693,  0.12036042, -0.13557067,  0.15517005,  0.13315100,  -0.03074946, -0.92997876, -0.93718779,
+             -0.07874922,  0.15086478, -0.68085546,  0.77423311,  0.08712373,   0.25266303,  0.848079  ,  0.89108911,
+             -0.24580188,  0.26338108,  0.09556297, -0.12178159,  0.91319299,   0.90475733, -0.03994767,  0.12839983,
+             -0.38944259,  0.4101685 ,  0.45214166, -0.58335985, -0.90125958,  -0.93270816, -0.16410814, -0.32074956,
+             -0.26338108, -0.24580188, -0.12178159, -0.09556297, -0.90475733,   0.91319299, -0.12839983, -0.03994767,
+             -0.4101685 , -0.38944259, -0.58335985, -0.45214166,  0.93270817,  -0.90125958,  0.32074956, -0.16410814,
+             -0.12036042, -0.07443693,  0.15517005,  0.13557067,  0.03074946,   0.13315101,  0.93718779, -0.92997876,
+             -0.15086478, -0.07874922,  0.77423311,  0.68085546, -0.25266303,   0.08712373, -0.89108911,  0.84807900;
+    // clang-format on
+    GQCP::SquareMatrix<double> C_ket_right {8};
+    // clang-format off
+    C_ket_right <<  0.25851329, -0.14539151, -0.17177142, -0.01126487,  0.81289875, -0.77260907,  0.50167389, -0.44422385,
+                    0.36593356, -0.28669343, -0.84796858, -0.13503625, -0.62437698,  0.96771154, -0.55231929,  0.30317456,
+                    0.25853403,  0.14539669,  0.17176599, -0.01126146,  0.81450567,  0.7709918 , -0.501289  , -0.44451308,
+                    0.36597032,  0.28670189,  0.847938  , -0.13501526, -0.62639487, -0.96647128,  0.5520554 ,  0.30349133,
+                    0.10076798, -0.23874662,  0.04823423,  0.17685836,  0.42013282, -0.48352714, -0.79642816,  0.8239984 ,
+                    0.16561668, -0.35007843,  0.19502141,  0.90182842, -0.55545195,  0.39170258,  0.56753639, -0.94408827,
+                   -0.10075937, -0.23872464,  0.0482368 , -0.17686313, -0.42104909, -0.4826058 , -0.79588057, -0.82460595,
+                   -0.16560552, -0.35003836,  0.19503259, -0.9018579 ,  0.55619574,  0.39048771,  0.56690551,  0.94451894;
+    // clang-format on
+    GQCP::SquareMatrix<double> C_ket_wrong {7};
+    // clang-format off
+    C_ket_wrong <<  0.25851329, -0.14539151, -0.17177142, -0.01126487,  0.81289875, -0.77260907,  0.50167389,
+                    0.36593356, -0.28669343, -0.84796858, -0.13503625, -0.62437698,  0.96771154, -0.55231929,
+                    0.25853403,  0.14539669,  0.17176599, -0.01126146,  0.81450567,  0.7709918 , -0.501289  ,
+                    0.36597032,  0.28670189,  0.847938  , -0.13501526, -0.62639487, -0.96647128,  0.5520554 ,
+                    0.10076798, -0.23874662,  0.04823423,  0.17685836,  0.42013282, -0.48352714, -0.79642816,
+                    0.16561668, -0.35007843,  0.19502141,  0.90182842, -0.55545195,  0.39170258,  0.56753639,
+                   -0.10075937, -0.23872464,  0.0482368 , -0.17686313, -0.42104909, -0.4826058 , -0.79588057;
+    // clang-format on
+    // Transform the matrices to the correct transformation type.
+    const auto bra_expansion = GQCP::GTransformation<double> {C_bra};
+    const auto ket_expansion_right = GQCP::GTransformation<double> {C_ket_right};
+    const auto ket_expansion_wrong = GQCP::GTransformation<double> {C_ket_wrong};
+
+    using NonOrthogonalStateBasisType = GQCP::GNonOrthogonalStateBasis<double>;
+    // Check that the constructor doesn't throw an exception when the right dimensions of states are used.
+    BOOST_CHECK_NO_THROW(NonOrthogonalStateBasisType basis(std::vector<GQCP::GTransformation<double>> {bra_expansion, ket_expansion_right}, S, molecule.numberOfElectrons()));
+    // Check that the constructor throws an exception when the wrong dimensions of states are used.
+    BOOST_CHECK_THROW(NonOrthogonalStateBasisType basis_wrong(std::vector<GQCP::GTransformation<double>> {bra_expansion, ket_expansion_wrong}, S, molecule.numberOfElectrons()), std::invalid_argument);
+}
+
+
+/**
+ *  Test whether the non-orthogonal state basis evaluates the Hamiltonian correctly. All other evaluations (one- and two-electron operators) are used within the Hamiltonian functionality.
+ *  This test checks the `GNonOrthogonalStateBasis` case, however as both the `R` and the `G` case test the functionality of the `SimpleNonOrthogonalStateBasis`, the restricted case won't be tested separately.
+ */
+BOOST_AUTO_TEST_CASE(operator_evaluations) {
+    // This test case is taken from a python prototype from @lelemmen and @johdvos.
+    // It was for H2, at 2.5au internuclear distance for the 6-31G basis set.
+    const auto molecule = GQCP::Molecule::HChain(2, 2.5, 0);  // H2, 2.5 bohr apart.
+
+    // The general spinor basis is also needed, as we require the overlap operator in AO basis.
+    const GQCP::GSpinorBasis<double, GQCP::GTOShell> g_spinor_basis {molecule, "6-31G"};
+    const auto S = g_spinor_basis.overlap();
+
+    // Initialize two non-orthogonal "Generalised states".
+    GQCP::SquareMatrix<double> basis_state_1 {8};
+    // clang-format off
+    basis_state_1 << -0.07443693,  0.12036042, -0.13557067,  0.15517005,  0.13315100,  -0.03074946, -0.92997876, -0.93718779,
+                     -0.07874922,  0.15086478, -0.68085546,  0.77423311,  0.08712373,   0.25266303,  0.848079  ,  0.89108911,
+                     -0.24580188,  0.26338108,  0.09556297, -0.12178159,  0.91319299,   0.90475733, -0.03994767,  0.12839983,
+                     -0.38944259,  0.4101685 ,  0.45214166, -0.58335985, -0.90125958,  -0.93270816, -0.16410814, -0.32074956,
+                     -0.26338108, -0.24580188, -0.12178159, -0.09556297, -0.90475733,   0.91319299, -0.12839983, -0.03994767,
+                     -0.4101685 , -0.38944259, -0.58335985, -0.45214166,  0.93270817,  -0.90125958,  0.32074956, -0.16410814,
+                     -0.12036042, -0.07443693,  0.15517005,  0.13557067,  0.03074946,   0.13315101,  0.93718779, -0.92997876,
+                     -0.15086478, -0.07874922,  0.77423311,  0.68085546, -0.25266303,   0.08712373, -0.89108911,  0.84807900;
+    // clang-format on
+    GQCP::SquareMatrix<double> basis_state_2 {8};
+    // clang-format off
+    basis_state_2 <<  0.25851329, -0.14539151, -0.17177142, -0.01126487,  0.81289875, -0.77260907,  0.50167389, -0.44422385,
+                      0.36593356, -0.28669343, -0.84796858, -0.13503625, -0.62437698,  0.96771154, -0.55231929,  0.30317456,
+                      0.25853403,  0.14539669,  0.17176599, -0.01126146,  0.81450567,  0.7709918 , -0.501289  , -0.44451308,
+                      0.36597032,  0.28670189,  0.847938  , -0.13501526, -0.62639487, -0.96647128,  0.5520554 ,  0.30349133,
+                      0.10076798, -0.23874662,  0.04823423,  0.17685836,  0.42013282, -0.48352714, -0.79642816,  0.8239984 ,
+                      0.16561668, -0.35007843,  0.19502141,  0.90182842, -0.55545195,  0.39170258,  0.56753639, -0.94408827,
+                     -0.10075937, -0.23872464,  0.0482368 , -0.17686313, -0.42104909, -0.4826058 , -0.79588057, -0.82460595,
+                     -0.16560552, -0.35003836,  0.19503259, -0.9018579 ,  0.55619574,  0.39048771,  0.56690551,  0.94451894;
+    // clang-format on
+    GQCP::SquareMatrix<double> basis_state_3 {8};
+    // clang-format off
+    basis_state_3 <<  -0.265842  ,  0.17716735, -0.15969328, -0.00308706,  0.84741422, -0.81942223,  0.41366608, -0.36889812,
+                      -0.36278694,  0.36406651, -0.80340861, -0.13144475, -0.65133121,  1.03324716, -0.44428872,  0.24605534,
+                      -0.26584976, -0.17716927,  0.15969112, -0.00308558,  0.84933355,  0.81745234, -0.41355441, -0.36897416,
+                      -0.36280035, -0.36406982,  0.80339638, -0.13143372, -0.65375477, -1.0317334 ,  0.4442138 ,  0.24613641,
+                      -0.09736842,  0.22594293,  0.06676532,  0.17043252,  0.3439281 , -0.39253422, -0.84701679,  0.86052195,
+                      -0.15038318,  0.32968947,  0.23916148,  0.91374992, -0.47007004,  0.32909412,  0.60131983, -0.98100354,
+                       0.0973641 ,  0.22593416,  0.06676626, -0.17043417, -0.34482098, -0.39170837, -0.84682078, -0.86073623,
+                       0.15037797,  0.32967347,  0.2391655 , -0.91376119,  0.47081908,  0.32796701,  0.60109455,  0.98115454;
+    // clang-format on
+    // Transform the matrices to the correct transformation type.
+    const auto bra_expansion = GQCP::GTransformation<double> {basis_state_1};
+    const auto ket_expansion_right = GQCP::GTransformation<double> {basis_state_2};
+    const auto ket_expansion_wrong = GQCP::GTransformation<double> {basis_state_3};
+
+    // Create a vector out of these three basis states.
+    std::vector<GQCP::GTransformation<double>> basis_vector {basis_state_1, basis_state_2, basis_state_3};
+
+    // Create a non-orthogonal state basis, using the basis state vector, the overlap operator in AO basis and the number of occupied orbitals.
+    const auto NOS_basis = GQCP::GNonOrthogonalStateBasis<double> {basis_vector, S, molecule.numberOfElectrons()};
+
+    // To evaluate the Hamiltonian in the non-orthogonal state basis, we need the second quantized Hamiltonian in AO basis.
+    const auto hamiltonian_AO = g_spinor_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));
+
+    // We can now evaluate this Hamiltonian operator in the non-orthogonal basis.
+    // The Hamiltonian evaluated in non-orthogonal basis requires the nuclear repuslion to be taken into account.
+    const auto non_orthogonal_hamiltonian = NOS_basis.evaluateHamiltonianOperator(hamiltonian_AO, GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()));
+
+    // Set up a reference Hamiltonian.
+    // The dimension of the Hamiltonian is equal to the number of basis states used.
+    GQCP::SquareMatrix<double> reference_hamiltonian {3};
+    // clang-format off
+    reference_hamiltonian <<  -1.03611672, -0.83337779, -0.78876307,
+                              -0.83337779, -1.03337473, -1.02413064,
+                              -0.78876307, -1.02413064, -1.0270364 ;
+    // clang-format on
+
+    // Compare the reference with the evaluated Hamiltonian.
+    BOOST_CHECK(non_orthogonal_hamiltonian.isApprox(reference_hamiltonian, 1e-6));
+}

--- a/gqcp/tests/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis_test.cpp
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis_test.cpp
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(operator_evaluations) {
     const GQCP::GSpinorBasis<double, GQCP::GTOShell> g_spinor_basis {molecule, "6-31G"};
     const auto S = g_spinor_basis.overlap();
 
-    // Initialize some non-orthogonal "Generalised states".
+    // Initialize some non-orthogonal "generalised states".
     GQCP::SquareMatrix<double> basis_state_1 {8};
     // clang-format off
     basis_state_1 << -0.07443693,  0.12036042, -0.13557067,  0.15517005,  0.13315100,  -0.03074946, -0.92997876, -0.93718779,

--- a/gqcp/tests/Basis/NonOrthogonalBasis/RNonOrthogonalStateBasis_test.cpp
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/RNonOrthogonalStateBasis_test.cpp
@@ -1,0 +1,137 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#define BOOST_TEST_MODULE "RNonOrthogonalStateBasis_test"
+
+#include <boost/test/unit_test.hpp>
+
+#include "Basis/NonOrthogonalBasis/RNonOrthogonalStateBasis.hpp"
+#include "Basis/SpinorBasis/RSpinOrbitalBasis.hpp"
+#include "Basis/Transformations/RTransformation.hpp"
+#include "Molecule/Molecule.hpp"
+
+
+/**
+ *  Test whether or not the constructor of a non-orthogonal state basis throws when this is expected.
+ */
+BOOST_AUTO_TEST_CASE(constructor) {
+    // This test case is taken from a python prototype from @lelemmen and @johdvos.
+    // It was for H2, at 2.5au internuclear distance for the 6-31G basis set.
+    const auto molecule = GQCP::Molecule::HChain(2, 2.5, 0);  // H2, 2.5 bohr apart.
+
+    // The restricted spin orbital basis is also needed, as we require the overlap operator in AO basis.
+    const GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spin_orbital_basis {molecule, "6-31G"};
+    const auto S = spin_orbital_basis.overlap();
+
+    // Initialize some non-orthogonal "Restricted states".
+    GQCP::SquareMatrix<double> state_1 {4};
+    // clang-format off
+    state_1 << -0.07443693,  0.12036042, -0.13557067,  0.15517005,
+               -0.07874922,  0.15086478, -0.68085546,  0.77423311,
+               -0.24580188,  0.26338108,  0.09556297, -0.12178159,
+               -0.38944259,  0.4101685 ,  0.45214166, -0.58335985;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_2 {4};
+    // clang-format off
+    state_2 <<  0.25851329, -0.14539151, -0.17177142, -0.01126487,
+                0.36593356, -0.28669343, -0.84796858, -0.13503625,
+                0.25853403,  0.14539669,  0.17176599, -0.01126146,
+                0.36597032,  0.28670189,  0.847938  , -0.13501526;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_3 {3};
+    // clang-format off
+    state_3 <<  0.25851329, -0.14539151, -0.17177142,
+                0.36593356, -0.28669343, -0.84796858,
+                0.25853403,  0.14539669,  0.17176599;
+    // clang-format on
+    // Transform the matrices to the correct transformation type.
+    const auto state1_expansion = GQCP::RTransformation<double> {state_1};
+    const auto state2_expansion = GQCP::RTransformation<double> {state_2};
+    const auto state3_expansion = GQCP::RTransformation<double> {state_3};
+
+    using NonOrthogonalStateBasisType = GQCP::RNonOrthogonalStateBasis<double>;
+    // Check that the constructor doesn't throw an exception when the right dimensions of states are used.
+    BOOST_CHECK_NO_THROW(NonOrthogonalStateBasisType basis(std::vector<GQCP::RTransformation<double>> {state1_expansion, state2_expansion}, S, molecule.numberOfElectronPairs()));
+    // Check that the constructor throws an exception when the wrong dimensions of states are used.
+    BOOST_CHECK_THROW(NonOrthogonalStateBasisType basis_wrong(std::vector<GQCP::RTransformation<double>> {state1_expansion, state3_expansion}, S, molecule.numberOfElectronPairs()), std::invalid_argument);
+}
+
+
+/**
+ *  Test whether the non-orthogonal state basis evaluates the Hamiltonian correctly. All other evaluations (one- and two-electron operators) are used within the Hamiltonian functionality.
+ */
+BOOST_AUTO_TEST_CASE(operator_evaluations) {
+    // This test case is taken from a python prototype from @lelemmen and @johdvos.
+    // It was for H2, at 2.5au internuclear distance for the 6-31G basis set.
+    const auto molecule = GQCP::Molecule::HChain(2, 2.5, 0);  // H2, 2.5 bohr apart.
+
+    // The restricted spin orbital basis is also needed, as we require the overlap operator in AO basis.
+    const GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spin_orbital_basis {molecule, "6-31G"};
+    const auto S = spin_orbital_basis.overlap();
+
+    // Initialize two non-orthogonal "Generalised states".
+    GQCP::SquareMatrix<double> state_1 {4};
+    // clang-format off
+    state_1 << -0.07443693,  0.12036042, -0.13557067,  0.15517005,
+               -0.07874922,  0.15086478, -0.68085546,  0.77423311,
+               -0.24580188,  0.26338108,  0.09556297, -0.12178159,
+               -0.38944259,  0.4101685 ,  0.45214166, -0.58335985;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_2 {4};
+    // clang-format off
+    state_2 <<  0.25851329, -0.14539151, -0.17177142, -0.01126487,
+                0.36593356, -0.28669343, -0.84796858, -0.13503625,
+                0.25853403,  0.14539669,  0.17176599, -0.01126146,
+                0.36597032,  0.28670189,  0.847938  , -0.13501526;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_3 {4};
+    // clang-format off
+    state_3 <<  -0.265842  ,  0.17716735, -0.15969328, -0.00308706,
+                -0.36278694,  0.36406651, -0.80340861, -0.13144475,
+                -0.26584976, -0.17716927,  0.15969112, -0.00308558,
+                -0.36280035, -0.36406982,  0.80339638, -0.13143372;
+    // clang-format on
+    // Transform the matrices to the correct transformation type.
+    const auto basis_state_1 = GQCP::RTransformation<double> {state_1};
+    const auto basis_state_2 = GQCP::RTransformation<double> {state_2};
+    const auto basis_state_3 = GQCP::RTransformation<double> {state_3};
+
+    // Create a vector out of these three basis states.
+    std::vector<GQCP::RTransformation<double>> basis_vector {basis_state_1, basis_state_2, basis_state_3};
+
+    // Create a non-orthogonal state basis, using the basis state vector, the overlap operator in AO basis and the number of occupied orbitals.
+    const auto NOS_basis = GQCP::RNonOrthogonalStateBasis<double> {basis_vector, S, molecule.numberOfElectronPairs()};
+
+    // To evaluate the Hamiltonian in the non-orthogonal state basis, we need the second quantized Hamiltonian in AO basis.
+    const auto hamiltonian_AO = spin_orbital_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));
+
+    // We can now evaluate this Hamiltonian operator in the non-orthogonal basis.
+    // The Hamiltonian evaluated in non-orthogonal basis requires the nuclear repuslion to be taken into account.
+    const auto non_orthogonal_hamiltonian = NOS_basis.evaluateHamiltonianOperator(hamiltonian_AO, GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()));
+
+    // Set up a reference Hamiltonian. Data taken from the implementation of @lelemmen and @johdvos.
+    // The dimension of the Hamiltonian is equal to the number of basis states used.
+    GQCP::SquareMatrix<double> reference_hamiltonian {3};
+    // clang-format off
+    reference_hamiltonian <<  -0.22799722, -0.33706571, -0.33885917,
+                              -0.33706571, -0.53329832, -0.53611542,
+                              -0.33885917, -0.53611542, -0.53892183;
+    // clang-format on
+
+    // Compare the reference with the evaluated Hamiltonian.
+    BOOST_CHECK(non_orthogonal_hamiltonian.isApprox(reference_hamiltonian, 1e-6));
+}

--- a/gqcp/tests/Basis/NonOrthogonalBasis/RNonOrthogonalStateBasis_test.cpp
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/RNonOrthogonalStateBasis_test.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(operator_evaluations) {
     const GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spin_orbital_basis {molecule, "6-31G"};
     const auto S = spin_orbital_basis.overlap();
 
-    // Initialize two non-orthogonal "Generalised states".
+    // Initialize two non-orthogonal "restricted states".
     GQCP::SquareMatrix<double> state_1 {4};
     // clang-format off
     state_1 << -0.07443693,  0.12036042, -0.13557067,  0.15517005,

--- a/gqcp/tests/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis_test.cpp
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis_test.cpp
@@ -1,0 +1,108 @@
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+
+#define BOOST_TEST_MODULE "UNonOrthogonalStateBasis_test"
+
+#include <boost/test/unit_test.hpp>
+
+#include "Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp"
+#include "Basis/SpinorBasis/USpinOrbitalBasis.hpp"
+#include "Basis/Transformations/UTransformation.hpp"
+#include "Basis/Transformations/UTransformationComponent.hpp"
+#include "Molecule/Molecule.hpp"
+
+
+/**
+ *  Test whether or not the constructor of a non-orthogonal state basis throws when this is expected.
+ */
+BOOST_AUTO_TEST_CASE(constructor) {
+    // This test case is taken from a python prototype from @lelemmen and @johdvos.
+    // It was for H2, at 2.5au internuclear distance for the 6-31G basis set.
+    const auto molecule = GQCP::Molecule::HChain(2, 0.944863, 0);  // H2, 0.5 Angstrom apart.
+
+    // The restricted spin orbital basis is also needed, as we require the overlap operator in AO basis.
+    const GQCP::USpinOrbitalBasis<double, GQCP::GTOShell> spin_orbital_basis {molecule, "6-31G"};
+    const auto S = spin_orbital_basis.overlap();
+
+    // Initialize some non-orthogonal "unrestricted states".
+    GQCP::SquareMatrix<double> state_1_alpha {4};
+    // clang-format off
+    state_1_alpha << 0.11206486,  0.0664533 ,  -0.06223693, -0.23572168,
+                     0.14935776,  1.61380725,   0.57998371,  0.50570049,
+                     0.05498453, -0.00201046,  -0.14404996,  0.42154899,
+                     0.06584014, -1.03012307,   0.61860373, -0.38383381;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_1_beta {4};
+    // clang-format off
+    state_1_beta <<  0.35722807,   0.01455789, -0.65501355, -0.1817075 ,
+                     0.0558135 ,   1.53245558,  0.05524368,  0.65134408,
+                     0.26831116,  -0.04871381, -0.47300476,  1.13157038,
+                     0.11243095,  -1.29670236,  0.06771168, -0.77975514;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_2_alpha {4};
+    // clang-format off
+    state_2_alpha <<  0.26797459,  0.03623556, -0.40680507, -0.33042291,
+                      0.19357135,  2.34671211,  0.10421429,  1.4965034 ,
+                      0.08067523, -0.00582667, -0.31647872,  0.8164066 ,
+                      0.16186438, -2.45695288,  0.45360206, -0.61357143;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_2_beta {4};
+    // clang-format off
+    state_2_beta <<  0.340871928  ,  0.0652390350, -0.491818890 , -0.987725549,
+                     0.0927480365 ,  2.22620330  ,  0.0325517208,  0.310965988,
+                     0.00167619567, -0.0560473064, -0.211679596 ,  0.638032341,
+                     0.186865435  , -0.529305142 ,  0.316966132 , -0.376218036;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_3_alpha {4};
+    // clang-format off
+    state_3_alpha <<  0.32165359,  0.07409797, -0.61754043, -1.29664545,
+                      0.17649753,  0.42795186,  0.14375287,  0.25679393,
+                      0.0132411 , -0.00790032, -0.27440902,  0.32891666,
+                      0.02341172, -1.21673966,  0.42086602, -0.56974723;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_3_beta {4};
+    // clang-format off
+    state_3_beta <<  0.03621239,  0.05062348,  -0.1906441 ,  -1.28517284,
+                     0.09895494,  2.0934359 ,   0.20758293,   0.39451284,
+                     0.27260356, -0.0417335 ,  -0.48423516,   0.20045802,
+                     0.19128949, -0.62531908,   0.19289412,  -1.50848556;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_4_alpha {3};
+    // clang-format off
+    state_4_alpha <<  0.04917986,  0.04546257, -0.1548098 ,
+                      0.00962112,  0.62442864,  0.46972332,
+                      0.35956581, -0.05316816, -0.5599045 ;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_4_beta {3};
+    // clang-format off
+    state_4_beta <<  0.28046056,  0.03568668, -0.0270097 , 
+                     0.01472352,  0.14086505,  0.58691824,  
+                     0.31468179, -0.00655532, -0.1611742 ;
+    // clang-format on
+
+    // Transform the matrices to the correct transformation type.
+    const auto state1_expansion = GQCP::UTransformation<double> {GQCP::UTransformationComponent<double> {state_1_alpha}, GQCP::UTransformationComponent<double> {state_1_beta}};
+    const auto state2_expansion = GQCP::UTransformation<double> {GQCP::UTransformationComponent<double> {state_2_alpha}, GQCP::UTransformationComponent<double> {state_2_beta}};
+    const auto state3_expansion = GQCP::UTransformation<double> {GQCP::UTransformationComponent<double> {state_3_alpha}, GQCP::UTransformationComponent<double> {state_3_beta}};
+    const auto state4_expansion = GQCP::UTransformation<double> {GQCP::UTransformationComponent<double> {state_4_alpha}, GQCP::UTransformationComponent<double> {state_4_beta}};
+
+    using NonOrthogonalStateBasisType = GQCP::UNonOrthogonalStateBasis<double>;
+    // Check that the constructor doesn't throw an exception when the right dimensions of states are used.
+    BOOST_CHECK_NO_THROW(NonOrthogonalStateBasisType basis(std::vector<GQCP::UTransformation<double>> {state1_expansion, state2_expansion, state3_expansion}, S, molecule.numberOfElectronPairs(), molecule.numberOfElectronPairs()));
+    // Check that the constructor throws an exception when the wrong dimensions of states are used.
+    BOOST_CHECK_THROW(NonOrthogonalStateBasisType basis_wrong(std::vector<GQCP::UTransformation<double>> {state1_expansion, state2_expansion, state4_expansion}, S, molecule.numberOfElectronPairs(), molecule.numberOfElectronPairs()), std::invalid_argument);
+}

--- a/gqcp/tests/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis_test.cpp
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis_test.cpp
@@ -106,3 +106,97 @@ BOOST_AUTO_TEST_CASE(constructor) {
     // Check that the constructor throws an exception when the wrong dimensions of states are used.
     BOOST_CHECK_THROW(NonOrthogonalStateBasisType basis_wrong(std::vector<GQCP::UTransformation<double>> {state1_expansion, state2_expansion, state4_expansion}, S, molecule.numberOfElectronPairs(), molecule.numberOfElectronPairs()), std::invalid_argument);
 }
+
+/**
+ *  Test whether or not the overlap operator is evaluated correctly over a non-orthogonal state basis.
+ */
+BOOST_AUTO_TEST_CASE(overlap_and_hamiltonian) {
+    // This test case is taken from a python prototype from @lelemmen and @johdvos.
+    // It was for H2, at 2.5au internuclear distance for the 6-31G basis set.
+    const auto molecule = GQCP::Molecule::HChain(2, 0.944863, 0);  // H2, 0.5 Angstrom apart.
+
+    // The restricted spin orbital basis is also needed, as we require the overlap operator in AO basis.
+    const GQCP::USpinOrbitalBasis<double, GQCP::GTOShell> spin_orbital_basis {molecule, "6-31G"};
+    const auto S = spin_orbital_basis.overlap();
+
+    // Initialize some non-orthogonal "unrestricted states".
+    GQCP::SquareMatrix<double> state_1_alpha {4};
+    // clang-format off
+    state_1_alpha << 0.11206486,  0.0664533 ,  -0.06223693, -0.23572168,
+                     0.14935776,  1.61380725,   0.57998371,  0.50570049,
+                     0.05498453, -0.00201046,  -0.14404996,  0.42154899,
+                     0.06584014, -1.03012307,   0.61860373, -0.38383381;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_1_beta {4};
+    // clang-format off
+    state_1_beta <<  0.35722807,   0.01455789, -0.65501355, -0.1817075 ,
+                     0.0558135 ,   1.53245558,  0.05524368,  0.65134408,
+                     0.26831116,  -0.04871381, -0.47300476,  1.13157038,
+                     0.11243095,  -1.29670236,  0.06771168, -0.77975514;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_2_alpha {4};
+    // clang-format off
+    state_2_alpha <<  0.26797459,  0.03623556, -0.40680507, -0.33042291,
+                      0.19357135,  2.34671211,  0.10421429,  1.4965034 ,
+                      0.08067523, -0.00582667, -0.31647872,  0.8164066 ,
+                      0.16186438, -2.45695288,  0.45360206, -0.61357143;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_2_beta {4};
+    // clang-format off
+    state_2_beta <<  0.340871928  ,  0.0652390350, -0.491818890 , -0.987725549,
+                     0.0927480365 ,  2.22620330  ,  0.0325517208,  0.310965988,
+                     0.00167619567, -0.0560473064, -0.211679596 ,  0.638032341,
+                     0.186865435  , -0.529305142 ,  0.316966132 , -0.376218036;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_3_alpha {4};
+    // clang-format off
+    state_3_alpha <<  0.32165359,  0.07409797, -0.61754043, -1.29664545,
+                      0.17649753,  0.42795186,  0.14375287,  0.25679393,
+                      0.0132411 , -0.00790032, -0.27440902,  0.32891666,
+                      0.02341172, -1.21673966,  0.42086602, -0.56974723;
+    // clang-format on
+    GQCP::SquareMatrix<double> state_3_beta {4};
+    // clang-format off
+    state_3_beta <<  0.03621239,  0.05062348,  -0.1906441 ,  -1.28517284,
+                     0.09895494,  2.0934359 ,   0.20758293,   0.39451284,
+                     0.27260356, -0.0417335 ,  -0.48423516,   0.20045802,
+                     0.19128949, -0.62531908,   0.19289412,  -1.50848556;
+    // clang-format on
+
+    // Transform the matrices to the correct transformation type.
+    const auto state1_expansion = GQCP::UTransformation<double> {GQCP::UTransformationComponent<double> {state_1_alpha}, GQCP::UTransformationComponent<double> {state_1_beta}};
+    const auto state2_expansion = GQCP::UTransformation<double> {GQCP::UTransformationComponent<double> {state_2_alpha}, GQCP::UTransformationComponent<double> {state_2_beta}};
+    const auto state3_expansion = GQCP::UTransformation<double> {GQCP::UTransformationComponent<double> {state_3_alpha}, GQCP::UTransformationComponent<double> {state_3_beta}};
+
+    using NonOrthogonalStateBasisType = GQCP::UNonOrthogonalStateBasis<double>;
+    NonOrthogonalStateBasisType NOCIbasis {std::vector<GQCP::UTransformation<double>> {state1_expansion, state2_expansion, state3_expansion}, S, molecule.numberOfElectronPairs(), molecule.numberOfElectronPairs()};
+
+    // Evaluate the overlap operator in the NOCI basis.
+    const auto overlap_matrix = NOCIbasis.evaluateOverlapOperator();
+
+    // In itialize a reference overlap matrix. Reference data taken from the implementation of @johdvos.
+    GQCP::SquareMatrix<double> overlap_reference {3};
+    // clang-format off
+    overlap_reference <<  0.05573789, 0.07821839, 0.05588782,
+                          0.07821839, 0.11900939, 0.07973549,
+                          0.05588782, 0.07973549, 0.066858  ;
+    // clang-format on
+
+    // Check whether the calculated overlap matches the reference.
+    BOOST_CHECK(overlap_matrix.isApprox(overlap_reference, 1e-6));
+
+    // evaluate the Hamiltonian in the NOCI basis.
+    const auto sq_ham = spin_orbital_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));
+    const auto ham = NOCIbasis.evaluateHamiltonianOperator(sq_ham, GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()));
+
+    // Initialize a reference Hamiltonian. Reference data taken from the implementation of @johdvos.
+    GQCP::SquareMatrix<double> hamiltonian_reference {3};
+    // clang-format off
+    hamiltonian_reference <<  -0.05634827, -0.07880862,  -0.0594536 ,
+                              -0.07880862, -0.1082845 ,  -0.08489053,
+                              -0.0594536 , -0.08489053,  -0.06239094;
+    // clang-format on
+    // std::cout << ham << std::endl;
+    // Check whether the calculated Hamiltonian matches the reference.
+    BOOST_CHECK(ham.isApprox(hamiltonian_reference, 1e-6));
+}

--- a/gqcp/tests/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis_test.cpp
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis_test.cpp
@@ -19,11 +19,14 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "Basis/BiorthogonalBasis/ULowdinPairingBasis.hpp"
 #include "Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis.hpp"
 #include "Basis/SpinorBasis/USpinOrbitalBasis.hpp"
 #include "Basis/Transformations/UTransformation.hpp"
 #include "Basis/Transformations/UTransformationComponent.hpp"
+#include "Mathematical/Representation/Tensor.hpp"
 #include "Molecule/Molecule.hpp"
+#include "QuantumChemical/Spin.hpp"
 
 
 /**

--- a/gqcp/tests/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis_test.cpp
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis_test.cpp
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(overlap_and_hamiltonian) {
     // It was for H2, at 2.5au internuclear distance for the 6-31G basis set.
     const auto molecule = GQCP::Molecule::HChain(2, 0.944863, 0);  // H2, 0.5 Angstrom apart.
 
-    // The restricted spin orbital basis is also needed, as we require the overlap operator in AO basis.
+    // The unrestricted spin orbital basis is also needed, as we require the overlap operator in AO basis.
     const GQCP::USpinOrbitalBasis<double, GQCP::GTOShell> spin_orbital_basis {molecule, "6-31G"};
     const auto S = spin_orbital_basis.overlap();
 
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(overlap_and_hamiltonian) {
     // Evaluate the overlap operator in the NOCI basis.
     const auto overlap_matrix = NOCIbasis.evaluateOverlapOperator();
 
-    // In itialize a reference overlap matrix. Reference data taken from the implementation of @johdvos.
+    // Initialize a reference overlap matrix. Reference data taken from the implementation of @johdvos.
     GQCP::SquareMatrix<double> overlap_reference {3};
     // clang-format off
     overlap_reference <<  0.05573789, 0.07821839, 0.05588782,
@@ -199,7 +199,6 @@ BOOST_AUTO_TEST_CASE(overlap_and_hamiltonian) {
                               -0.07880862, -0.1082845 ,  -0.08489053,
                               -0.0594536 , -0.08489053,  -0.06239094;
     // clang-format on
-    // std::cout << ham << std::endl;
     // Check whether the calculated Hamiltonian matches the reference.
     BOOST_CHECK(ham.isApprox(hamiltonian_reference, 1e-6));
 }

--- a/gqcp/tests/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis_test.cpp
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/UNonOrthogonalStateBasis_test.cpp
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
  *  Test whether or not the overlap operator is evaluated correctly over a non-orthogonal state basis.
  */
 BOOST_AUTO_TEST_CASE(overlap_and_hamiltonian) {
-    // This test case is taken from a python prototype from @lelemmen and @johdvos.
+    // This test case is taken from a Python prototype from @lelemmen and @johdvos.
     // It was for H2, at 2.5au internuclear distance for the 6-31G basis set.
     const auto molecule = GQCP::Molecule::HChain(2, 0.944863, 0);  // H2, 0.5 Angstrom apart.
 


### PR DESCRIPTION
**Short description**

This PR will provide the implementation for a basis, consisting of non-orthogonal states that can evaluate the necessary operators in this basis. 

**Related issues**

closes #997 

**To do**

- [x] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [x] implement parent class `SimpleNonOrthogonalStateBasis`
- [x] implement `GNonOrthogonalStateBasis`
- [x] implement `RNonOrthogonalStateBasis`
- [x] implement ~`UNonOrthogonalStateBasisComponent`~ and `UNonOrthogonalStateBasis`
- [x] implement test for the unrestricted case
- [x] implement test cases with zero overlaps
