### PR TITLE
Sz bindings for real GSpinorBasis

### DIFF
--- a/gqcp/include/Basis/BiorthogonalBasis/SimpleLowdinPairingBasis.hpp
+++ b/gqcp/include/Basis/BiorthogonalBasis/SimpleLowdinPairingBasis.hpp
@@ -155,9 +155,9 @@ public:
         Tensor<Scalar, 2> C_ket_occupied_tensor = Tensor<Scalar, 2>(occ_ket_map);
 
         // Perform the contractions in order to biorthogonalize the occupied bra and ket expansions.
-        // The SVD results in matrices U and V_adjoint. This is why, in order to do a contraction with matrix `V` we take the conjugate of the resulting matrix.
+        // The SVD, in contrast to numpy, returns the matrices U and V. No adjoint or transpose is necessary.
         Tensor<Scalar, 2> biorthogonal_bra_occupied = C_bra_occupied_tensor.template einsum<1>("ui,ij->uj", svd.matrixU());
-        Tensor<Scalar, 2> biorthogonal_ket_occupied = C_ket_occupied_tensor.template einsum<1>("ui,ij->uj", svd.matrixV().conjugate());
+        Tensor<Scalar, 2> biorthogonal_ket_occupied = C_ket_occupied_tensor.template einsum<1>("ui,ij->uj", svd.matrixV());
 
         // We now have the biorthogonal expansion coefficients.
         this->occupied_biorthogonal_state_expansions = std::pair<Matrix, Matrix> {biorthogonal_bra_occupied.asMatrix(), biorthogonal_ket_occupied.asMatrix()};
@@ -178,7 +178,7 @@ public:
         const auto overlap = this->biorthogonal_overlaps.prod();
 
         // We now check the aforementioned condition.
-        if (std::abs(overlap - X_occupied.determinant()) > 1e-12) {
+        if (std::abs(overlap - X_occupied.determinant()) > 1e-8) {
             throw std::invalid_argument("LowdinPairingBasis<Scalar>(const Transformation& C_bra, const Transformation& C_ket, const ScalarGSQOneElectronOperator<Scalar>& S_AO, const size_t number_of_electrons, const double threshold): The given parameters lead to a wrong overlap calculation.");
         }
     }

--- a/gqcp/tests/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis_test.cpp
+++ b/gqcp/tests/Basis/NonOrthogonalBasis/GNonOrthogonalStateBasis_test.cpp
@@ -159,3 +159,74 @@ BOOST_AUTO_TEST_CASE(operator_evaluations) {
     // Compare the reference with the evaluated Hamiltonian.
     BOOST_CHECK(non_orthogonal_hamiltonian.isApprox(reference_hamiltonian, 1e-6));
 }
