### PR TITLE
Re-enable real OO-DOCI

### DIFF
--- a/gqcp/include/QCMethod/CI/DOCINewtonOrbitalOptimizer.hpp
+++ b/gqcp/include/QCMethod/CI/DOCINewtonOrbitalOptimizer.hpp
@@ -52,17 +52,8 @@ public:
     // The type of Eigenproblem solver.
     using EigenproblemSolver = _EigenproblemSolver;
 
-    // The type of Eigenproblem environment.
-    using EigenproblemEnvironment = EigenproblemEnvironment<double>;
-
-    // The type of eigenpairs used in this orbital optimizer.
-    using Eigenpair = Eigenpair<double, double>;
-
     // The type of ONV basis used for DOCI calculations.
     using ONVBasis = SeniorityZeroONVBasis;
-
-    // The type of linear expansion wave function model.
-    using LinearExpansion = LinearExpansion<double, ONVBasis>;
 
 
 private:
@@ -70,17 +61,17 @@ private:
     ONVBasis onv_basis;
 
     // The associated eigenproblem solver and environment.
-    EigenproblemEnvironment eigenproblem_environment;
+    EigenproblemEnvironment<double> eigenproblem_environment;
     EigenproblemSolver eigenproblem_solver;
 
     // The linear expansion representing the DOCI wave function model.
-    LinearExpansion ground_state_expansion;
+    LinearExpansion<double, ONVBasis> ground_state_expansion;
 
     // The number of requested eigenpairs.
     size_t number_of_requested_eigenpairs;
 
     // The eigenpairs containing the eigenvalues and eigenvectors of the eigenvalue problem.
-    std::vector<Eigenpair> m_eigenpairs;
+    std::vector<Eigenpair<double, double>> m_eigenpairs;
 
 
 public:
@@ -97,7 +88,7 @@ public:
      *  @param convergence_threshold            The threshold used to check for convergence.
      *  @param maximum_number_of_iterations     The maximum number of iterations that may be used to achieve convergence.
      */
-    DOCINewtonOrbitalOptimizer(const SeniorityZeroONVBasis& onv_basis, const EigenproblemSolver& eigenproblem_solver, const EigenproblemEnvironment& eigenproblem_environment, std::shared_ptr<BaseHessianModifier> hessian_modifier, const size_t number_of_requested_eigenpairs = 1, const double convergence_threshold = 1.0e-08, const size_t maximum_number_of_iterations = 128) :
+    DOCINewtonOrbitalOptimizer(const SeniorityZeroONVBasis& onv_basis, const EigenproblemSolver& eigenproblem_solver, const EigenproblemEnvironment<double>& eigenproblem_environment, std::shared_ptr<BaseHessianModifier> hessian_modifier, const size_t number_of_requested_eigenpairs = 1, const double convergence_threshold = 1.0e-08, const size_t maximum_number_of_iterations = 128) :
         onv_basis {onv_basis},
         eigenproblem_solver {eigenproblem_solver},
         eigenproblem_environment {eigenproblem_environment},
@@ -178,7 +169,7 @@ public:
      *
      *  @return The eigenpair that is associated to the given index.
      */
