### PR TITLE
Refactor calculateOrbitalRDM method.

### DIFF
--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1802,6 +1802,32 @@ public:
             throw std::invalid_argument("LinearExpansion::calculateOrbitalRDM(std::vector<ONV>& system_onvs, std::vector<ONV>& environment_onvs, const ONV& onv_n_bra, const ONV& onv_b_ket) const: The amount of system ONVs should be exactly the same as the amount of environment ONVs.");
         }
 
+        const auto create_onv_basis = [](const std::vector<typename ONVBasis::ONV>& onvs) {
+            std::vector<typename ONVBasis::ONV> onv_basis;
+            std::vector<size_t> unique_representations;
+
+            for (const auto& onv : onvs) {
+
+                bool unique = true;
+                const auto onv_representation = onv.unsignedRepresentation();
+
+                for (const auto& unique_representation : unique_representations) {
+                    if (onv_representation == unique_representation) {
+                        unique = false;
+                    }
+                }
+
+                if (unique) {
+                    onv_basis.push_back(onv);
+                    onv_basis_representations.push_back(onv.unsignedRepresentation());
+                }
+            }
+            return onv_basis;
+        });
+
+        const auto test_onv_basis = create_onv_basis(system_onvs);
+        std::cout << "test onv basis size: " << test_onv_basis.size() << std::endl;
+
         const auto dim = system_onv_basis.size();
         GQCP::SquareMatrix<Scalar> rho = GQCP::SquareMatrix<Scalar>::Zero(dim);
 

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1796,38 +1796,38 @@ public:
      *  @return The orbital reduced density matrix.
      */
     template <typename Z = ONVBasis>
