### PR TITLE
fix the stability threshold in the python bindings

### DIFF
--- a/gqcpy/include/interfaces.hpp
+++ b/gqcpy/include/interfaces.hpp
@@ -1081,7 +1081,7 @@ void bindQCModelHartreeFockComplexStabilityInterface(Class& py_class) {
 
         .def("isInternallyStable",
              &Type::isInternallyStable,
-             py::arg("threshold") = 1.0e-05,
+             py::arg("threshold") = -1.0e-05,
              "Return a boolean, telling us if the real or complex valued internal stability matrix belongs to a stable or unstable set of parameters.")
 
         .def(
@@ -1121,7 +1121,7 @@ void bindQCModelHartreeFockRealStabilityInterface(Class& py_class) {
             [](const Type& stability_matrices, const double threshold) {
                 return stability_matrices.isExternallyStable(threshold);
             },
-            py::arg("threshold") = 1.0e-05,
+            py::arg("threshold") = -1.0e-05,
             "Return a boolean, telling us if the real valued external stability matrix belongs to a stable or unstable set of parameters.");
 
     // Add the APIs from the complex interface, as every real method has those as well.

--- a/gqcpy/src/QCModel/HF/StabilityMatrices/RHFStabilityMatrices_bindings.cpp
+++ b/gqcpy/src/QCModel/HF/StabilityMatrices/RHFStabilityMatrices_bindings.cpp
@@ -75,7 +75,7 @@ void bindQCModelRHFStabilityInterface(Class& py_class) {
 
         .def("isTripletStable",
              &Type::isTripletStable,
-             py::arg("threshold") = 1.0e-05,
+             py::arg("threshold") = -1.0e-05,
              "Return a boolean, telling us if the restricted->unrestricted stability matrix belongs to a stable or unstable set of parameters.");
 }
 
@@ -93,7 +93,7 @@ void bindRHFStabilityMatrices(py::module& module) {
             [](const RHFStabilityMatrices<double>& stability_matrices, const double threshold) {
                 return stability_matrices.isComplexConjugateStable(threshold);
             },
-            py::arg("threshold") = 1.0e-05,
+            py::arg("threshold") = -1.0e-05,
             "Return a boolean, telling us if the real->complex stability matrix belongs to a stable or unstable set of parameters.");
 
     // Expose the `HartreeFockRealStability` interface.
@@ -113,7 +113,7 @@ void bindRHFStabilityMatrices(py::module& module) {
             [](const RHFStabilityMatrices<complex>& stability_matrices, const double threshold) {
                 return stability_matrices.isExternallyStable(threshold);
             },
-            py::arg("threshold") = 1.0e-05,
+            py::arg("threshold") = -1.0e-05,
             "Return a boolean, telling us if the complex valued external stability matrix belongs to a stable or unstable set of parameters.");
 
     // Expose the `HartreeFockComplexStability` interface.

--- a/gqcpy/src/QCModel/HF/StabilityMatrices/UHFStabilityMatrices_bindings.cpp
+++ b/gqcpy/src/QCModel/HF/StabilityMatrices/UHFStabilityMatrices_bindings.cpp
@@ -75,7 +75,7 @@ void bindQCModelUHFStabilityInterface(Class& py_class) {
 
         .def("isSpinUnconservedStable",
              &Type::isSpinUnconservedStable,
-             py::arg("threshold") = 1.0e-05,
+             py::arg("threshold") = -1.0e-05,
              "Return a boolean, telling us if the unrestricted->generalized stability matrix belongs to a stable or unstable set of parameters.")
 
         .def(
@@ -87,8 +87,7 @@ void bindQCModelUHFStabilityInterface(Class& py_class) {
             py::arg("N_occupied_beta"),
             py::arg("N_virtual_alpha"),
             py::arg("N_virtual_beta"),
-            "Return the transformation corresponding to the lowest-lying eigenvector of the internal instability Hessian."
-        );
+            "Return the transformation corresponding to the lowest-lying eigenvector of the internal instability Hessian.");
 }
 
 
@@ -105,7 +104,7 @@ void bindUHFStabilityMatrices(py::module& module) {
             [](const UHFStabilityMatrices<double>& stability_matrices, const double threshold) {
                 return stability_matrices.isComplexConjugateStable(threshold);
             },
-            py::arg("threshold") = 1.0e-05,
+            py::arg("threshold") = -1.0e-05,
             "Return a boolean, telling us if the real->complex stability matrix belongs to a stable or unstable set of parameters.");
 
     // Expose the `HartreeFockRealStability` interface.
@@ -125,7 +124,7 @@ void bindUHFStabilityMatrices(py::module& module) {
             [](const UHFStabilityMatrices<complex>& stability_matrices, const double threshold) {
                 return stability_matrices.isExternallyStable(threshold);
             },
-            py::arg("threshold") = 1.0e-05,
+            py::arg("threshold") = -1.0e-05,
             "Return a boolean, telling us if the complex valued external stability matrix belongs to a stable or unstable set of parameters.");
 
     // Expose the `HartreeFockComplexStability` interface.


### PR DESCRIPTION
**Short description**

The stability threshold in the python bindings was set to `1e-5` instead of `-1e-5` causing some methods to return a false statement about stability when used in python.
