### PR TITLE
Optimization for calculateSystemOrbitalRDM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/version.hpp.in gqcp/version/version.hpp
 configure_file(${CMAKE_SOURCE_DIR}/cmake/version.cpp.in gqcp/version/version.cpp)
 
 add_library(gqcp_version STATIC ${CMAKE_CURRENT_BINARY_DIR}/gqcp/version/version.cpp)
-target_compile_features(gqcp_version PUBLIC cxx_std_14)
+target_compile_features(gqcp_version PUBLIC cxx_std_17)
 target_include_directories(gqcp_version
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/gqcp/version>

--- a/gqcp/include/ONVBasis/SpinResolvedONV.hpp
+++ b/gqcp/include/ONVBasis/SpinResolvedONV.hpp
@@ -131,6 +131,11 @@ public:
     size_t numberOfElectrons(const Spin sigma) const;
 
     /**
+     *  @return The total number of electrons this spin-resolved ONV describes.
+     */
+    size_t numberOfElectrons() const;
+
+    /**
      *  @param sigma                alpha or beta
      * 
      *  @return The number of sigma-spatial orbitals/spin-orbitals that this ONV is expressed with.

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1837,7 +1837,10 @@ public:
                 double matrix_element = 0.0;
 
                 auto N_diff = system_onv_basis[r].numberOfElectrons() - system_onv_basis[c].numberOfElectrons();
-                auto Sz_diff = std::is_same<Z, SpinResolvedONVBasis>::value == true ? (system_onv_basis[r].numberOfElectrons(Spin::alpha) - system_onv_basis[r].numberOfElectrons(Spin::beta)) - (system_onv_basis[c].numberOfElectrons(Spin::alpha) - system_onv_basis[c].numberOfElectrons(Spin::beta)) : 0;
+                size_t Sz_diff = 0;
+                if (std::is_same<Z, SpinResolvedONVBasis>::value) {
+                    Sz_diff = system_onv_basis[r].numberOfElectrons(Spin::alpha) - system_onv_basis[r].numberOfElectrons(Spin::beta)) - (system_onv_basis[c].numberOfElectrons(Spin::alpha) - system_onv_basis[c].numberOfElectrons(Spin::beta));
+                }
 
                 if (N_diff == 0 && Sz_diff == 0) {
                     // \sum_j <j|<n|\Psi><\Psi|n'>|j> -> onv_n_bra = <n| and onv_n_ket = |n'>

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1838,7 +1838,7 @@ public:
 
                 auto N_diff = system_onv_basis[r].numberOfElectrons() - system_onv_basis[c].numberOfElectrons();
                 size_t Sz_diff = 0;
-                if constexpr (std::is_same<Z, SpinResolvedONVBasis>::value) {
+                if constexpr (std::is_same_v<Z, SpinResolvedONVBasis>) {
                     Sz_diff = (system_onv_basis[r].numberOfElectrons(Spin::alpha) - system_onv_basis[r].numberOfElectrons(Spin::beta)) - (system_onv_basis[c].numberOfElectrons(Spin::alpha) - system_onv_basis[c].numberOfElectrons(Spin::beta));
                 }
 

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1838,7 +1838,7 @@ public:
 
                 auto N_diff = system_onv_basis[r].numberOfElectrons() - system_onv_basis[c].numberOfElectrons();
                 size_t Sz_diff = 0;
-                if (std::is_same<ONVBasis, SpinResolvedONVBasis>::value) {
+                if constexpr (std::is_same<Z, SpinResolvedONVBasis>::value) {
                     Sz_diff = (system_onv_basis[r].numberOfElectrons(Spin::alpha) - system_onv_basis[r].numberOfElectrons(Spin::beta)) - (system_onv_basis[c].numberOfElectrons(Spin::alpha) - system_onv_basis[c].numberOfElectrons(Spin::beta));
                 }
 

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1839,7 +1839,7 @@ public:
                 auto N_diff = system_onv_basis[r].numberOfElectrons() - system_onv_basis[c].numberOfElectrons();
                 size_t Sz_diff = 0;
                 if (std::is_same<Z, SpinResolvedONVBasis>::value) {
-                    Sz_diff = system_onv_basis[r].numberOfElectrons(Spin::alpha) - system_onv_basis[r].numberOfElectrons(Spin::beta)) - (system_onv_basis[c].numberOfElectrons(Spin::alpha) - system_onv_basis[c].numberOfElectrons(Spin::beta));
+                    Sz_diff = (system_onv_basis[r].numberOfElectrons(Spin::alpha) - system_onv_basis[r].numberOfElectrons(Spin::beta)) - (system_onv_basis[c].numberOfElectrons(Spin::alpha) - system_onv_basis[c].numberOfElectrons(Spin::beta));
                 }
 
                 if (N_diff == 0 && Sz_diff == 0) {

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1837,8 +1837,8 @@ public:
                 double matrix_element = 0.0;
 
                 auto N_diff = system_onv_basis[r].numberOfElectrons() - system_onv_basis[c].numberOfElectrons();
-                auto Sz_diff = std::is_same<Z, SpinResolvedONVBasis>::value ? (system_onv_basis[r].numberOfElectrons(Spin::alpha) - system_onv_basis[r].numberOfElectrons(Spin::beta)) - (system_onv_basis[c].numberOfElectrons(Spin::alpha) - system_onv_basis[c].numberOfElectrons(Spin::beta)) : 0;
-                
+                auto Sz_diff = std::is_same<Z, SpinResolvedONVBasis>::value == true ? (system_onv_basis[r].numberOfElectrons(Spin::alpha) - system_onv_basis[r].numberOfElectrons(Spin::beta)) - (system_onv_basis[c].numberOfElectrons(Spin::alpha) - system_onv_basis[c].numberOfElectrons(Spin::beta)) : 0;
+
                 if (N_diff == 0 && Sz_diff == 0) {
                     // \sum_j <j|<n|\Psi><\Psi|n'>|j> -> onv_n_bra = <n| and onv_n_ket = |n'>
                     for (size_t p = 0; p < system_onvs.size(); ++p) {      // Loop over |\Psi> = \sum_p |system_p>|environment_p>.

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1838,7 +1838,7 @@ public:
 
                 auto N_diff = system_onv_basis[r].numberOfElectrons() - system_onv_basis[c].numberOfElectrons();
                 size_t Sz_diff = 0;
-                if (std::is_same<Z, SpinResolvedONVBasis>::value) {
+                if (std::is_same<ONVBasis, SpinResolvedONVBasis>::value) {
                     Sz_diff = (system_onv_basis[r].numberOfElectrons(Spin::alpha) - system_onv_basis[r].numberOfElectrons(Spin::beta)) - (system_onv_basis[c].numberOfElectrons(Spin::alpha) - system_onv_basis[c].numberOfElectrons(Spin::beta));
                 }
 

--- a/gqcp/src/ONVBasis/SpinResolvedONV.cpp
+++ b/gqcp/src/ONVBasis/SpinResolvedONV.cpp
@@ -208,6 +208,15 @@ size_t SpinResolvedONV::numberOfElectrons(const Spin sigma) const {
 
 
 /**
+ *  @return The total number of electrons this spin-resolved ONV describes.
+ */
+size_t SpinResolvedONV::numberOfElectrons() const {
+
+    return this->numberOfElectrons(Spin::alpha) + this->numberOfElectrons(Spin::beta);
+}
+
+
+/**
  *  @param sigma                Alpha or beta.
  * 
  *  @return The number of sigma-spatial orbitals/spin-orbitals that this ONV is expressed with.

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(orbital_reduced_density_matrix) {
     // |10>, |00>, |10>, |01>, |11>, |01>
     std::vector<GQCP::SpinUnresolvedONV> environment_onvs {{2, 1, 1}, {2, 0, 0}, {2, 1, 1}, {2, 1, 2}, {2, 2, 3}, {2, 1, 2}};
 
-    const auto rho = wfn.calculateOrbitalRDM(system_onvs, environment_onvs);
+    const auto rho = wfn.calculateSystemOrbitalRDM(system_onvs, environment_onvs);
 
     // <n| = <10|, |n'> = |10>
     BOOST_CHECK_EQUAL(rho(0, 0), wfn.coefficient(0) * wfn.coefficient(0) + wfn.coefficient(3) * wfn.coefficient(3));

--- a/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
+++ b/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
@@ -244,9 +244,9 @@ void bindLinearExpansions(py::module& module) {
          */
 
         .def(
-            "calculateOrbitalRDM",
+            "calculateSystemOrbitalRDM",
             [](const LinearExpansion<double, SpinResolvedONVBasis>& linear_expansion, const std::vector<GQCP::SpinResolvedONV>& system_onvs, const std::vector<GQCP::SpinResolvedONV>& environment_onvs) {
-                return linear_expansion.calculateOrbitalRDM(system_onvs, environment_onvs);
+                return linear_expansion.calculateSystemOrbitalRDM(system_onvs, environment_onvs);
             },
             py::arg("system_onvs"),
             py::arg("environment_onvs"),
@@ -356,9 +356,9 @@ void bindLinearExpansions(py::module& module) {
             "Return an element of the N-DM, as specified by the given bra and ket indices. `calculateNDMElement({0, 1}, {2, 1})` would calculate an element of the 2-NDM d^{(2)} (0, 1, 1, 2) corresponding the operator string: `a^dagger_0 a^dagger_1 a_2 a_1`.")
 
         .def(
-            "calculateOrbitalRDM",
+            "calculateSystemOrbitalRDM",
             [](const LinearExpansion<double, SpinUnresolvedONVBasis>& linear_expansion, const std::vector<GQCP::SpinUnresolvedONV>& system_onvs, const std::vector<GQCP::SpinUnresolvedONV>& environment_onvs) {
-                return linear_expansion.calculateOrbitalRDM(system_onvs, environment_onvs);
+                return linear_expansion.calculateSystemOrbitalRDM(system_onvs, environment_onvs);
             },
             py::arg("system_onvs"),
             py::arg("environment_onvs"),


### PR DESCRIPTION
**Short description**

As the method `calculateSystemOrbitalRDM` becomes computationally expensive for larger systems, `GQCP` could benefit from an optimization where matrix elements are zero when
<img width="471" alt="Screenshot 2021-12-06 at 14 30 42" src="https://user-images.githubusercontent.com/33431368/144854638-ab756339-8359-44e3-bc28-30cd033e8722.png">

(see [Rissler2005](https://doi.org/10.1016/j.chemphys.2005.10.018))

**To do**

- [ ] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [ ] Add other smaller task to be completed as a Markdown task list
