### PR TITLE
Refactor calculation of orbital RDM.

### DIFF
--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1838,15 +1838,18 @@ public:
 
         GQCP::Tensor<Scalar, 2> C(system_onv_basis.size(), environment_onv_basis.size());  // = GQCP::Matrix<Scalar>::Zero();
         C.setZero();
+        C.asMatrix().print();
 
         for (size_t ij = 0; ij < system_onvs.size(); ++ij) {
 
             int i = onv_index(system_onvs[ij], system_onv_basis);
             int j = onv_index(environment_onvs[ij], environment_onv_basis);
-            std::cout << "i: " << i << "\tj: " << j << "\tcoefficient: " << this->coefficient(ij) << std::endl;
+            std::cout << "onv i: " << system_onvs[ij] << "\tonv j: " << environment_onvs[ij];
+            std::cout << "\ti: " << i << "\tj: " << j << "\tcoefficient: " << this->coefficient(ij) << std::endl;
 
             C(i, j) = this->coefficient(ij);
         }
+        return C;
     }
 
     /**

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1836,13 +1836,14 @@ public:
             return -1;
         };
 
-        GQCP::Tensor<Scalar, 2> C {system_onv_basis.size(), environment_onv_basis.size()};// = GQCP::Matrix<Scalar>::Zero();
+        GQCP::Tensor<Scalar, 2> C(system_onv_basis.size(), environment_onv_basis.size());  // = GQCP::Matrix<Scalar>::Zero();
         C.setZero();
 
         for (size_t ij = 0; ij < system_onvs.size(); ++ij) {
 
             int i = onv_index(system_onvs[ij], system_onv_basis);
             int j = onv_index(environment_onvs[ij], environment_onv_basis);
+            std::cout << "i: " << i << "\tj: " << j << "\tcoefficient: " << this->coefficient(ij) << std::endl;
 
             C(i, j) = this->coefficient(ij);
         }

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1801,7 +1801,7 @@ public:
             throw std::invalid_argument("LinearExpansion::calculateSystemOrbitalRDM(std::vector<ONV>& system_onvs, std::vector<ONV>& environment_onvs) const: The amount of system ONVs should be exactly the same as the amount of environment ONVs.");
         }
 
-        // Create a collection of unique ONVs to determine the dimension of the orbital RDM.
+        // Create a collection of unique ONVs to determine the dimension of the system orbital RDM.
         const auto unique_onvs = [](const std::vector<typename ONVBasis::ONV>& onvs) {
             // The ONV basis containing all unique ONVs.
             std::vector<typename ONVBasis::ONV> onv_collection;
@@ -1852,12 +1852,12 @@ public:
 
 
     /**
-     *  Calculate the orbital reduced density matrix as defined in equation (2) of Rissler2005 (https://doi.org/10.1016/j.chemphys.2005.10.018).
+     *  Calculate the system orbital reduced density matrix as defined in equation (2) of Rissler2005 (https://doi.org/10.1016/j.chemphys.2005.10.018).
      *
      *  @param system_onvs              A vector of all ONVs of the system that is obtained after splitting a collection of ONVs into two subsystems.
      *  @param environment_onvs         A vector of all ONVs of the environment that is obtained after splitting a collection of ONVs into two subsystems.
      *
-     *  @return The orbital reduced density matrix.
+     *  @return The system orbital reduced density matrix.
      */
     template <typename Z = ONVBasis>
     enable_if_t<std::is_same<Z, SpinUnresolvedONVBasis>::value | std::is_same<Z, SpinResolvedONVBasis>::value, GQCP::Tensor<Scalar, 2>> calculateSystemOrbitalRDM(const std::vector<typename ONVBasis::ONV>& system_onvs, const std::vector<typename ONVBasis::ONV>& environment_onvs) const {

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -30,6 +30,7 @@
 #include "DensityMatrix/SpinResolved1DM.hpp"
 #include "DensityMatrix/SpinResolved2DM.hpp"
 #include "Mathematical/Representation/Matrix.hpp"
+#include "Mathematical/Representation/Tensor.hpp"
 #include "ONVBasis/SpinResolvedONV.hpp"
 #include "ONVBasis/SpinResolvedONVBasis.hpp"
 #include "ONVBasis/SpinResolvedSelectedONVBasis.hpp"
@@ -1794,7 +1795,7 @@ public:
      *  @return The expansion coefficients in tensor form.
      */
     template <typename Z = ONVBasis>
-    enable_if_t<std::is_same<Z, SpinUnresolvedONVBasis>::value | std::is_same<Z, SpinResolvedONVBasis>::value, GQCP::Matrix<Scalar>> tensorizeCoefficients(const std::vector<typename ONVBasis::ONV>& system_onvs, const std::vector<typename ONVBasis::ONV>& environment_onvs) const {
+    enable_if_t<std::is_same<Z, SpinUnresolvedONVBasis>::value | std::is_same<Z, SpinResolvedONVBasis>::value, GQCP::Tensor<Scalar, 2>> tensorizeCoefficients(const std::vector<typename ONVBasis::ONV>& system_onvs, const std::vector<typename ONVBasis::ONV>& environment_onvs) const {
 
         if (system_onvs.size() != environment_onvs.size()) {
             throw std::invalid_argument("LinearExpansion::calculateSystemOrbitalRDM(std::vector<ONV>& system_onvs, std::vector<ONV>& environment_onvs) const: The amount of system ONVs should be exactly the same as the amount of environment ONVs.");
@@ -1835,7 +1836,8 @@ public:
             return -1;
         };
 
-        GQCP::Matrix<Scalar> C = GQCP::Matrix<Scalar>::Zero(system_onv_basis.size(), environment_onv_basis.size());
+        GQCP::Tensor<Scalar, 2> C {system_onv_basis.size(), environment_onv_basis.size()};// = GQCP::Matrix<Scalar>::Zero();
+        C.setZero();
 
         for (size_t ij = 0; ij < system_onvs.size(); ++ij) {
 

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -1801,132 +1801,76 @@ public:
             throw std::invalid_argument("LinearExpansion::calculateSystemOrbitalRDM(std::vector<ONV>& system_onvs, std::vector<ONV>& environment_onvs) const: The amount of system ONVs should be exactly the same as the amount of environment ONVs.");
         }
 
-        // Determine the dimensions of the orbital density matrix.
+        // Create a collection of unique ONVs to determine the dimension of the orbital RDM.
         const auto unique_onvs = [](const std::vector<typename ONVBasis::ONV>& onvs) {
             // The ONV basis containing all unique ONVs.
-            std::vector<typename ONVBasis::ONV> onv_basis;
+            std::vector<typename ONVBasis::ONV> onv_collection;
 
             for (const auto& onv : onvs) {
 
                 bool unique = true;
-                // If the ONV already is inside this basis, do not add it again.
-                for (const auto& unique_onv : onv_basis) {
+                // If the ONV already is inside this collection, do not add it again.
+                for (const auto& unique_onv : onv_collection) {
                     if (onv.asString() == unique_onv.asString()) {
                         unique = false;
                     }
                 }
-                // If it is an unique ONV, add it to the ONV basis.
+                // If it is an unique ONV, add it to the ONV collection.
                 if (unique) {
-                    onv_basis.push_back(onv);
+                    onv_collection.push_back(onv);
                 }
             }
-            return onv_basis;
+            return onv_collection;
         };
 
-        const auto system_onv_basis = unique_onvs(system_onvs);
-        const auto environment_onv_basis = unique_onvs(environment_onvs);
+        const auto system_onv_collection = unique_onvs(system_onvs);
+        const auto environment_onv_collection = unique_onvs(environment_onvs);
 
-        const auto onv_index = [](const typename ONVBasis::ONV onv, std::vector<typename ONVBasis::ONV> onv_basis) {
-            for (int i = 0; i < onv_basis.size(); ++i) {
+        // Retrieve the index of a given ONV in the collection of unique ONVs.
+        const auto onv_index = [](const typename ONVBasis::ONV onv, std::vector<typename ONVBasis::ONV> onv_collection) {
+            for (int i = 0; i < onv_collection.size(); ++i) {
 
-                if (onv == onv_basis[i]) {
+                if (onv == onv_collection[i]) {
                     return i;
                 }
             }
             return -1;
         };
 
-        GQCP::Tensor<Scalar, 2> C(system_onv_basis.size(), environment_onv_basis.size());  // = GQCP::Matrix<Scalar>::Zero();
+        GQCP::Tensor<Scalar, 2> C(system_onv_collection.size(), environment_onv_collection.size());
         C.setZero();
-        C.asMatrix().print();
 
         for (size_t ij = 0; ij < system_onvs.size(); ++ij) {
 
-            int i = onv_index(system_onvs[ij], system_onv_basis);
-            int j = onv_index(environment_onvs[ij], environment_onv_basis);
-            std::cout << "onv i: " << system_onvs[ij] << "\tonv j: " << environment_onvs[ij];
-            std::cout << "\ti: " << i << "\tj: " << j << "\tcoefficient: " << this->coefficient(ij) << std::endl;
+            int i = onv_index(system_onvs[ij], system_onv_collection);
+            int j = onv_index(environment_onvs[ij], environment_onv_collection);
 
             C(i, j) = this->coefficient(ij);
         }
         return C;
     }
 
+
     /**
-     *  Calculate the orbital reduced density matrix as defined in equation (3) of Rissler2005 (https://doi.org/10.1016/j.chemphys.2005.10.018).
+     *  Calculate the orbital reduced density matrix as defined in equation (2) of Rissler2005 (https://doi.org/10.1016/j.chemphys.2005.10.018).
      *
-     *  @param system_onvs              A vector of all ONVs of the system that is obtained after splitting an ONV basis into two subsystems.
-     *  @param environment_onvs         A vector of all ONVs of the environment that is obtained after splitting an ONV basis into two subsystems.
+     *  @param system_onvs              A vector of all ONVs of the system that is obtained after splitting a collection of ONVs into two subsystems.
+     *  @param environment_onvs         A vector of all ONVs of the environment that is obtained after splitting a collection of ONVs into two subsystems.
      *
      *  @return The orbital reduced density matrix.
      */
     template <typename Z = ONVBasis>
-    enable_if_t<std::is_same<Z, SpinUnresolvedONVBasis>::value | std::is_same<Z, SpinResolvedONVBasis>::value, GQCP::SquareMatrix<Scalar>> calculateSystemOrbitalRDM(const std::vector<typename ONVBasis::ONV>& system_onvs, const std::vector<typename ONVBasis::ONV>& environment_onvs) const {
+    enable_if_t<std::is_same<Z, SpinUnresolvedONVBasis>::value | std::is_same<Z, SpinResolvedONVBasis>::value, GQCP::Tensor<Scalar, 2>> calculateSystemOrbitalRDM(const std::vector<typename ONVBasis::ONV>& system_onvs, const std::vector<typename ONVBasis::ONV>& environment_onvs) const {
 
         if (system_onvs.size() != environment_onvs.size()) {
             throw std::invalid_argument("LinearExpansion::calculateSystemOrbitalRDM(std::vector<ONV>& system_onvs, std::vector<ONV>& environment_onvs) const: The amount of system ONVs should be exactly the same as the amount of environment ONVs.");
         }
 
-        // Determine the dimensions of the orbital density matrix.
-        const auto unique_onvs = [](const std::vector<typename ONVBasis::ONV>& onvs) {
-            // The ONV basis containing all unique ONVs.
-            std::vector<typename ONVBasis::ONV> onv_basis;
+        // The coefficients must be in the tensorized form to apply equation (2).
+        const auto C = this->tensorizeCoefficients(system_onvs, environment_onvs);
 
-            for (const auto& onv : onvs) {
-
-                bool unique = true;
-                // If the ONV already is inside this basis, do not add it again.
-                for (const auto& unique_onv : onv_basis) {
-                    if (onv.asString() == unique_onv.asString()) {
-                        unique = false;
-                    }
-                }
-                // If it is an unique ONV, add it to the ONV basis.
-                if (unique) {
-                    onv_basis.push_back(onv);
-                }
-            }
-            return onv_basis;
-        };
-
-        const auto system_onv_basis = unique_onvs(system_onvs);
-        const auto environment_onv_basis = unique_onvs(environment_onvs);
-
-        // Calculate the orbital reduced density matrix.
-        const auto dim = system_onv_basis.size();
-        GQCP::SquareMatrix<Scalar> rho = GQCP::SquareMatrix<Scalar>::Zero(dim);
-
-        for (size_t r = 0; r < dim; ++r) {
-            for (size_t c = 0; c < dim; ++c) {
-
-                double matrix_element = 0.0;
-
-                auto N_diff = system_onv_basis[r].numberOfElectrons() - system_onv_basis[c].numberOfElectrons();
-                size_t Sz_diff = 0;
-                if constexpr (std::is_same_v<Z, SpinResolvedONVBasis>) {
-                    Sz_diff = (system_onv_basis[r].numberOfElectrons(Spin::alpha) - system_onv_basis[r].numberOfElectrons(Spin::beta)) - (system_onv_basis[c].numberOfElectrons(Spin::alpha) - system_onv_basis[c].numberOfElectrons(Spin::beta));
-                }
-
-                if (N_diff == 0 && Sz_diff == 0) {
-                    // \sum_j <j|<n|\Psi><\Psi|n'>|j> -> onv_n_bra = <n| and onv_n_ket = |n'>
-                    for (size_t p = 0; p < system_onvs.size(); ++p) {      // Loop over |\Psi> = \sum_p |system_p>|environment_p>.
-                        for (size_t q = 0; q < system_onvs.size(); ++q) {  // Loop over <\Psi| = \sum_q <environment_q|<system_q|.
-                            // If <n|onv_system> and <onv_system'|n'> are both 1, we can calculate the overlap with the environment ONVs.
-                            if ((system_onv_basis[r] == system_onvs[p]) && (system_onvs[q] == system_onv_basis[c])) {
-                                for (size_t j = 0; j < environment_onv_basis.size(); ++j) {  // Loop over all ONVs of the environment. (\sum_j <j|...|j>)
-                                    // If <j|environment_onv> and <environment_onv'|j> both are 1, the coefficients will contribute to the matrix element.
-                                    if ((environment_onv_basis[j] == environment_onvs[p]) && (environment_onvs[q] == environment_onv_basis[j])) {
-                                        matrix_element += this->coefficient(p) * this->coefficient(q);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    rho(r, c) = matrix_element;
-                }
-            }
-        }
-        return rho;
+        // Partial trace over the index of the environment ("j").
+        return C.template einsum<1>("ij,kj->ik", C);
     }
 
 

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -147,16 +147,16 @@ BOOST_AUTO_TEST_CASE(orbital_reduced_density_matrix) {
     // const auto rho = wfn.calculateSystemOrbitalRDM(system_onvs, environment_onvs);
     const auto C = wfn.tensorizeCoefficients(system_onvs, environment_onvs);
 
-    GQCP::MatrixX<double> C_ref {4, 4};
     // clang-format off
-    C_ref << 
+    GQCP::Matrix<double, 4, 4> C_ref;
+    C_ref <<
         wfn.coefficient(1), 0, wfn.coefficient(3), 0,
         0, wfn.coefficient(0), 0, 0,
         wfn.coefficient(2), 0, wfn.coefficient(4), 0,
         0, 0, 0, wfn.coefficient(5);
     // clang-format on
 
-    BOOST_CHECK(C.isApprox(C_ref));
+    BOOST_CHECK(C.asMatrix().isApprox(C_ref));
 }
 
 

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -148,15 +148,15 @@ BOOST_AUTO_TEST_CASE(orbital_reduced_density_matrix) {
     const auto C = wfn.tensorizeCoefficients(system_onvs, environment_onvs);
 
     // clang-format off
-    GQCP::Matrix<double, 4, 4> C_ref;
-    C_ref <<
-        wfn.coefficient(1), 0, wfn.coefficient(3), 0,
-        0, wfn.coefficient(0), 0, 0,
-        wfn.coefficient(2), 0, wfn.coefficient(4), 0,
-        0, 0, 0, wfn.coefficient(5);
-    // clang-format on
+    //GQCP::Matrix<double, 4, 4> C_ref;
+    //C_ref <<
+    //    wfn.coefficient(1), 0, wfn.coefficient(3), 0,
+    //    0, wfn.coefficient(0), 0, 0,
+    //    wfn.coefficient(2), 0, wfn.coefficient(4), 0,
+    //    0, 0, 0, wfn.coefficient(5);
+    //  clang-format on
 
-    BOOST_CHECK(C.asMatrix().isApprox(C_ref));
+    // BOOST_CHECK(C.asMatrix().isApprox(C_ref));
 }
 
 

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -132,6 +132,9 @@ BOOST_AUTO_TEST_CASE(single_orbital_entropy_throw) {
 }
 
 
+/**
+ *  Check if the coefficients of the linear expansion are tensorized in the correct way.
+ */
 BOOST_AUTO_TEST_CASE(tensorize_coeffients) {
 
     const GQCP::SpinUnresolvedONVBasis onv_basis {4, 2};
@@ -157,6 +160,9 @@ BOOST_AUTO_TEST_CASE(tensorize_coeffients) {
 }
 
 
+/**
+ *  Check if the calculation of the system orbital density matrix matches the manual example (https://github.com/GQCG/GQCP/pull/1000#issuecomment-944194757).
+ */
 BOOST_AUTO_TEST_CASE(orbital_reduced_density_matrix) {
 
     // Manual example, see (https://github.com/GQCG/GQCP/pull/1000#issuecomment-944194757) for more details.

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -147,13 +147,14 @@ BOOST_AUTO_TEST_CASE(orbital_reduced_density_matrix) {
     // const auto rho = wfn.calculateSystemOrbitalRDM(system_onvs, environment_onvs);
     const auto C = wfn.tensorizeCoefficients(system_onvs, environment_onvs);
 
-    GQCP::MatrixX<double> C_ref {
-                        {wfn.coefficient(1), 0, wfn.coefficient(3), 0},
-                        {0, wfn.coefficient(0), 0, 0},
-                        {wfn.coefficient(2), 0, wfn.coefficient(4), 0},
-                        {0, 0, 0, wfn.coefficient(5)}
-
-    };
+    GQCP::MatrixX<double> C_ref {4, 4};
+    // clang-format off
+    C_ref << 
+        wfn.coefficient(1), 0, wfn.coefficient(3), 0,
+        0, wfn.coefficient(0), 0, 0,
+        wfn.coefficient(2), 0, wfn.coefficient(4), 0,
+        0, 0, 0, wfn.coefficient(5);
+    // clang-format on
 
     BOOST_CHECK(C.isApprox(C_ref));
 }

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -131,6 +131,8 @@ BOOST_AUTO_TEST_CASE(single_orbital_entropy_throw) {
     BOOST_CHECK_THROW(linear_expansion.calculateSingleOrbitalEntropy(4);, std::invalid_argument);  // Orbital index is larger than the amount of orbitals.
 }
 
+BOOST_AUTO_TEST_CASE(C_tensor) {
+}
 
 BOOST_AUTO_TEST_CASE(orbital_reduced_density_matrix) {
 
@@ -144,28 +146,8 @@ BOOST_AUTO_TEST_CASE(orbital_reduced_density_matrix) {
     // |10>, |00>, |10>, |01>, |11>, |01>
     std::vector<GQCP::SpinUnresolvedONV> environment_onvs {{2, 1, 1}, {2, 0, 0}, {2, 1, 1}, {2, 1, 2}, {2, 2, 3}, {2, 1, 2}};
 
-    const auto rho = wfn.calculateSystemOrbitalRDM(system_onvs, environment_onvs);
-
-    // <n| = <10|, |n'> = |10>
-    BOOST_CHECK_EQUAL(rho(0, 0), wfn.coefficient(0) * wfn.coefficient(0) + wfn.coefficient(3) * wfn.coefficient(3));
-    // <n| = <10|, |n'> = |11>
-    BOOST_CHECK_EQUAL(rho(0, 1), 0);
-    // <n| = <10|, |n'> = |01>
-    BOOST_CHECK_EQUAL(rho(0, 2), wfn.coefficient(0) * wfn.coefficient(2) + wfn.coefficient(3) * wfn.coefficient(5));
-    // <n| = <10|, |n'> = |00>
-    BOOST_CHECK_EQUAL(rho(0, 3), 0);
-    // <n| = <11|, |n'> = |11>
-    BOOST_CHECK_EQUAL(rho(1, 1), wfn.coefficient(1) * wfn.coefficient(1));
-    // <n| = <11|, |n'> = |01>
-    BOOST_CHECK_EQUAL(rho(1, 2), 0);
-    // <n| = <11|, |n'> = |00>
-    BOOST_CHECK_EQUAL(rho(1, 3), 0);
-    // <n| = <01|, |n'> = |01>
-    BOOST_CHECK_EQUAL(rho(2, 2), wfn.coefficient(2) * wfn.coefficient(2) + wfn.coefficient(5) * wfn.coefficient(5));
-    // <n| = <01|, |n'> = |00>
-    BOOST_CHECK_EQUAL(rho(2, 3), 0);
-    // <n| = <00|, |n'> = |00>
-    BOOST_CHECK_EQUAL(rho(3, 3), wfn.coefficient(4) * wfn.coefficient(4));
+    // const auto rho = wfn.calculateSystemOrbitalRDM(system_onvs, environment_onvs);
+    const auto C = wfn.tensorizeCoefficients(system_onvs, environment_onvs);
 }
 
 

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -134,8 +134,6 @@ BOOST_AUTO_TEST_CASE(single_orbital_entropy_throw) {
 
 BOOST_AUTO_TEST_CASE(tensorize_coeffients) {
 
-    // Manual example, see (https://github.com/GQCG/GQCP/pull/1000#issuecomment-944194757) for more details.
-
     const GQCP::SpinUnresolvedONVBasis onv_basis {4, 2};
     const auto wfn = GQCP::LinearExpansion<double, GQCP::SpinUnresolvedONVBasis>::Random(onv_basis);
 
@@ -154,11 +152,6 @@ BOOST_AUTO_TEST_CASE(tensorize_coeffients) {
         0, wfn.coefficient(2), wfn.coefficient(4), 0,
         0, 0, 0, wfn.coefficient(5);
     //  clang-format on
-
-    std::cout << "C tensor: " << std::endl;
-    C.asMatrix().print();
-    std::cout << "C_ref: " << std::endl;
-    C_ref.print();
 
     BOOST_CHECK(C.asMatrix().isApprox(C_ref));
 }

--- a/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
+++ b/gqcp/tests/QCModel/CI/LinearExpansion_test.cpp
@@ -131,8 +131,6 @@ BOOST_AUTO_TEST_CASE(single_orbital_entropy_throw) {
     BOOST_CHECK_THROW(linear_expansion.calculateSingleOrbitalEntropy(4);, std::invalid_argument);  // Orbital index is larger than the amount of orbitals.
 }
 
-BOOST_AUTO_TEST_CASE(C_tensor) {
-}
 
 BOOST_AUTO_TEST_CASE(orbital_reduced_density_matrix) {
 
@@ -148,6 +146,16 @@ BOOST_AUTO_TEST_CASE(orbital_reduced_density_matrix) {
 
     // const auto rho = wfn.calculateSystemOrbitalRDM(system_onvs, environment_onvs);
     const auto C = wfn.tensorizeCoefficients(system_onvs, environment_onvs);
+
+    GQCP::MatrixX<double> C_ref {
+                        {wfn.coefficient(1), 0, wfn.coefficient(3), 0},
+                        {0, wfn.coefficient(0), 0, 0},
+                        {wfn.coefficient(2), 0, wfn.coefficient(4), 0},
+                        {0, 0, 0, wfn.coefficient(5)}
+
+    };
+
+    BOOST_CHECK(C.isApprox(C_ref));
 }
 
 


### PR DESCRIPTION
**Short description**

This PR is aimed to accelerate the calculation of the orbital RDM. The code has been split up in two parts:
- calculation of the coefficient tensor (this is just a matrix)
- contraction of the coefficient tensor to deliver an orbital RDM
Since this refactor prevents the unnecessary looping to calculate each orbital RDM element, its performance is improved (see screenshot).
<img width="661" alt="timing_tensor_vs_linear" src="https://user-images.githubusercontent.com/33431368/151837495-09ca3a26-9b9a-4c39-a7d7-02ee10a6216a.png">


**To do**

- [ ] (if applicable, when creating new source files): don't forget to update the Doxygen file, the collective `gqcp.hpp` include header and the CMake files
- [ ] Add other smaller task to be completed as a Markdown task list