-    const Eigenpair& eigenpair(const size_t index = 0) const {
+    const Eigenpair<double, double>& eigenpair(const size_t index = 0) const {
 
         if (this->is_converged) {
             return this->m_eigenpairs[index];
@@ -190,7 +181,7 @@ public:
     /**
      *  @return All eigenpairs found by this orbital optimizer.
      */
-    const std::vector<Eigenpair>& eigenpairs() const {
+    const std::vector<Eigenpair<double, double>>& eigenpairs() const {
 
         if (this->is_converged) {
             return this->m_eigenpairs;
@@ -208,12 +199,12 @@ public:
      *
      *  @return The index-th excited state after doing the OO-DOCI calculation.
      */
-    LinearExpansion makeLinearExpansion(size_t index = 0) const {
+    LinearExpansion<double, ONVBasis> makeLinearExpansion(size_t index = 0) const {
         if (index > this->m_eigenpairs.size()) {
             throw std::logic_error("DOCINewtonOrbitalOptimizer::makeLinearExpansion(size_t): Not enough requested m_eigenpairs for the given index.");
         }
 
-        return LinearExpansion(this->onv_basis, this->m_eigenpairs[index].eigenvector());
+        return LinearExpansion<double, ONVBasis>(this->onv_basis, this->m_eigenpairs[index].eigenvector());
     }
 };
 

--- a/gqcp/include/QCMethod/CI/DOCINewtonOrbitalOptimizer.hpp
+++ b/gqcp/include/QCMethod/CI/DOCINewtonOrbitalOptimizer.hpp
@@ -1,189 +1,221 @@
-// // This file is part of GQCG-GQCP.
-// //
-// // Copyright (C) 2017-2020  the GQCG developers
-// //
-// // GQCG-GQCP is free software: you can redistribute it and/or modify
-// // it under the terms of the GNU Lesser General Public License as published by
-// // the Free Software Foundation, either version 3 of the License, or
-// // (at your option) any later version.
-// //
-// // GQCG-GQCP is distributed in the hope that it will be useful,
-// // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// // GNU Lesser General Public License for more details.
-// //
-// // You should have received a copy of the GNU Lesser General Public License
-// // along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
 
-// #pragma once
-
-
-// #include "Mathematical/Optimization/Eigenproblem/Eigenpair.hpp"
-// #include "Mathematical/Optimization/Eigenproblem/EigenproblemEnvironment.hpp"
-// #include "ONVBasis/SeniorityZeroONVBasis.hpp"
-// #include "QCMethod/CI/CI.hpp"
-// #include "QCMethod/CI/CIEnvironment.hpp"
-// #include "QCMethod/OrbitalOptimization/QCMethodNewtonOrbitalOptimizer.hpp"
-// #include "QCModel/CI/LinearExpansion.hpp"
-
-// #include <memory>
+#pragma once
 
 
-// namespace GQCP {
+#include "Basis/Transformations/ROrbitalRotationGenerators.hpp"
+#include "Mathematical/Optimization/Eigenproblem/Eigenpair.hpp"
+#include "Mathematical/Optimization/Eigenproblem/EigenproblemEnvironment.hpp"
+#include "ONVBasis/SeniorityZeroONVBasis.hpp"
+#include "QCMethod/CI/CI.hpp"
+#include "QCMethod/CI/CIEnvironment.hpp"
+#include "QCMethod/OrbitalOptimization/QCMethodNewtonOrbitalOptimizer.hpp"
+#include "QCModel/CI/LinearExpansion.hpp"
+
+#include <memory>
 
 
-// /**
-//  *  A class that performs gradient-and-Hessian-based orbital optimization for DOCI by sequentially
-//  *      - solving the DOCI eigenvalue problem
-//  *      - solving the Newton step to find the anti-Hermitian orbital rotation parameters
-//  *      - rotating the underlying spatial orbital basis
-//  *
-//  *  @tparam _EigenproblemSolver          the type of the eigenproblem solver that is used
-//  */
-// template <typename _EigenproblemSolver>
-// class DOCINewtonOrbitalOptimizer:
-//     public QCMethodNewtonOrbitalOptimizer {
-
-// public:
-//     using EigenproblemSolver = _EigenproblemSolver;
+namespace GQCP {
 
 
-// private:
-//     SeniorityZeroONVBasis onv_basis;  // the Fock subspace used for DOCI calculations
+/**
+ * MARK: DOCINewtonOrbitalOPtimizer implementation
+ */
 
-//     EigenproblemEnvironment eigenproblem_environment;
-//     EigenproblemSolver eigenproblem_solver;
+/**
+ *  A class that performs gradient-and-Hessian-based orbital optimization for DOCI by sequentially:
+ *      - solving the DOCI eigenvalue problem,
+ *      - solving the Newton step to find the anti-Hermitian orbital rotation parameters,
+ *      - rotating the underlying spatial orbital basis.
+ *
+ *  @tparam _EigenproblemSolver          The type of the eigenproblem solver that is used.
+ */
+template <typename _EigenproblemSolver>
+class DOCINewtonOrbitalOptimizer:
+    public QCMethodNewtonOrbitalOptimizer {
+public:
+    // The type of Eigenproblem solver.
+    using EigenproblemSolver = _EigenproblemSolver;
 
-//     LinearExpansion<SeniorityZeroONVBasis> ground_state_expansion;
+    // The type of Eigenproblem environment.
+    using EigenproblemEnvironment = EigenproblemEnvironment<double>;
 
-//     size_t number_of_requested_eigenpairs;
-//     std::vector<Eigenpair<double>> m_eigenpairs;  // eigenvalues and -vectors
+    // The type of eigenpairs used in this orbital optimizer.
+    using Eigenpair = Eigenpair<double, double>;
 
+    // The type of ONV basis used for DOCI calculations.
+    using ONVBasis = SeniorityZeroONVBasis;
 
-// public:
-//     // CONSTRUCTORS
-
-//     /**
-//      *  @param onv_basis                        the Fock subspace used for DOCI calculations
-//      *  @param eigenproblem_environment         the environments that acts as the calculation context for the eigenproblem solver
-//      *  @param eigenproblem_solver              the algorithm that tries to solve the DOCI eigenvalue problem
-//      *  @param hessian_modifier                 the modifier functor that should be used when an indefinite Hessian is encountered
-//      *  @param number_of_requested_eigenpairs   the number of m_eigenpairs that should be looked for
-//      *  @param convergence_threshold            the threshold used to check for convergence
-//      *  @param maximum_number_of_iterations     the maximum number of iterations that may be used to achieve convergence
-//      */
-//     DOCINewtonOrbitalOptimizer(const SeniorityZeroONVBasis& onv_basis, const EigenproblemSolver& eigenproblem_solver, const EigenproblemEnvironment& eigenproblem_environment, std::shared_ptr<BaseHessianModifier> hessian_modifier, const size_t number_of_requested_eigenpairs = 1, const double convergence_threshold = 1.0e-08, const size_t maximum_number_of_iterations = 128) :
-//         onv_basis {onv_basis},
-//         eigenproblem_solver {eigenproblem_solver},
-//         eigenproblem_environment {eigenproblem_environment},
-//         number_of_requested_eigenpairs {number_of_requested_eigenpairs},
-//         QCMethodNewtonOrbitalOptimizer(hessian_modifier, convergence_threshold, maximum_number_of_iterations) {}
-
-
-//     // PUBLIC OVERRIDDEN METHODS
-
-//     /**
-//      *  @return the current 1-DM
-//      */
-//     Orbital1DM<double> calculate1DM() const override {
-//         return this->ground_state_expansion.calculate1DM();
-//     }
+    // The type of linear expansion wave function model.
+    using LinearExpansion = LinearExpansion<double, ONVBasis>;
 
 
-//     /**
-//      *  @return the current 2-DM
-//      */
-//     Orbital2DM<double> calculate2DM() const override {
-//         return this->ground_state_expansion.calculate2DM();
-//     }
+private:
+    // The Fock subspace used for DOCI calculations.
+    ONVBasis onv_basis;
+
+    // The associated eigenproblem solver and environment.
+    EigenproblemEnvironment eigenproblem_environment;
+    EigenproblemSolver eigenproblem_solver;
+
+    // The linear expansion representing the DOCI wave function model.
+    LinearExpansion ground_state_expansion;
+
+    // The number of requested eigenpairs.
+    size_t number_of_requested_eigenpairs;
+
+    // The eigenpairs containing the eigenvalues and eigenvectors of the eigenvalue problem.
+    std::vector<Eigenpair> m_eigenpairs;
 
 
-//     /**
-//      *  Use gradient and Hessian information to determine a new direction for the 'full' orbital rotation generators kappa. Note that a distinction is made between 'free' generators, i.e. those that are calculated from the gradient and Hessian information and the 'full' generators, which also include the redundant parameters (that can be set to zero). The 'full' generators are used to calculate the total rotation matrix using the matrix exponential
-//      *
-//      *  @param sq_hamiltonian      the current Hamiltonian
-//      *
-//      *  @return the new full set orbital generators, including the redundant parameters
-//      */
-//     OrbitalRotationGenerators calculateNewFullOrbitalGenerators(const RSQHamiltonian<double>& sq_hamiltonian) const override {
-//         return this->calculateNewFreeOrbitalGenerators(sq_hamiltonian);  // no extra step necessary
-//     }
+public:
+    /**
+     * MARK: Constructors
+     */
+
+    /**
+     *  @param onv_basis                        The Fock subspace used for DOCI calculations.
+     *  @param eigenproblem_environment         The environments that acts as the calculation context for the eigenproblem solver.
+     *  @param eigenproblem_solver              The algorithm that tries to solve the DOCI eigenvalue problem.
+     *  @param hessian_modifier                 The modifier functor that should be used when an indefinite Hessian is encountered.
+     *  @param number_of_requested_eigenpairs   The number of m_eigenpairs that should be looked for.
+     *  @param convergence_threshold            The threshold used to check for convergence.
+     *  @param maximum_number_of_iterations     The maximum number of iterations that may be used to achieve convergence.
+     */
+    DOCINewtonOrbitalOptimizer(const SeniorityZeroONVBasis& onv_basis, const EigenproblemSolver& eigenproblem_solver, const EigenproblemEnvironment& eigenproblem_environment, std::shared_ptr<BaseHessianModifier> hessian_modifier, const size_t number_of_requested_eigenpairs = 1, const double convergence_threshold = 1.0e-08, const size_t maximum_number_of_iterations = 128) :
+        onv_basis {onv_basis},
+        eigenproblem_solver {eigenproblem_solver},
+        eigenproblem_environment {eigenproblem_environment},
+        number_of_requested_eigenpairs {number_of_requested_eigenpairs},
+        QCMethodNewtonOrbitalOptimizer(hessian_modifier, convergence_threshold, maximum_number_of_iterations) {}
 
 
-//     /**
-//      *  Prepare this object (i.e. the context for the orbital optimization algorithm) to be able to check for convergence in this Newton-based orbital optimizer
-//      *
-//      *  In the case of this uncoupled DOCI orbital optimizer, the DOCI eigenvalue problem is re-solved in every iteration using the current orbitals
-//      */
-//     void prepareDMCalculation(const RSQHamiltonian<double>& sq_hamiltonian) override {
+    /**
+     * MARK: Overridden methods
+     */
 
-//         // (Re)create the eigenproblem environment in the current orbital basis.
-//         if (this->eigenproblem_environment.A.cols() != 0) {  // if the optimization environment is 'dense'
-//             this->eigenproblem_environment = CIEnvironment::Dense(sq_hamiltonian, this->onv_basis);
-//         } else {
-
-//             // Recreate the iterative eigenproblem environment with the previous guesses.
-//             if (this->number_of_iterations != 0) {  // not needed when we haven't done an OO iteration
-//                 const auto dim = this->onv_basis.dimension();
-//                 MatrixX<double> V = MatrixX<double>::Zero(dim, this->number_of_requested_eigenpairs);
-
-//                 const auto m_eigenpairs = this->eigenproblem_environment.eigenpairs(this->number_of_requested_eigenpairs);
-//                 for (size_t i = 0; i < this->number_of_requested_eigenpairs; i++) {
-//                     V.col(i) = m_eigenpairs[i].eigenvector();
-//                 }
-
-//                 this->eigenproblem_environment = CIEnvironment::Iterative(sq_hamiltonian, this->onv_basis, V);
-//             }
-//         }
-
-//         // Set the ground state expansion and the possibly requested excited states.
-//         this->ground_state_expansion = QCMethod::CI<SeniorityZeroONVBasis>(this->onv_basis, this->number_of_requested_eigenpairs).optimize(this->eigenproblem_solver, this->eigenproblem_environment).groundStateParameters();
-//         this->m_eigenpairs = eigenproblem_environment.eigenpairs(this->number_of_requested_eigenpairs);
-//     }
+    /**
+     *  @return The current 1-DM.
+     */
+    Orbital1DM<double> calculate1DM() const override {
+        return this->ground_state_expansion.calculate1DM();
+    }
 
 
-//     // PUBLIC METHODS
-
-//     /**
-//      *  @param index                the index of a state
-//      *
-//      *  @return the eigenpair that is associated to the given index
-//      */
-//     const Eigenpair<double>& eigenpair(const size_t index = 0) const {
-
-//         if (this->is_converged) {
-//             return this->m_eigenpairs[index];
-//         } else {
-//             throw std::logic_error("DOCINewtonOrbitalOptimizer::eigenpair(const size_t): You are trying to get eigenpairs but the orbital optimization hasn't converged (yet).");
-//         }
-//     }
-
-//     /**
-//      *  @return all eigenpairs found by this orbital optimizer
-//      */
-//     const std::vector<Eigenpair<double>>& eigenpairs() const {
-
-//         if (this->is_converged) {
-//             return this->m_eigenpairs;
-//         } else {
-//             throw std::logic_error("DOCINewtonOrbitalOptimizer::eigenpairs(): You are trying to get eigenpairs but the orbital optimization hasn't converged (yet).");
-//         }
-//     }
+    /**
+     *  @return The current 2-DM.
+     */
+    Orbital2DM<double> calculate2DM() const override {
+        return this->ground_state_expansion.calculate2DM();
+    }
 
 
-//     /**
-//      *  @param index        the index of the index-th excited state
-//      *
-//      *  @return the index-th excited state after doing the OO-DOCI calculation
-//      */
-//     LinearExpansion<SeniorityZeroONVBasis> makeLinearExpansion(size_t index = 0) const {
-//         if (index > this->m_eigenpairs.size()) {
-//             throw std::logic_error("DOCINewtonOrbitalOptimizer::makeLinearExpansion(size_t): Not enough requested m_eigenpairs for the given index.");
-//         }
-
-//         return LinearExpansion<SeniorityZeroONVBasis>(this->onv_basis, this->m_eigenpairs[index].eigenvector());
-//     }
-// };
+    /**
+     *  Use gradient and Hessian information to determine a new direction for the 'full' orbital rotation generators kappa. Note that a distinction is made between 'free' generators, i.e. those that are calculated from the gradient and Hessian information and the 'full' generators, which also include the redundant parameters (that can be set to zero). The 'full' generators are used to calculate the total rotation matrix using the matrix exponential.
+     *
+     *  @param sq_hamiltonian      The current second quantized Hamiltonian.
+     *
+     *  @return The new full set orbital generators, including the redundant parameters.
+     */
+    ROrbitalRotationGenerators<double> calculateNewFullOrbitalGenerators(const RSQHamiltonian<double>& sq_hamiltonian) const override {
+        return this->calculateNewFreeOrbitalGenerators(sq_hamiltonian);  // No extra step necessary.
+    }
 
 
-// }  // namespace GQCP
+    /**
+     *  Prepare this object (i.e. the context for the orbital optimization algorithm) to be able to check for convergence in this Newton-based orbital optimizer.
+     *
+     *  In the case of this uncoupled DOCI orbital optimizer, the DOCI eigenvalue problem is re-solved in every iteration using the current orbitals.
+     */
+    void prepareDMCalculation(const RSQHamiltonian<double>& sq_hamiltonian) override {
+
+        // (Re)create the eigenproblem environment in the current orbital basis.
+        if (this->eigenproblem_environment.A.cols() != 0) {  // If the optimization environment is 'dense'.
+            this->eigenproblem_environment = CIEnvironment::Dense(sq_hamiltonian, this->onv_basis);
+        } else {
+
+            // Recreate the iterative eigenproblem environment with the previous guesses.
+            if (this->number_of_iterations != 0) {  // Not needed when we haven't done an OO iteration.
+                const auto dim = this->onv_basis.dimension();
+                MatrixX<double> V = MatrixX<double>::Zero(dim, this->number_of_requested_eigenpairs);
+
+                const auto m_eigenpairs = this->eigenproblem_environment.eigenpairs(this->number_of_requested_eigenpairs);
+                for (size_t i = 0; i < this->number_of_requested_eigenpairs; i++) {
+                    V.col(i) = m_eigenpairs[i].eigenvector();
+                }
+
+                this->eigenproblem_environment = CIEnvironment::Iterative(sq_hamiltonian, this->onv_basis, V);
+            }
+        }
+
+        // Set the ground state expansion and the possibly requested excited states.
+        this->ground_state_expansion = QCMethod::CI<double, ONVBasis>(this->onv_basis, this->number_of_requested_eigenpairs).optimize(this->eigenproblem_solver, this->eigenproblem_environment).groundStateParameters();
+        this->m_eigenpairs = eigenproblem_environment.eigenpairs(this->number_of_requested_eigenpairs);
+    }
+
+
+    /**
+     * MARK: Eigenpair access
+     */
+
+    /**
+     *  @param index                The index of a state.
+     *
+     *  @return The eigenpair that is associated to the given index.
+     */
+    const Eigenpair& eigenpair(const size_t index = 0) const {
+
+        if (this->is_converged) {
+            return this->m_eigenpairs[index];
+        } else {
+            throw std::logic_error("DOCINewtonOrbitalOptimizer::eigenpair(const size_t): You are trying to get eigenpairs but the orbital optimization hasn't converged (yet).");
+        }
+    }
+
+    /**
+     *  @return All eigenpairs found by this orbital optimizer.
+     */
+    const std::vector<Eigenpair>& eigenpairs() const {
+
+        if (this->is_converged) {
+            return this->m_eigenpairs;
+        } else {
+            throw std::logic_error("DOCINewtonOrbitalOptimizer::eigenpairs(): You are trying to get eigenpairs but the orbital optimization hasn't converged (yet).");
+        }
+    }
+
+    /**
+     * MARK: Wave function model
+     */
+
+    /**
+     *  @param index        The index of the index-th excited state.
+     *
+     *  @return The index-th excited state after doing the OO-DOCI calculation.
+     */
+    LinearExpansion makeLinearExpansion(size_t index = 0) const {
+        if (index > this->m_eigenpairs.size()) {
+            throw std::logic_error("DOCINewtonOrbitalOptimizer::makeLinearExpansion(size_t): Not enough requested m_eigenpairs for the given index.");
+        }
+
+        return LinearExpansion(this->onv_basis, this->m_eigenpairs[index].eigenvector());
+    }
+};
+
+
+}  // namespace GQCP

--- a/gqcp/tests/QCMethod/CI/CMakeLists.txt
+++ b/gqcp/tests/QCMethod/CI/CMakeLists.txt
@@ -1,6 +1,6 @@
 list(APPEND test_target_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/DOCI_test.cpp
-    # ${CMAKE_CURRENT_SOURCE_DIR}/DOCINewtonOrbitalOptimizer_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/DOCINewtonOrbitalOptimizer_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/FCI_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Hubbard_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/selected_CI_test.cpp

--- a/gqcp/tests/QCMethod/CI/DOCINewtonOrbitalOptimizer_test.cpp
+++ b/gqcp/tests/QCMethod/CI/DOCINewtonOrbitalOptimizer_test.cpp
@@ -1,124 +1,126 @@
-// // This file is part of GQCG-GQCP.
-// //
-// // Copyright (C) 2017-2020  the GQCG developers
-// //
-// // GQCG-GQCP is free software: you can redistribute it and/or modify
-// // it under the terms of the GNU Lesser General Public License as published by
-// // the Free Software Foundation, either version 3 of the License, or
-// // (at your option) any later version.
-// //
-// // GQCG-GQCP is distributed in the hope that it will be useful,
-// // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// // GNU Lesser General Public License for more details.
-// //
-// // You should have received a copy of the GNU Lesser General Public License
-// // along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
+// This file is part of GQCG-GQCP.
+//
+// Copyright (C) 2017-2020  the GQCG developers
+//
+// GQCG-GQCP is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// GQCG-GQCP is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
 
-// #define BOOST_TEST_MODULE "DOCI_orbital_optimization_test"
+#define BOOST_TEST_MODULE "DOCI_orbital_optimization_test"
 
-// #include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
-// #include "Basis/Transformations/transform.hpp"
-// #include "Mathematical/Optimization/Eigenproblem/Davidson/DavidsonSolver.hpp"
-// #include "Mathematical/Optimization/Eigenproblem/EigenproblemSolver.hpp"
-// #include "Mathematical/Optimization/Minimization/IterativeIdentitiesHessianModifier.hpp"
-// #include "Operator/SecondQuantized/SQHamiltonian.hpp"
-// #include "QCMethod/CI/CIEnvironment.hpp"
-// #include "QCMethod/CI/DOCINewtonOrbitalOptimizer.hpp"
-// #include "QCMethod/HF/RHF/DiagonalRHFFockMatrixObjective.hpp"
-// #include "QCMethod/HF/RHF/RHF.hpp"
-// #include "QCMethod/HF/RHF/RHFSCFSolver.hpp"
-
-
-// /**
-//  *  Check if OO-DOCI (dense) matches FCI for a two-electron system.
-//  *  The system of interest is H2//STO-3G, with reference results obtained from Christina at Ayer's lab.
-//  */
-// BOOST_AUTO_TEST_CASE(OO_DOCI_h2_sto_3g) {
-
-//     const double reference_fci_energy = -1.13726333769813;
-
-//     // Prepare the molecular Hamiltonian in the canonical RHF basis.
-//     const auto molecule = GQCP::Molecule::ReadXYZ("data/h2_cristina.xyz");
-//     const auto N_P = molecule.numberOfElectrons() / 2;
-//     const auto internuclear_repulsion_energy = GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()).value();  // 0.713176780299327
-
-//     GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spinor_basis {molecule, "STO-3G"};
-//     const auto K = spinor_basis.numberOfSpatialOrbitals();
-
-//     auto sq_hamiltonian = spinor_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));  // In an AO basis.
-
-//     auto rhf_environment = GQCP::RHFSCFEnvironment<double>::WithCoreGuess(molecule.numberOfElectrons(), sq_hamiltonian, spinor_basis.overlap().parameters());
-//     auto plain_rhf_scf_solver = GQCP::RHFSCFSolver<double>::Plain();
-//     const GQCP::DiagonalRHFFockMatrixObjective<double> objective {sq_hamiltonian};
-//     const auto rhf_parameters = GQCP::QCMethod::RHF<double>().optimize(objective, plain_rhf_scf_solver, rhf_environment).groundStateParameters();
-
-//     transform(rhf_parameters.expansion(), spinor_basis, sq_hamiltonian);
+#include "Basis/Transformations/transform.hpp"
+#include "Mathematical/Optimization/Eigenproblem/Davidson/DavidsonSolver.hpp"
+#include "Mathematical/Optimization/Eigenproblem/EigenproblemSolver.hpp"
+#include "Mathematical/Optimization/Minimization/IterativeIdentitiesHessianModifier.hpp"
+#include "Operator/FirstQuantized/NuclearRepulsionOperator.hpp"
+#include "Operator/SecondQuantized/SQHamiltonian.hpp"
+#include "QCMethod/CI/CIEnvironment.hpp"
+#include "QCMethod/CI/DOCINewtonOrbitalOptimizer.hpp"
+#include "QCMethod/HF/RHF/DiagonalRHFFockMatrixObjective.hpp"
+#include "QCMethod/HF/RHF/RHF.hpp"
+#include "QCMethod/HF/RHF/RHFSCFEnvironment.hpp"
+#include "QCMethod/HF/RHF/RHFSCFSolver.hpp"
 
 
-//     // Do the DOCI orbital optimization: construct the orbital optimizer and let it do its work.
-//     const GQCP::SeniorityZeroONVBasis onv_basis {K, N_P};
+/**
+ *  Check if OO-DOCI (dense) matches FCI for a two-electron system.
+ *  The system of interest is H2//STO-3G, with reference results obtained from Christina at Ayer's lab.
+ */
+BOOST_AUTO_TEST_CASE(OO_DOCI_h2_sto_3g) {
 
-//     auto environment = GQCP::CIEnvironment::Dense(sq_hamiltonian, onv_basis);
-//     auto solver = GQCP::EigenproblemSolver::Dense<double>();
-//     using EigenproblemSolver = decltype(solver);
+    const double reference_fci_energy = -1.13726333769813;
 
-//     auto hessian_modifier = std::make_shared<GQCP::IterativeIdentitiesHessianModifier>();
-//     GQCP::DOCINewtonOrbitalOptimizer<EigenproblemSolver> orbital_optimizer {onv_basis, solver, environment, hessian_modifier};
-//     orbital_optimizer.optimize(spinor_basis, sq_hamiltonian);
+    // Prepare the molecular Hamiltonian in the canonical RHF basis.
+    const auto molecule = GQCP::Molecule::ReadXYZ("data/h2_cristina.xyz");
+    const auto N_P = molecule.numberOfElectrons() / 2;
+    const auto internuclear_repulsion_energy = GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()).value();  // 0.713176780299327
 
-//     const auto OO_DOCI_eigenvalue = orbital_optimizer.eigenpair().eigenvalue();
+    GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spinor_basis {molecule, "STO-3G"};
+    const auto K = spinor_basis.numberOfSpatialOrbitals();
 
+    auto sq_hamiltonian = spinor_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));  // In an AO basis.
 
-//     // Check if the OO-DOCI energy is equal to the FCI energy.
-//     const double OO_DOCI_energy = OO_DOCI_eigenvalue + internuclear_repulsion_energy;
-//     BOOST_CHECK(std::abs(OO_DOCI_energy - reference_fci_energy) < 1.0e-08);
-// }
+    auto rhf_environment = GQCP::RHFSCFEnvironment<double>::WithCoreGuess(molecule.numberOfElectrons(), sq_hamiltonian, spinor_basis.overlap().parameters());
+    auto plain_rhf_scf_solver = GQCP::RHFSCFSolver<double>::Plain();
+    const GQCP::DiagonalRHFFockMatrixObjective<double> objective {sq_hamiltonian};
+    const auto rhf_parameters = GQCP::QCMethod::RHF<double>().optimize(objective, plain_rhf_scf_solver, rhf_environment).groundStateParameters();
 
-
-// /**
-//  *  Check if OO-DOCI (Davidson) matches FCI for a two-electron system.
-//  *  The system of interest is H2//6-31G**, with reference results obtained from Christina at Ayer's lab.
-//  */
-// BOOST_AUTO_TEST_CASE(OO_DOCI_h2_6_31gxx_Davidson) {
-
-//     const double reference_fci_energy = -1.16514875501195;
-
-//     // Prepare the molecular Hamiltonian in the canonical RHF basis.
-//     const auto molecule = GQCP::Molecule::ReadXYZ("data/h2_cristina.xyz");
-//     const auto N_P = molecule.numberOfElectrons() / 2;
-//     const auto internuclear_repulsion_energy = GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()).value();  // 0.713176780299327
-
-//     GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spinor_basis {molecule, "6-31G**"};
-//     const auto K = spinor_basis.numberOfSpatialOrbitals();
-
-//     auto sq_hamiltonian = spinor_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));  // In an AO basis.
-
-//     auto rhf_environment = GQCP::RHFSCFEnvironment<double>::WithCoreGuess(molecule.numberOfElectrons(), sq_hamiltonian, spinor_basis.overlap().parameters());
-//     auto plain_rhf_scf_solver = GQCP::RHFSCFSolver<double>::Plain();
-//     const GQCP::DiagonalRHFFockMatrixObjective<double> objective {sq_hamiltonian};
-//     const auto rhf_parameters = GQCP::QCMethod::RHF<double>().optimize(objective, plain_rhf_scf_solver, rhf_environment).groundStateParameters();
-
-//     transform(rhf_parameters.expansion(), spinor_basis, sq_hamiltonian);
+    transform(rhf_parameters.expansion(), spinor_basis, sq_hamiltonian);
 
 
-//     // Do the DOCI orbital optimization: construct the orbital optimizer and let it do its work.
-//     const GQCP::SeniorityZeroONVBasis onv_basis {K, N_P};
+    // Do the DOCI orbital optimization: construct the orbital optimizer and let it do its work.
+    const GQCP::SeniorityZeroONVBasis onv_basis {K, N_P};
 
-//     const auto initial_guess = GQCP::LinearExpansion<double, GQCP::SeniorityZeroONVBasis>::HartreeFock(onv_basis).coefficients();
-//     auto environment = GQCP::CIEnvironment::Iterative(sq_hamiltonian, onv_basis, initial_guess);
-//     auto solver = GQCP::EigenproblemSolver::Davidson();
-//     using EigenproblemSolver = decltype(solver);
+    auto environment = GQCP::CIEnvironment::Dense(sq_hamiltonian, onv_basis);
+    auto solver = GQCP::EigenproblemSolver::Dense<double>();
+    using EigenproblemSolver = decltype(solver);
 
-//     auto hessian_modifier = std::make_shared<GQCP::IterativeIdentitiesHessianModifier>();
-//     GQCP::DOCINewtonOrbitalOptimizer<EigenproblemSolver> orbital_optimizer {onv_basis, solver, environment, hessian_modifier};
-//     orbital_optimizer.optimize(spinor_basis, sq_hamiltonian);
+    auto hessian_modifier = std::make_shared<GQCP::IterativeIdentitiesHessianModifier>();
+    GQCP::DOCINewtonOrbitalOptimizer<EigenproblemSolver> orbital_optimizer {onv_basis, solver, environment, hessian_modifier};
+    orbital_optimizer.optimize(spinor_basis, sq_hamiltonian);
 
-//     const auto OO_DOCI_eigenvalue = orbital_optimizer.eigenpair().eigenvalue();
+    const auto OO_DOCI_eigenvalue = orbital_optimizer.eigenpair().eigenvalue();
 
 
-//     // Check if the OO-DOCI energy is equal to the FCI energy.
-//     const double OO_DOCI_energy = OO_DOCI_eigenvalue + internuclear_repulsion_energy;
-//     BOOST_CHECK(std::abs(OO_DOCI_energy - reference_fci_energy) < 1.0e-08);
-// }
+    // Check if the OO-DOCI energy is equal to the FCI energy.
+    const double OO_DOCI_energy = OO_DOCI_eigenvalue + internuclear_repulsion_energy;
+    BOOST_CHECK(std::abs(OO_DOCI_energy - reference_fci_energy) < 1.0e-08);
+}
+
+
+/**
+ *  Check if OO-DOCI (Davidson) matches FCI for a two-electron system.
+ *  The system of interest is H2//6-31G**, with reference results obtained from Christina at Ayer's lab.
+ */
+BOOST_AUTO_TEST_CASE(OO_DOCI_h2_6_31gxx_Davidson) {
+
+    const double reference_fci_energy = -1.16514875501195;
+
+    // Prepare the molecular Hamiltonian in the canonical RHF basis.
+    const auto molecule = GQCP::Molecule::ReadXYZ("data/h2_cristina.xyz");
+    const auto N_P = molecule.numberOfElectrons() / 2;
+    const auto internuclear_repulsion_energy = GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()).value();  // 0.713176780299327
+
+    GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spinor_basis {molecule, "6-31G**"};
+    const auto K = spinor_basis.numberOfSpatialOrbitals();
+
+    auto sq_hamiltonian = spinor_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));  // In an AO basis.
+
+    auto rhf_environment = GQCP::RHFSCFEnvironment<double>::WithCoreGuess(molecule.numberOfElectrons(), sq_hamiltonian, spinor_basis.overlap().parameters());
+    auto plain_rhf_scf_solver = GQCP::RHFSCFSolver<double>::Plain();
+    const GQCP::DiagonalRHFFockMatrixObjective<double> objective {sq_hamiltonian};
+    const auto rhf_parameters = GQCP::QCMethod::RHF<double>().optimize(objective, plain_rhf_scf_solver, rhf_environment).groundStateParameters();
+
+    transform(rhf_parameters.expansion(), spinor_basis, sq_hamiltonian);
+
+
+    // Do the DOCI orbital optimization: construct the orbital optimizer and let it do its work.
+    const GQCP::SeniorityZeroONVBasis onv_basis {K, N_P};
+
+    const auto initial_guess = GQCP::LinearExpansion<double, GQCP::SeniorityZeroONVBasis>::HartreeFock(onv_basis).coefficients();
+    auto environment = GQCP::CIEnvironment::Iterative(sq_hamiltonian, onv_basis, initial_guess);
+    auto solver = GQCP::EigenproblemSolver::Davidson();
+    using EigenproblemSolver = decltype(solver);
+
+    auto hessian_modifier = std::make_shared<GQCP::IterativeIdentitiesHessianModifier>();
+    GQCP::DOCINewtonOrbitalOptimizer<EigenproblemSolver> orbital_optimizer {onv_basis, solver, environment, hessian_modifier};
+    orbital_optimizer.optimize(spinor_basis, sq_hamiltonian);
+
+    const auto OO_DOCI_eigenvalue = orbital_optimizer.eigenpair().eigenvalue();
+
+
+    // Check if the OO-DOCI energy is equal to the FCI energy.
+    const double OO_DOCI_energy = OO_DOCI_eigenvalue + internuclear_repulsion_energy;
+    BOOST_CHECK(std::abs(OO_DOCI_energy - reference_fci_energy) < 1.0e-08);
+}

--- a/gqcp/tests/QCMethod/CI/DOCINewtonOrbitalOptimizer_test.cpp
+++ b/gqcp/tests/QCMethod/CI/DOCINewtonOrbitalOptimizer_test.cpp
@@ -21,6 +21,7 @@
 
 #include "Basis/Transformations/transform.hpp"
 #include "Mathematical/Optimization/Eigenproblem/Davidson/DavidsonSolver.hpp"
+#include "Mathematical/Optimization/Eigenproblem/EigenproblemEnvironment.hpp"
 #include "Mathematical/Optimization/Eigenproblem/EigenproblemSolver.hpp"
 #include "Mathematical/Optimization/Minimization/IterativeIdentitiesHessianModifier.hpp"
 #include "Operator/FirstQuantized/NuclearRepulsionOperator.hpp"

--- a/gqcpy/gqcpy.cpp
+++ b/gqcpy/gqcpy.cpp
@@ -202,6 +202,8 @@ void bindCCSDSolver(py::module& module);
 // QCMethod - CI
 void bindCIEnvironments(py::module& module);
 void bindCIFactory(py::module& module);
+void bindDOCINewtonOrbitalOptimizers(py::module& module);
+void bindDOCINewtonOrbitalOptimizerFactory(py::module& module);
 void bindQCMethodCI(py::module& module);
 
 
@@ -452,6 +454,8 @@ PYBIND11_MODULE(gqcpy, module) {
     // QCMethod - CI
     gqcpy::bindCIEnvironments(module);
     gqcpy::bindCIFactory(module);
+    gqcpy::bindDOCINewtonOrbitalOptimizers(module);
+    gqcpy::bindDOCINewtonOrbitalOptimizerFactory(module);
     gqcpy::bindQCMethodCI(module);
 
 

--- a/gqcpy/src/QCMethod/CI/CMakeLists.txt
+++ b/gqcpy/src/QCMethod/CI/CMakeLists.txt
@@ -2,6 +2,8 @@ list(APPEND python_bindings_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/CI_factory_bindings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CI_bindings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CIEnvironment_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/DOCINewtonOrbitalOptimizer_bindings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/DOCINewtonOrbitalOptimizer_factory_bindings.cpp
 )
 
 set(python_bindings_sources ${python_bindings_sources} PARENT_SCOPE)

--- a/gqcpy/src/QCMethod/CI/DOCINewtonOrbitalOptimizer_bindings.cpp
+++ b/gqcpy/src/QCMethod/CI/DOCINewtonOrbitalOptimizer_bindings.cpp
@@ -32,9 +32,9 @@ using namespace GQCP;
 
 /**
  *  Bind a templated DOCI Newton orbital optimizer.
- * 
+ *
  *  @tparam EigenproblemSolver          the type of the eigenvalue problem solver that should be used
- * 
+ *
  *  @param module                       the pybind11 module in which these bindings should appear
  *  @param suffix                       the suffix that should appear in the Python class name in the following manner: "DOCINewtonOrbitalOptimizer_suffix"
  */
@@ -45,7 +45,9 @@ void bindDOCINewtonOrbitalOptimizer(py::module& module, const std::string& suffi
                                                                ("DOCINewtonOrbitalOptimizer_" + suffix).c_str(),
                                                                "A class that performs gradient-and-Hessian-based orbital optimization for DOCI")
 
-        // PUBLIC METHODS
+        /**
+         * MARK: Optimization
+         */
 
         .def(
             "optimize",
@@ -53,13 +55,72 @@ void bindDOCINewtonOrbitalOptimizer(py::module& module, const std::string& suffi
                 optimizer.optimize(spinor_basis, sq_hamiltonian);
             },
             py::arg("spinor_basis"),
-            py::arg("sq_hamiltonian"));
+            py::arg("sq_hamiltonian"))
+
+
+        /**
+         * MARK: Eigenpair access
+         */
+
+        .def(
+            "eigenvalue",
+            [](const DOCINewtonOrbitalOptimizer<EigenproblemSolver>& optimizer, const size_t index = 0) {
+                return optimizer.eigenpair(index).eigenvalue();
+            },
+            py::arg("index") = 0,
+            "Return the eigenvalue at the given index found by the optimizer.")
+
+        .def(
+            "eigenvalues",
+            [](const DOCINewtonOrbitalOptimizer<EigenproblemSolver>& optimizer) {
+                std::vector<double> eigenvalues {};
+
+                for (size_t i = 0; i < optimizer.eigenpairs().size(); i++) {
+                    eigenvalues.push_back(optimizer.eigenpair(i).eigenvalue());
+                }
+                return eigenvalues;
+            },
+            "Return all the eigenvalues found by the optimizer.")
+
+
+        .def(
+            "eigenvector",
+            [](const DOCINewtonOrbitalOptimizer<EigenproblemSolver>& optimizer, const size_t index = 0) {
+                return optimizer.eigenpair(index).eigenvector();
+            },
+            py::arg("index") = 0,
+            "Return the eigenvector at the given index found by the optimizer.")
+
+        .def(
+            "eigenvectors",
+            [](const DOCINewtonOrbitalOptimizer<EigenproblemSolver>& optimizer) {
+                std::vector<GQCP::VectorX<double>> eigenvectors {};
+
+                for (size_t i = 0; i < optimizer.eigenpairs().size(); i++) {
+                    eigenvectors.push_back(optimizer.eigenpair(i).eigenvector());
+                }
+                return eigenvectors;
+            },
+            "Return all the eigenvectors found by the optimizer.")
+
+
+        /**
+         * MARK: Wave function model
+         */
+
+        .def(
+            "makeLinearExpansion",
+            [](const DOCINewtonOrbitalOptimizer<EigenproblemSolver>& optimizer, const size_t index = 0) {
+                return optimizer.makeLinearExpansion(index);
+            },
+            py::arg("index") = 0,
+            "Return the linear expansion wave function model of the given eigenpair found by the optimizer.");
 }
 
 
 /**
  *  Bind all kinds of DOCI Newton orbital optimizers to the given module.
- * 
+ *
  *  @param module           the module to which these optimizers should be bound: gqcpy
  */
 void bindDOCINewtonOrbitalOptimizers(py::module& module) {

--- a/gqcpy/src/QCMethod/CI/DOCINewtonOrbitalOptimizer_bindings.cpp
+++ b/gqcpy/src/QCMethod/CI/DOCINewtonOrbitalOptimizer_bindings.cpp
@@ -64,8 +64,8 @@ void bindDOCINewtonOrbitalOptimizer(py::module& module, const std::string& suffi
  */
 void bindDOCINewtonOrbitalOptimizers(py::module& module) {
 
-    bindDOCINewtonOrbitalOptimizer<Algorithm<EigenproblemEnvironment>>(module, "Dense");
-    bindDOCINewtonOrbitalOptimizer<IterativeAlgorithm<EigenproblemEnvironment>>(module, "Iterative");
+    bindDOCINewtonOrbitalOptimizer<Algorithm<EigenproblemEnvironment<double>>>(module, "Dense");
+    bindDOCINewtonOrbitalOptimizer<IterativeAlgorithm<EigenproblemEnvironment<double>>>(module, "Iterative");
 }
 
 

--- a/gqcpy/src/QCMethod/CI/DOCINewtonOrbitalOptimizer_factory_bindings.cpp
+++ b/gqcpy/src/QCMethod/CI/DOCINewtonOrbitalOptimizer_factory_bindings.cpp
@@ -43,7 +43,7 @@ void bindDOCINewtonOrbitalOptimizerFactoryMethod(py::module& module) {
 
     module.def(
         "DOCINewtonOrbitalOptimizer",
-        [](const SeniorityZeroONVBasis& onv_basis, const EigenproblemSolver& solver, const EigenproblemEnvironment& environment, const size_t number_of_requested_eigenpairs = 1, const double convergence_threshold = 1.0e-08, const size_t maximum_number_of_iterations = 128) {
+        [](const SeniorityZeroONVBasis& onv_basis, const EigenproblemSolver& solver, const EigenproblemEnvironment<double>& environment, const size_t number_of_requested_eigenpairs = 1, const double convergence_threshold = 1.0e-08, const size_t maximum_number_of_iterations = 128) {
             auto hessian_modifier = std::make_shared<IterativeIdentitiesHessianModifier>();
 
             return DOCINewtonOrbitalOptimizer<EigenproblemSolver>(onv_basis, solver, environment, hessian_modifier, number_of_requested_eigenpairs, convergence_threshold, maximum_number_of_iterations);
@@ -62,8 +62,8 @@ void bindDOCINewtonOrbitalOptimizerFactoryMethod(py::module& module) {
  */
 void bindDOCINewtonOrbitalOptimizerFactory(py::module& module) {
 
-    bindDOCINewtonOrbitalOptimizerFactoryMethod<IterativeAlgorithm<EigenproblemEnvironment>>(module);
-    bindDOCINewtonOrbitalOptimizerFactoryMethod<Algorithm<EigenproblemEnvironment>>(module);
+    bindDOCINewtonOrbitalOptimizerFactoryMethod<IterativeAlgorithm<EigenproblemEnvironment<double>>>(module);
+    bindDOCINewtonOrbitalOptimizerFactoryMethod<Algorithm<EigenproblemEnvironment<double>>>(module);
 }
 
 

--- a/gqcpy/src/QCMethod/CI/DOCINewtonOrbitalOptimizer_factory_bindings.cpp
+++ b/gqcpy/src/QCMethod/CI/DOCINewtonOrbitalOptimizer_factory_bindings.cpp
@@ -35,11 +35,15 @@ using namespace GQCP;
 
 /**
  *  Bind a factory-like method for a DOCI Newton orbital optimizer.
- * 
+ *
  *  @tparam EigenproblemSolver          the type of the eigenvalue problem solver that should be used
  */
 template <typename EigenproblemSolver>
 void bindDOCINewtonOrbitalOptimizerFactoryMethod(py::module& module) {
+
+    /**
+     * MARK: Constructor
+     */
 
     module.def(
         "DOCINewtonOrbitalOptimizer",

--- a/website/_toc.yml
+++ b/website/_toc.yml
@@ -26,6 +26,7 @@
     - file: examples/Following-internal-GHF-instabilities
     - file: examples/ONVPath
     - file: examples/DOCI
+    - file: examples/OO-DOCI
     - file: examples/FCI
     - file: examples/Hubbard
     - file: examples/AP1roG-calculations

--- a/website/examples/OO-DOCI.ipynb
+++ b/website/examples/OO-DOCI.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OO-DOCI calculations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DOCI is, in essence, just another type of CI, so doing DOCI calculations is very analogous to doing FCI calculations. In the OO-DOCI case, we enhance the regular DOCI method with the use of an orbital optimizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Force the local gqcpy to be imported\n",
+    "import sys\n",
+    "sys.path.insert(0, '../../build/gqcpy/')\n",
+    "\n",
+    "import gqcpy\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Preparing the Hamiltonian in the canonical RHF basis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As always, we'll first set up the Hamiltonian in an orthonormal spinor basis. For this example, we'll use the canonical RHF basis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "molecule = gqcpy.Molecule.ReadXYZ(\"../../gqcp/tests/data/h2_cristina.xyz\" , 0)  # Create a neutral molecule\n",
+    "N = molecule.numberOfElectrons()\n",
+    "N_P = N // 2  # number of electron pairs\n",
+    "\n",
+    "spinor_basis = gqcpy.RSpinOrbitalBasis_d(molecule, \"STO-3G\")\n",
+    "K = spinor_basis.numberOfSpatialOrbitals()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "S = spinor_basis.quantize(gqcpy.OverlapOperator())\n",
+    "nuc_rep = gqcpy.NuclearRepulsionOperator(molecule.MolecularFramework()).value()\n",
+    "sq_hamiltonian = spinor_basis.quantize(gqcpy.FQMolecularHamiltonian(molecule))\n",
+    "\n",
+    "environment = gqcpy.RHFSCFEnvironment_d.WithCoreGuess(N, sq_hamiltonian, S)\n",
+    "solver = gqcpy.RHFSCFSolver_d.Plain()\n",
+    "objective = gqcpy.DiagonalRHFFockMatrixObjective_d(sq_hamiltonian)  # use the default threshold of 1.0e-08\n",
+    "rhf_parameters = gqcpy.RHF_d.optimize(objective, solver, environment).groundStateParameters()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "C = rhf_parameters.expansion()\n",
+    "spinor_basis.transform(C)\n",
+    "sq_hamiltonian.transform(C)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dense OO-DOCI calculations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For FCI, we would create the full spin-resolved ONV basis. For DOCI, we need the full seniority-zero ONV basis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "onv_basis = gqcpy.SeniorityZeroONVBasis(K, N_P)  # number of spatial orbitals, number of electron pairs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The subsequent steps are very analogous. We create a solver and associated environment, and use the CI QCMethod to find the optimal parameters and energies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "solver = gqcpy.EigenproblemSolver.Dense_d()\n",
+    "environment = gqcpy.CIEnvironment.Dense(sq_hamiltonian, onv_basis)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now have to declare our orbital optimizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer = gqcpy.DOCINewtonOrbitalOptimizer(onv_basis, solver, environment)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The orbital optimizer can now do the required optimization given the spinor basis and the second quantized Hamiltonian."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer.optimize(spinor_basis, sq_hamiltonian)"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "e4c6ce54e6d1ccff551279c9aafc06b78c48fd9e60d6b4e74c0583a74ec1d1f9"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.5 64-bit ('base': conda)",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/website/examples/OO-DOCI.ipynb
+++ b/website/examples/OO-DOCI.ipynb
@@ -157,31 +157,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
-     "ename": "AttributeError",
-     "evalue": "'gqcpy.DOCINewtonOrbitalOptimizer_Dense' object has no attribute 'eigenvalue'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-10-a1ee4c551cce>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moptimizer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0meigenvalue\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m: 'gqcpy.DOCINewtonOrbitalOptimizer_Dense' object has no attribute 'eigenvalue'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-1.137263337693952\n"
      ]
     }
    ],
    "source": [
-    "print(optimizer.eigenvalue())"
+    "print(optimizer.eigenvalue() + nuc_rep)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/website/examples/OO-DOCI.ipynb
+++ b/website/examples/OO-DOCI.ipynb
@@ -58,12 +58,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "S = spinor_basis.quantize(gqcpy.OverlapOperator())\n",
-    "nuc_rep = gqcpy.NuclearRepulsionOperator(molecule.MolecularFramework()).value()\n",
+    "nuc_rep = gqcpy.NuclearRepulsionOperator(molecule.nuclearFramework()).value()\n",
     "sq_hamiltonian = spinor_basis.quantize(gqcpy.FQMolecularHamiltonian(molecule))\n",
     "\n",
     "environment = gqcpy.RHFSCFEnvironment_d.WithCoreGuess(N, sq_hamiltonian, S)\n",
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,17 +148,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
     "optimizer.optimize(spinor_basis, sq_hamiltonian)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'gqcpy.DOCINewtonOrbitalOptimizer_Dense' object has no attribute 'eigenvalue'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-10-a1ee4c551cce>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moptimizer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0meigenvalue\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m: 'gqcpy.DOCINewtonOrbitalOptimizer_Dense' object has no attribute 'eigenvalue'"
+     ]
+    }
+   ],
+   "source": [
+    "print(optimizer.eigenvalue())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "interpreter": {
-   "hash": "e4c6ce54e6d1ccff551279c9aafc06b78c48fd9e60d6b4e74c0583a74ec1d1f9"
+   "hash": "4654e147d6fe676f31a9f86e2485eea716359f8709963986145f7c2d0088ba8c"
   },
   "kernelspec": {
    "display_name": "Python 3.8.5 64-bit ('base': conda)",


### PR DESCRIPTION
**Short description**

In line with the request from @pbultink, this PR will re-enable the real valued OO-DOCI functionalities. I have opted to only enable the real case at this moment, as there is a lot of work to be done in templating all of the `OrbitalOPtimization.cpp` files. 

**Related issues**

- issue #872 is related, but will not be closed completely. I will update the issue once this PR is finished.

**To do**

- [x] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [x] Re-enable the C++ functionalities of real valued OO-DOCI
- [x] Implement python bindings for real valued OO-DOCI.