+
+
+/**
+ *  Test whether the non-orthogonal state basis evaluates the Hamiltonian correctly. All other evaluations (one- and two-electron operators) are used within the Hamiltonian functionality.
+ */
+BOOST_AUTO_TEST_CASE(operator_evaluations_complex) {
+    // This is a self implemented test case, with rotated H3 states in STO-3G.
+    const auto molecule = GQCP::Molecule::HRingFromDistance(3, 1.88973, 0);  // H3, 1 Angstrom apart.
+
+    // The general spinor basis is also needed, as we require the overlap operator in AO basis.
+    const GQCP::GSpinorBasis<GQCP::complex, GQCP::GTOShell> g_spinor_basis {molecule, "STO-3G"};
+    const auto S = g_spinor_basis.overlap();
+
+    // Initialize some non-orthogonal "generalised states".
+    GQCP::SquareMatrix<GQCP::complex> basis_state_1 {6};
+    // clang-format off
+    basis_state_1 << 0.460055771  - 5.63405828e-17j,  1.35013939  + 0.0j           ,  0.996501939    - 1.22036291e-16j,  0.535358621 - 6.55625222e-17j,  1.35013939 + 0.0j            ,  0.0 + 0.0j,
+                     0.460055767  - 5.63405822e-17j,  1.35013943  + 0.0j           , -0.996501918    + 1.22036288e-16j,  0.535358665 - 6.55625275e-17j,  1.35013943 + 0.0j            ,  0.0 + 0.0j,
+                     0.301611955  - 3.69368116e-17j,  3.07322180  + 0.0j           , -2.63772351e-08 + 3.23027965e-24j, -1.18334547  + 1.44918025e-16j,  3.07322180 + 0.0j            ,  0.0 + 0.0j,
+                    -0.0956361988 + 0.0j           , -0.280666403 - 3.43717213e-17j, -0.207152401    + 0.0j           , -0.111290123 + 0.0j           , -0.280666403 - 3.43717213e-17j,  0.0 + 0.0j,
+                    -0.0956361979 + 0.0j           , -0.280666413 - 3.43717224e-17j,  0.207152397    + 0.0j           , -0.111290132 + 0.0j           , -0.280666413 - 3.43717224e-17j,  0.0 + 0.0j,
+                    -0.0626989655 + 0.0j           , -0.638860046 - 7.82377910e-17j,  5.48328845e-09 + 0.0j           ,  0.245993356 + 0.0j           , -0.638860046 - 7.82377910e-17j,  0.0 + 0.0j;
+    // clang-format on
+    GQCP::SquareMatrix<GQCP::complex> basis_state_2 {6};
+    // clang-format off
+    basis_state_2 <<  0.230027886 - 0.398419985j,  0.799802113 + 0.0j        ,  0.498250970    - 0.862995994j   ,  0.267679311 - 0.463634166j,  0.799802113 + 0.0j        , 0.0 + 0.0j,
+                      0.230027883 - 0.398419981j,  0.799802140 + 0.0j        , -0.498250959    + 0.862995976j   ,  0.267679332 - 0.463634204j,  0.799802140 + 0.0j        , 0.0 + 0.0j,
+                      0.150805978 - 0.261203615j,  1.82053003  + 0.0j        , -1.31886175e-08 + 2.28433557e-08j, -0.591672737 + 1.02480724j ,  1.82053003  + 0.0j        , 0.0 + 0.0j,
+                     -0.161442683 + 0.0j        , -0.140333202 - 0.243064235j, -0.349692268    + 0.0j           , -0.187867944 + 0.0j        , -0.140333202 - 0.243064235j, 0.0 + 0.0j,
+                     -0.161442681 + 0.0j        , -0.140333206 - 0.243064243j,  0.349692261    + 0.0j           , -0.187867959 + 0.0j        , -0.140333206 - 0.243064243j, 0.0 + 0.0j,
+                     -0.105841609 + 0.0j        , -0.319430023 - 0.553269029j,  9.25629424e-09 + 0.0j           ,  0.415259365 + 0.0j        , -0.319430023 - 0.553269029j, 0.0 + 0.0j;
+    // clang-format on
+    GQCP::SquareMatrix<GQCP::complex> basis_state_3 {6};
+    // clang-format off
+    basis_state_3 <<  -1.02152902e-16 - 0.460055771j,  0.615580024    + 0.0j        , -2.21267879e-16 - 0.996501939j   , -1.18873494e-16 - 0.535358621j, 0.615580024    +0.0j         ,  0.0 + 0.0j,
+                      -1.02152901e-16 - 0.460055767j,  0.615580044    + 0.0j        ,  2.21267875e-16 + 0.996501918j   , -1.18873503e-16 - 0.535358665j, 0.615580044    +0.0j         ,  0.0 + 0.0j,
+                      -6.69713075e-17 - 0.301611955j,  1.40119899     + 0.0j        ,  5.85692274e-24 + 2.63772351e-08j,  2.62755478e-16 + 1.18334547j , 1.40119899     +0.0j         ,  0.0 + 0.0j,
+                      -0.209756967    + 0.0j        ,  6.23204607e-17 - 0.280666403j, -0.454343228    + 0.0j           , -0.244090407    +0.0j         , 6.23204607e-17 - 0.280666403j,  0.0 + 0.0j,
+                      -0.209756965    + 0.0j        ,  6.23204627e-17 - 0.280666413j,  0.454343219    + 0.0j           , -0.244090427    +0.0j         , 6.23204627e-17 - 0.280666413j,  0.0 + 0.0j,
+                      -0.137516390    + 0.0j        ,  1.41855426e-16 - 0.638860046j,  1.20263872e-08 + 0.0j           ,  0.539532320    +0.0j         , 1.41855426e-16 - 0.638860046j,  0.0 + 0.0j;
+    // clang-format on
+    // Transform the matrices to the correct transformation type.
+    const auto state1 = GQCP::GTransformation<GQCP::complex> {basis_state_1};
+    const auto state2 = GQCP::GTransformation<GQCP::complex> {basis_state_2};
+    const auto state3 = GQCP::GTransformation<GQCP::complex> {basis_state_3};
+
+    // Create a vector out of these three basis states.
+    std::vector<GQCP::GTransformation<GQCP::complex>> basis_vector {state1, state2, state3};
+
+    // Create a non-orthogonal state basis, using the basis state vector, the overlap operator in AO basis and the number of occupied orbitals.
+    const auto NOS_basis = GQCP::GNonOrthogonalStateBasis<GQCP::complex> {basis_vector, S, molecule.numberOfElectrons()};
+
+    // To evaluate the Hamiltonian in the non-orthogonal state basis, we need the second quantized Hamiltonian in AO basis.
+    const auto hamiltonian_AO = g_spinor_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));
+
+    // We can now evaluate this Hamiltonian operator in the non-orthogonal basis.
+    // The Hamiltonian evaluated in non-orthogonal basis requires the nuclear repuslion to be taken into account.
+    const auto non_orthogonal_hamiltonian = NOS_basis.evaluateHamiltonianOperator(hamiltonian_AO, GQCP::NuclearRepulsionOperator(molecule.nuclearFramework()));
+
+    // Set up a reference Hamiltonian. Data taken from the implementation of @lelemmen and @johdvos.
+    // The dimension of the Hamiltonian is equal to the number of basis states used.
+    GQCP::SquareMatrix<GQCP::complex> reference_hamiltonian {3};
+    // clang-format off
+    reference_hamiltonian <<  -2.24753914 + 0.0j, -1.31305449 + 0.0j, -0.91478496 - 0.0j,
+                              -1.31305449 + 0.0j, -0.98424265 + 0.0j, -0.79501504 - 0.0j,
+                              -0.91478496 - 0.0j, -0.79501504 - 0.0j, -0.72522018 - 0.0j;
+    // clang-format on
+
+    // Compare the reference with the evaluated Hamiltonian.
+    BOOST_CHECK(non_orthogonal_hamiltonian.isApprox(reference_hamiltonian, 1e-6));
+}

