### PR TITLE
Add stl.h library for automatic conversions.

### DIFF
--- a/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
+++ b/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
@@ -25,6 +25,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 
 namespace gqcpy {


### PR DESCRIPTION
**Short description**

Add automatic conversion for `std::vector<>`.

**To do**

- [ ] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [ ] Add other smaller task to be completed as a Markdown task list