-    enable_if_t<std::is_same<Z, SpinUnresolvedONVBasis>::value | std::is_same<Z, SpinResolvedONVBasis>::value, GQCP::SquareMatrix<Scalar>> calculateOrbitalRDM(const std::vector<typename ONVBasis::ONV>& system_onvs, const std::vector<typename ONVBasis::ONV>& environment_onvs, const std::vector<typename ONVBasis::ONV>& system_onv_basis, const std::vector<typename ONVBasis::ONV>& environment_onv_basis) const {
+    enable_if_t<std::is_same<Z, SpinUnresolvedONVBasis>::value | std::is_same<Z, SpinResolvedONVBasis>::value, GQCP::SquareMatrix<Scalar>> calculateOrbitalRDM(const std::vector<typename ONVBasis::ONV>& system_onvs, const std::vector<typename ONVBasis::ONV>& environment_onvs) const {
 
         if (system_onvs.size() != environment_onvs.size()) {
-            throw std::invalid_argument("LinearExpansion::calculateOrbitalRDM(std::vector<ONV>& system_onvs, std::vector<ONV>& environment_onvs, const ONV& onv_n_bra, const ONV& onv_b_ket) const: The amount of system ONVs should be exactly the same as the amount of environment ONVs.");
+            throw std::invalid_argument("LinearExpansion::calculateOrbitalRDM(std::vector<ONV>& system_onvs, std::vector<ONV>& environment_onvs) const: The amount of system ONVs should be exactly the same as the amount of environment ONVs.");
         }
 
-        const auto create_onv_basis = [](const std::vector<typename ONVBasis::ONV>& onvs) {
+        // Determine the dimensions of the orbital density matrix.
+        const auto unique_onvs = [](const std::vector<typename ONVBasis::ONV>& onvs) {
+            // The ONV basis containing all unique ONVs.
             std::vector<typename ONVBasis::ONV> onv_basis;
-            std::vector<size_t> unique_representations;
 
             for (const auto& onv : onvs) {
 
                 bool unique = true;
-                const auto onv_representation = onv.unsignedRepresentation();
-
-                for (const auto& unique_representation : unique_representations) {
-                    if (onv_representation == unique_representation) {
+                // If the ONV already is inside this basis, do not add it again.
+                for (const auto& unique_onv : onv_basis) {
+                    if (onv.asString() == unique_onv.asString()) {
                         unique = false;
                     }
                 }
-
+                // If it is an unique ONV, add it to the ONV basis.
                 if (unique) {
                     onv_basis.push_back(onv);
-                    onv_basis_representations.push_back(onv.unsignedRepresentation());
                 }
             }
             return onv_basis;
-        });
+        };
 
-        const auto test_onv_basis = create_onv_basis(system_onvs);
-        std::cout << "test onv basis size: " << test_onv_basis.size() << std::endl;
+        const auto system_onv_basis = unique_onvs(system_onvs);
+        const auto environment_onv_basis = unique_onvs(environment_onvs);
 
+        // Calculate the orbital reduced density matrix.
         const auto dim = system_onv_basis.size();
         GQCP::SquareMatrix<Scalar> rho = GQCP::SquareMatrix<Scalar>::Zero(dim);
 

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -143,12 +143,8 @@ BOOST_AUTO_TEST_CASE(orbital_reduced_density_matrix) {
     std::vector<GQCP::SpinUnresolvedONV> system_onvs {{2, 1, 1}, {2, 2, 3}, {2, 1, 2}, {2, 1, 1}, {2, 0, 0}, {2, 1, 2}};
     // |10>, |00>, |10>, |01>, |11>, |01>
     std::vector<GQCP::SpinUnresolvedONV> environment_onvs {{2, 1, 1}, {2, 0, 0}, {2, 1, 1}, {2, 1, 2}, {2, 2, 3}, {2, 1, 2}};
-    // |10>, |11>, |01>, |00>
-    std::vector<GQCP::SpinUnresolvedONV> system_onv_basis {{2, 1, 1}, {2, 2, 3}, {2, 1, 2}, {2, 0, 0}};
-    // |10>, |00>, |01>, |11>
-    std::vector<GQCP::SpinUnresolvedONV> environment_onv_basis {{2, 1, 1}, {2, 0, 0}, {2, 1, 2}, {2, 2, 3}};
 
-    const auto rho = wfn.calculateOrbitalRDM(system_onvs, environment_onvs, system_onv_basis, environment_onv_basis);
+    const auto rho = wfn.calculateOrbitalRDM(system_onvs, environment_onvs);
 
     // <n| = <10|, |n'> = |10>
     BOOST_CHECK_EQUAL(rho(0, 0), wfn.coefficient(0) * wfn.coefficient(0) + wfn.coefficient(3) * wfn.coefficient(3));

--- a/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
+++ b/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
@@ -245,13 +245,11 @@ void bindLinearExpansions(py::module& module) {
 
         .def(
             "calculateOrbitalRDM",
-            [](const LinearExpansion<double, SpinResolvedONVBasis>& linear_expansion, const std::vector<GQCP::SpinResolvedONV>& system_onvs, const std::vector<GQCP::SpinResolvedONV>& environment_onvs, const std::vector<GQCP::SpinResolvedONV>& system_onv_basis, const std::vector<GQCP::SpinResolvedONV>& environment_onv_basis) {
-                return linear_expansion.calculateOrbitalRDM(system_onvs, environment_onvs, system_onv_basis, environment_onv_basis);
+            [](const LinearExpansion<double, SpinResolvedONVBasis>& linear_expansion, const std::vector<GQCP::SpinResolvedONV>& system_onvs, const std::vector<GQCP::SpinResolvedONV>& environment_onvs) {
+                return linear_expansion.calculateOrbitalRDM(system_onvs, environment_onvs);
             },
             py::arg("system_onvs"),
             py::arg("environment_onvs"),
-            py::arg("system_onv_basis"),
-            py::arg("environment_onv_basis"),
             "Return the orbital reduced density matrix")
 
         .def(
@@ -359,13 +357,11 @@ void bindLinearExpansions(py::module& module) {
 
         .def(
             "calculateOrbitalRDM",
-            [](const LinearExpansion<double, SpinUnresolvedONVBasis>& linear_expansion, const std::vector<GQCP::SpinUnresolvedONV>& system_onvs, const std::vector<GQCP::SpinUnresolvedONV>& environment_onvs, const std::vector<GQCP::SpinUnresolvedONV>& system_onv_basis, const std::vector<GQCP::SpinUnresolvedONV>& environment_onv_basis) {
-                return linear_expansion.calculateOrbitalRDM(system_onvs, environment_onvs, system_onv_basis, environment_onv_basis);
+            [](const LinearExpansion<double, SpinUnresolvedONVBasis>& linear_expansion, const std::vector<GQCP::SpinUnresolvedONV>& system_onvs, const std::vector<GQCP::SpinUnresolvedONV>& environment_onvs) {
+                return linear_expansion.calculateOrbitalRDM(system_onvs, environment_onvs);
             },
             py::arg("system_onvs"),
             py::arg("environment_onvs"),
-            py::arg("system_onv_basis"),
-            py::arg("environment_onv_basis"),
             "Return the orbital reduced density matrix")
 
         /*


### PR DESCRIPTION
**Short description**

This PR refactors the `calculateOrbitalRDM()` method of `LinearExpansion` such that it calculates the ONV basis of the system and environment instead of passing it as parameters.


**To do**

- [ ] Refactor method in `LinearExpansion.hpp`.
- [ ] Rewrite Python bindings.
- [ ] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [ ] Add other smaller task to be completed as a Markdown task list