--- a/gqcp/tests/QCMethod/NOCI/NOCI_test.cpp
+++ b/gqcp/tests/QCMethod/NOCI/NOCI_test.cpp
@@ -333,3 +333,70 @@ BOOST_AUTO_TEST_CASE(NOCI_complex_unrestricted) {
     // In this test case, the alpha and beta 1DM's should be equal. We check this fact, to confirm that all aspects of the complex NOCI method in an unrestricted basis work as expected.
     BOOST_CHECK(NOCI_parameters.calculate1DM().alpha().matrix().isApprox(NOCI_parameters.calculate1DM().beta().matrix(), 1e-6));
 }
+
+/**
+ *  Test the NOCI QC Method.
+ */
+BOOST_AUTO_TEST_CASE(NOCI_complex_generalized) {
+    // This is a self implemented test case, with rotated H3 states in STO-3G.
+    const auto molecule = GQCP::Molecule::HRingFromDistance(3, 1.88973, 0);  // H3, 1 Angstrom apart.
+
+    // The general spinor basis is also needed, as we require the overlap operator in AO basis.
+    const GQCP::GSpinorBasis<GQCP::complex, GQCP::GTOShell> g_spinor_basis {molecule, "STO-3G"};
+    const auto S = g_spinor_basis.overlap();
+
+    // Initialize some non-orthogonal "generalised states".
+    GQCP::SquareMatrix<GQCP::complex> basis_state_1 {6};
+    // clang-format off
+    basis_state_1 << 0.460055771  - 5.63405828e-17j,  1.35013939  + 0.0j           ,  0.996501939    - 1.22036291e-16j,  0.535358621 - 6.55625222e-17j,  1.35013939 + 0.0j            ,  0.0 + 0.0j,
+                     0.460055767  - 5.63405822e-17j,  1.35013943  + 0.0j           , -0.996501918    + 1.22036288e-16j,  0.535358665 - 6.55625275e-17j,  1.35013943 + 0.0j            ,  0.0 + 0.0j,
+                     0.301611955  - 3.69368116e-17j,  3.07322180  + 0.0j           , -2.63772351e-08 + 3.23027965e-24j, -1.18334547  + 1.44918025e-16j,  3.07322180 + 0.0j            ,  0.0 + 0.0j,
+                    -0.0956361988 + 0.0j           , -0.280666403 - 3.43717213e-17j, -0.207152401    + 0.0j           , -0.111290123 + 0.0j           , -0.280666403 - 3.43717213e-17j,  0.0 + 0.0j,
+                    -0.0956361979 + 0.0j           , -0.280666413 - 3.43717224e-17j,  0.207152397    + 0.0j           , -0.111290132 + 0.0j           , -0.280666413 - 3.43717224e-17j,  0.0 + 0.0j,
+                    -0.0626989655 + 0.0j           , -0.638860046 - 7.82377910e-17j,  5.48328845e-09 + 0.0j           ,  0.245993356 + 0.0j           , -0.638860046 - 7.82377910e-17j,  0.0 + 0.0j;
+    // clang-format on
+    GQCP::SquareMatrix<GQCP::complex> basis_state_2 {6};
+    // clang-format off
+    basis_state_2 <<  0.230027886 - 0.398419985j,  0.799802113 + 0.0j        ,  0.498250970    - 0.862995994j   ,  0.267679311 - 0.463634166j,  0.799802113 + 0.0j        , 0.0 + 0.0j,
+                      0.230027883 - 0.398419981j,  0.799802140 + 0.0j        , -0.498250959    + 0.862995976j   ,  0.267679332 - 0.463634204j,  0.799802140 + 0.0j        , 0.0 + 0.0j,
+                      0.150805978 - 0.261203615j,  1.82053003  + 0.0j        , -1.31886175e-08 + 2.28433557e-08j, -0.591672737 + 1.02480724j ,  1.82053003  + 0.0j        , 0.0 + 0.0j,
+                     -0.161442683 + 0.0j        , -0.140333202 - 0.243064235j, -0.349692268    + 0.0j           , -0.187867944 + 0.0j        , -0.140333202 - 0.243064235j, 0.0 + 0.0j,
+                     -0.161442681 + 0.0j        , -0.140333206 - 0.243064243j,  0.349692261    + 0.0j           , -0.187867959 + 0.0j        , -0.140333206 - 0.243064243j, 0.0 + 0.0j,
+                     -0.105841609 + 0.0j        , -0.319430023 - 0.553269029j,  9.25629424e-09 + 0.0j           ,  0.415259365 + 0.0j        , -0.319430023 - 0.553269029j, 0.0 + 0.0j;
+    // clang-format on
+    GQCP::SquareMatrix<GQCP::complex> basis_state_3 {6};
+    // clang-format off
+    basis_state_3 <<  -1.02152902e-16 - 0.460055771j,  0.615580024    + 0.0j        , -2.21267879e-16 - 0.996501939j   , -1.18873494e-16 - 0.535358621j, 0.615580024    +0.0j         ,  0.0 + 0.0j,
+                      -1.02152901e-16 - 0.460055767j,  0.615580044    + 0.0j        ,  2.21267875e-16 + 0.996501918j   , -1.18873503e-16 - 0.535358665j, 0.615580044    +0.0j         ,  0.0 + 0.0j,
+                      -6.69713075e-17 - 0.301611955j,  1.40119899     + 0.0j        ,  5.85692274e-24 + 2.63772351e-08j,  2.62755478e-16 + 1.18334547j , 1.40119899     +0.0j         ,  0.0 + 0.0j,
+                      -0.209756967    + 0.0j        ,  6.23204607e-17 - 0.280666403j, -0.454343228    + 0.0j           , -0.244090407    +0.0j         , 6.23204607e-17 - 0.280666403j,  0.0 + 0.0j,
+                      -0.209756965    + 0.0j        ,  6.23204627e-17 - 0.280666413j,  0.454343219    + 0.0j           , -0.244090427    +0.0j         , 6.23204627e-17 - 0.280666413j,  0.0 + 0.0j,
+                      -0.137516390    + 0.0j        ,  1.41855426e-16 - 0.638860046j,  1.20263872e-08 + 0.0j           ,  0.539532320    +0.0j         , 1.41855426e-16 - 0.638860046j,  0.0 + 0.0j;
+    // clang-format on
+    // Transform the matrices to the correct transformation type.
+    const auto state1 = GQCP::GTransformation<GQCP::complex> {basis_state_1};
+    const auto state2 = GQCP::GTransformation<GQCP::complex> {basis_state_2};
+    const auto state3 = GQCP::GTransformation<GQCP::complex> {basis_state_3};
+
+    // Create a vector out of these three basis states.
+    std::vector<GQCP::GTransformation<GQCP::complex>> basis_vector {state1, state2, state3};
+
+    // Create a non-orthogonal state basis, using the basis state vector, the overlap operator in AO basis and the number of occupied orbitals.
+    const auto NOS_basis = GQCP::GNonOrthogonalStateBasis<GQCP::complex> {basis_vector, S, molecule.numberOfElectrons()};
+
+    // Quantize the Hamiltonian in the general spinor basis.
+    const auto sq_hamiltonian = g_spinor_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));
+
+    // Create a dense solver and corresponding environment and put them together in the QCMethod.
+    auto environment = GQCP::NOCIEnvironment::Dense(sq_hamiltonian, NOS_basis, molecule);
+    auto solver = GQCP::GeneralizedEigenproblemSolver::Dense<GQCP::complex>();
+
+    // We ask for three states (which is all of them in this example) to be found.
+    const auto qc_structure = GQCP::QCMethod::NOCI<GQCP::complex, GQCP::GNonOrthogonalStateBasis<GQCP::complex>>(NOS_basis).optimize(solver, environment);
+
+    // Initialize a reference energy.
+    const double reference = -0.97341735;
+
+    // Check the result with the reference.
+    BOOST_CHECK(std::abs(reference - qc_structure.groundStateEnergy()) < 1e-6);
+}

--- a/gqcpy/src/Basis/SpinorBasis/GSpinorBasis_bindings.cpp
+++ b/gqcpy/src/Basis/SpinorBasis/GSpinorBasis_bindings.cpp
@@ -167,6 +167,14 @@ void bindGSpinorBases(py::module& module) {
     // Define the Python class for `GSpinorBasis_d`.
     py::class_<GSpinorBasis<double, GTOShell>> py_GSpinorBasis_d {module, "GSpinorBasis_d", "A class that represents a real, (generalized) spinor basis with underlying GTO shells."};
 
+    py_GSpinorBasis_d
+        .def(
+            "quantize",
+            [](const GSpinorBasis<double, GTOShell>& spinor_basis, const ElectronicSpin_zOperator& op) {
+                return spinor_basis.quantize(op);
+            },
+            "Return the electronic spin 'z' operator expressed in this spinor basis.");
+
     bindGSpinorBasisInterface(py_GSpinorBasis_d);
     bindGTOGSpinorBasisInterface(py_GSpinorBasis_d);
 

--- a/gqcpy/src/QCMethod/NOCI/NOCI_bindings.cpp
+++ b/gqcpy/src/QCMethod/NOCI/NOCI_bindings.cpp
@@ -24,6 +24,7 @@
 #include "Utilities/complex.hpp"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 
 namespace gqcpy {
@@ -82,23 +83,23 @@ void bindQCMethodNOCIInterface(Class& py_class) {
  */
 void bindQCMethodNOCI(py::module& module) {
 
-    py::class_<QCMethod::NOCI<double, GNonOrthogonalStateBasis<double>>> py_CI_d_GNonOrthogonalStateBasis {module, "CI_d_GNonOrthogonalStateBasis", "Real-valued non-orthogonal configuration interaction in a basis that consists of 'generalized' states."};
-    bindQCMethodNOCIInterface(py_CI_d_GNonOrthogonalStateBasis);
+    py::class_<QCMethod::NOCI<double, GNonOrthogonalStateBasis<double>>> py_NOCI_d_GNonOrthogonalStateBasis {module, "NOCI_d_GNonOrthogonalStateBasis", "Real-valued non-orthogonal configuration interaction in a basis that consists of 'generalized' states."};
+    bindQCMethodNOCIInterface(py_NOCI_d_GNonOrthogonalStateBasis);
 
-    py::class_<QCMethod::NOCI<double, RNonOrthogonalStateBasis<double>>> py_CI_d_RNonOrthogonalStateBasis {module, "CI_d_RNonOrthogonalStateBasis", "Real-valued non-orthogonal configuration interaction in a basis that consists of 'restricted' states."};
-    bindQCMethodNOCIInterface(py_CI_d_RNonOrthogonalStateBasis);
+    py::class_<QCMethod::NOCI<double, RNonOrthogonalStateBasis<double>>> py_NOCI_d_RNonOrthogonalStateBasis {module, "NOCI_d_RNonOrthogonalStateBasis", "Real-valued non-orthogonal configuration interaction in a basis that consists of 'restricted' states."};
+    bindQCMethodNOCIInterface(py_NOCI_d_RNonOrthogonalStateBasis);
 
-    py::class_<QCMethod::NOCI<double, UNonOrthogonalStateBasis<double>>> py_CI_d_UNonOrthogonalStateBasis {module, "CI_d_UNonOrthogonalStateBasis", "Real-valued non-orthogonal configuration interaction in a basis that consists of 'unrestricted' states."};
-    bindQCMethodNOCIInterface(py_CI_d_UNonOrthogonalStateBasis);
+    py::class_<QCMethod::NOCI<double, UNonOrthogonalStateBasis<double>>> py_NOCI_d_UNonOrthogonalStateBasis {module, "NOCI_d_UNonOrthogonalStateBasis", "Real-valued non-orthogonal configuration interaction in a basis that consists of 'unrestricted' states."};
+    bindQCMethodNOCIInterface(py_NOCI_d_UNonOrthogonalStateBasis);
 
-    py::class_<QCMethod::NOCI<complex, GNonOrthogonalStateBasis<complex>>> py_CI_cd_GNonOrthogonalStateBasis {module, "CI_cd_GNonOrthogonalStateBasis", "Complex-valued non-orthogonal configuration interaction in a basis that consists of 'generalized' states."};
-    bindQCMethodNOCIInterface(py_CI_cd_GNonOrthogonalStateBasis);
+    py::class_<QCMethod::NOCI<complex, GNonOrthogonalStateBasis<complex>>> py_NOCI_cd_GNonOrthogonalStateBasis {module, "NOCI_cd_GNonOrthogonalStateBasis", "Complex-valued non-orthogonal configuration interaction in a basis that consists of 'generalized' states."};
+    bindQCMethodNOCIInterface(py_NOCI_cd_GNonOrthogonalStateBasis);
 
-    py::class_<QCMethod::NOCI<complex, RNonOrthogonalStateBasis<complex>>> py_CI_cd_RNonOrthogonalStateBasis {module, "CI_cd_RNonOrthogonalStateBasis", "Complex-valued non-orthogonal configuration interaction in a basis that consists of 'restricted' states."};
-    bindQCMethodNOCIInterface(py_CI_cd_RNonOrthogonalStateBasis);
+    py::class_<QCMethod::NOCI<complex, RNonOrthogonalStateBasis<complex>>> py_NOCI_cd_RNonOrthogonalStateBasis {module, "NOCI_cd_RNonOrthogonalStateBasis", "Complex-valued non-orthogonal configuration interaction in a basis that consists of 'restricted' states."};
+    bindQCMethodNOCIInterface(py_NOCI_cd_RNonOrthogonalStateBasis);
 
-    py::class_<QCMethod::NOCI<complex, UNonOrthogonalStateBasis<complex>>> py_CI_cd_UNonOrthogonalStateBasis {module, "CI_cd_UNonOrthogonalStateBasis", "Complex-valued non-orthogonal configuration interaction in a basis that consists of 'unrestricted' states."};
-    bindQCMethodNOCIInterface(py_CI_cd_UNonOrthogonalStateBasis);
+    py::class_<QCMethod::NOCI<complex, UNonOrthogonalStateBasis<complex>>> py_NOCI_cd_UNonOrthogonalStateBasis {module, "NOCI_cd_UNonOrthogonalStateBasis", "Complex-valued non-orthogonal configuration interaction in a basis that consists of 'unrestricted' states."};
+    bindQCMethodNOCIInterface(py_NOCI_cd_UNonOrthogonalStateBasis);
 }
 
 

--- a/gqcpy/src/QCMethod/QCStructure_bindings.cpp
+++ b/gqcpy/src/QCMethod/QCStructure_bindings.cpp
@@ -108,12 +108,12 @@ void bindQCStructures(py::module& module) {
     bindQCStructure<LinearExpansion<double, SpinUnresolvedSelectedONVBasis>>(module, "LinearExpansion_SpinUnresolvedSelected_d", "A quantum chemical structure for real-valued linear expansions in a spin-unresolved selected ONV basis.");
     bindQCStructure<LinearExpansion<complex, SpinUnresolvedSelectedONVBasis>, complex>(module, "LinearExpansion_SpinUnresolvedSelected_cd", "A quantum chemical structure for complex-valued linear expansions in a spin-unresolved selected ONV basis.");
 
-    bindQCStructure<NOCIExpansion<double, GNonOrthogonalStateBasis<double>>>(module, "NOCI_GNonOrthogonalState_d", "A quantum chemical structure for real-valued expansions in a generalized non-orthogonal state basis.");
-    bindQCStructure<NOCIExpansion<complex, GNonOrthogonalStateBasis<complex>>>(module, "NOCI_GNonOrthogonalState_cd", "A quantum chemical structure for complex-valued expansions in a generalized non-orthogonal state basis.");
-    bindQCStructure<NOCIExpansion<double, RNonOrthogonalStateBasis<double>>>(module, "NOCI_RNonOrthogonalState_d", "A quantum chemical structure for real-valued expansions in a restricted non-orthogonal state basis.");
-    bindQCStructure<NOCIExpansion<complex, RNonOrthogonalStateBasis<complex>>>(module, "NOCI_RNonOrthogonalState_cd", "A quantum chemical structure for complex-valued expansions in a restricted non-orthogonal state basis.");
-    bindQCStructure<NOCIExpansion<double, UNonOrthogonalStateBasis<double>>>(module, "NOCI_UNonOrthogonalState_d", "A quantum chemical structure for real-valued expansions in a unrestricted non-orthogonal state basis.");
-    bindQCStructure<NOCIExpansion<complex, UNonOrthogonalStateBasis<complex>>>(module, "NOCI_UNonOrthogonalState_cd", "A quantum chemical structure for complex-valued expansions in a unrestricted non-orthogonal state basis.");
+    bindQCStructure<NOCIExpansion<double, GNonOrthogonalStateBasis<double>>>(module, "NOCIExpansion_GNonOrthogonalState_d", "A quantum chemical structure for real-valued expansions in a generalized non-orthogonal state basis.");
+    bindQCStructure<NOCIExpansion<complex, GNonOrthogonalStateBasis<complex>>, complex>(module, "NOCIExpansion_GNonOrthogonalState_cd", "A quantum chemical structure for complex-valued expansions in a generalized non-orthogonal state basis.");
+    bindQCStructure<NOCIExpansion<double, RNonOrthogonalStateBasis<double>>>(module, "NOCIExpansion_RNonOrthogonalState_d", "A quantum chemical structure for real-valued expansions in a restricted non-orthogonal state basis.");
+    bindQCStructure<NOCIExpansion<complex, RNonOrthogonalStateBasis<complex>>, complex>(module, "NOCIExpansion_RNonOrthogonalState_cd", "A quantum chemical structure for complex-valued expansions in a restricted non-orthogonal state basis.");
+    bindQCStructure<NOCIExpansion<double, UNonOrthogonalStateBasis<double>>>(module, "NOCIExpansion_UNonOrthogonalState_d", "A quantum chemical structure for real-valued expansions in a unrestricted non-orthogonal state basis.");
+    bindQCStructure<NOCIExpansion<complex, UNonOrthogonalStateBasis<complex>>, complex>(module, "NOCIExpansion_UNonOrthogonalState_cd", "A quantum chemical structure for complex-valued expansions in a unrestricted non-orthogonal state basis.");
 
     bindQCStructure<QCModel::AP1roG>(module, "AP1roG", "A quantum chemical structure for real-valued AP1roG parameters.");
     bindQCStructure<QCModel::vAP1roG>(module, "vAP1roG", "A quantum chemical structure for real-valued vAP1roG parameters.");


### PR DESCRIPTION
**Short description**

This PR let's us quantise Sz in a real GSpinor basis as well.
It also fixes some small bugs related to complex NOCI and adds tests to make sure of the correctness now.

**Related issues**

Resolves one part of issue #1015.

**To do**

- [x] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
