### PR TITLE
ForEach for linear expansion in spinUnresolvedONVBasis 

### DIFF
--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -2023,7 +2023,7 @@ public:
         const auto& onv_basis = this->onv_basis;
         const auto& coefficients = this->m_coefficients;
         onv_basis.forEach([&onv_basis, &callback, &coefficients](const SpinUnresolvedONV& onv, const size_t I) {
-            const auto address = onv_basis.compoundAddress(I);
+            const auto address = onv_basis.addressOf(I);
             const auto coefficient = coefficients(address);
 
             callback(coefficient, onv);

--- a/gqcp/include/QCModel/CI/LinearExpansion.hpp
+++ b/gqcp/include/QCModel/CI/LinearExpansion.hpp
@@ -2011,6 +2011,26 @@ public:
     }
 
 
+    /**
+     *  Iterate over all expansion coefficients and corresponding ONVs, and apply the given callback function.
+     *
+     *  @param callback                 The function to be applied in every iteration. Its arguments are an expansion coefficient and the corresponding ONV.
+     */
+    template <typename Z = ONVBasis>
+    enable_if_t<std::is_same<Z, SpinUnresolvedONVBasis>::value, void> forEach(const std::function<void(const Scalar, const SpinUnresolvedONV)>& callback) const {
+
+        // Iterate over all ONVs in this ONV basis, and look up the corresponding coefficient.
+        const auto& onv_basis = this->onv_basis;
+        const auto& coefficients = this->m_coefficients;
+        onv_basis.forEach([&onv_basis, &callback, &coefficients](const SpinUnresolvedONV& onv, const size_t I) {
+            const auto address = onv_basis.compoundAddress(I);
+            const auto coefficient = coefficients(address);
+
+            callback(coefficient, onv);
+        });
+    }
+
+
     /*
      *  MARK: Comparing
      */

--- a/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
+++ b/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
@@ -374,6 +374,18 @@ void bindLinearExpansions(py::module& module) {
             "Return the orbital reduced density matrix")
 
         /*
+         * MARK: Iteration
+         */
+
+        .def(
+            "forEach",
+            [](const LinearExpansion<double, SpinUnresolvedONVBasis>& linear_expansion, const std::function<void(const double, const SpinUnresolvedONV)>& callback) {
+                return linear_expansion.forEach(callback);
+            },
+            py::arg("callback"),
+            "Iterate over all expansion coefficients and corresponding ONVs, and apply the given callback function.")
+
+        /*
          *  MARK: Entropy
          */
 

--- a/website/examples/R-U-GHF-overlaps.ipynb
+++ b/website/examples/R-U-GHF-overlaps.ipynb
@@ -2,14 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Overlaps between R/U/GHF"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Force the local gqcpy to be imported\n",
     "import sys\n",
@@ -17,143 +19,155 @@
     "\n",
     "import gqcpy\n",
     "import numpy as np\n",
+    "import numpy.random as rand\n",
     "\n",
     "np.set_printoptions(precision=3, linewidth=120)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "In this notebook, we will explore the multi-configurational behaviour of UHF and GHF, by projecting the UHF and GHF ONVs onto the full ONV basis expressed with respect to the RHF orbitals."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Projecting UHF"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### H2"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "As an introductory example, let's start by examining H2. We'll set up an unrestricted spin-orbital basis, where the alpha- and beta-coefficient matrices are equal. Then, we expect the projection of the UHF ONV onto the ONV basis expressed with respect to the RHF spin-orbitals to yield a linear combination consisting of exactly one 1, and the rest 0."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "molecule = gqcpy.Molecule.HChain(2, 1.0)\n",
     "N = molecule.numberOfElectrons()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "r_spinor_basis = gqcpy.RSpinOrbitalBasis_d(molecule, \"STO-3G\")\n",
     "K = r_spinor_basis.numberOfSpatialOrbitals()\n",
     "\n",
     "S = r_spinor_basis.quantize(gqcpy.OverlapOperator())"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "sq_hamiltonian = r_spinor_basis.quantize(gqcpy.FQMolecularHamiltonian(molecule))  # 'sq' for 'second-quantized'"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "source": [
-    "sq_hamiltonian = r_spinor_basis.quantize(gqcpy.FQMolecularHamiltonian(molecule))  # 'sq' for 'second-quantized'"
-   ],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
    "source": [
     "rhf_environment = gqcpy.RHFSCFEnvironment_d.WithCoreGuess(N, sq_hamiltonian, S)\n",
     "rhf_solver = gqcpy.RHFSCFSolver_d.Plain()\n",
     "\n",
     "rhf_objective = gqcpy.DiagonalRHFFockMatrixObjective_d(sq_hamiltonian)  # use the default threshold of 1.0e-08"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "rhf_parameters = gqcpy.RHF_d.optimize(rhf_objective, rhf_solver, rhf_environment).groundStateParameters()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "After having done the RHF calculation, we are able to construct restricted and unrestricted spin-orbital bases."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "r_spinor_basis.transform(rhf_parameters.expansion())"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "u_spinor_basis = gqcpy.USpinOrbitalBasis_d.FromRestricted(r_spinor_basis)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "We are now in the position to calculate the expansion of the UHF determinant in the full spin-resolved ONV basis expressed with respect to the RHF spin-orbitals."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "uhf_determinant = gqcpy.SpinResolvedONV.UHF(2, 1, 1)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Projecting this determinant is done by constructing a `LinearExpansion` from an ONV projection:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1.0000 10|10\n",
+      "-0.0000 10|01\n",
+      "-0.0000 01|10\n",
+      " 0.0000 01|01\n"
+     ]
+    }
+   ],
    "source": [
     "expansion = gqcpy.LinearExpansion_SpinResolved.FromONVProjection(uhf_determinant, r_spinor_basis, u_spinor_basis)\n",
     "\n",
@@ -161,38 +175,27 @@
     "    print(\"{:7.4f}\".format(coefficient), onv)\n",
     "    \n",
     "expansion.forEach(print_function)"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      " 1.0000 01|01\n",
-      "-0.0000 01|10\n",
-      "-0.0000 10|01\n",
-      " 0.0000 10|10\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### H4"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "As a more interesting example, we'll project the H4 UHF triplet state onto the basis of ONVs expressed with respect to the RHF spin-orbitals."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "molecule = gqcpy.Molecule.HRingFromDistance(4, 1.0, 0)\n",
     "N = molecule.numberOfElectrons()\n",
@@ -201,40 +204,40 @@
     "N_beta = N//2\n",
     "\n",
     "internuclear_repulsion_energy = gqcpy.NuclearRepulsionOperator(molecule.nuclearFramework()).value()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Using Xeno's code, we find the following coefficient matrices for the RHF solution:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "C = [[-0.27745359, -0.8505133,   0.85051937,  2.02075317],\n",
     "     [-0.27745362, -0.85051937, -0.8505133,  -2.02075317],\n",
     "     [-0.27745359,  0.8505133,  -0.85051937,  2.02075317],\n",
     "     [-0.27745362,  0.85051937,  0.8505133,  -2.02075317]]\n",
     "C = np.array(C)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "and the UHF solution:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "C_alpha = [[-1.75646828e-01, -1.20606646e-06,  1.20281173e+00,  2.03213486e+00],\n",
     "           [-3.78560533e-01, -1.20281173e+00, -1.20606647e-06, -2.00427438e+00],\n",
@@ -247,119 +250,301 @@
     "          [-3.78560533e-01, -1.20281173e+00, -1.21724558e-06,  2.00427438e+00],\n",
     "          [-1.75646828e-01, -1.21724558e-06,  1.20281173e+00, -2.03213486e+00]]\n",
     "C_beta = np.array(C_beta)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Let's now set up the corresponding restricted and unrestricted spin-orbital bases."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "r_spinor_basis = gqcpy.RSpinOrbitalBasis_d(molecule, \"STO-3G\")\n",
     "r_spinor_basis.transform(gqcpy.RTransformation_d(C))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "u_spinor_basis = gqcpy.USpinOrbitalBasis_d(molecule, \"STO-3G\")\n",
     "u_spinor_basis.transform(gqcpy.UTransformation_d(gqcpy.UTransformationComponent_d(C_alpha), gqcpy.UTransformationComponent_d(C_beta)))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "We can now construct the UHF spin-resolved ONV:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "uhf_determinant = gqcpy.SpinResolvedONV.UHF(4, 2, 2)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "and project it onto the spin-resolved basis of ONVs expressed with respect to the orthonormal restricted spin-orbitals:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-0.4987 1100|1100\n",
+      " 0.4987 1100|1010\n",
+      " 0.0000 1100|0110\n",
+      " 0.0000 1100|1001\n",
+      "-0.0251 1100|0101\n",
+      " 0.0251 1100|0011\n",
+      "-0.4987 1010|1100\n",
+      " 0.4987 1010|1010\n",
+      " 0.0000 1010|0110\n",
+      " 0.0000 1010|1001\n",
+      "-0.0251 1010|0101\n",
+      " 0.0251 1010|0011\n",
+      "-0.0000 0110|1100\n",
+      " 0.0000 0110|1010\n",
+      " 0.0000 0110|0110\n",
+      " 0.0000 0110|1001\n",
+      "-0.0000 0110|0101\n",
+      " 0.0000 0110|0011\n",
+      " 0.0000 1001|1100\n",
+      "-0.0000 1001|1010\n",
+      "-0.0000 1001|0110\n",
+      "-0.0000 1001|1001\n",
+      " 0.0000 1001|0101\n",
+      "-0.0000 1001|0011\n",
+      " 0.0251 0101|1100\n",
+      "-0.0251 0101|1010\n",
+      "-0.0000 0101|0110\n",
+      "-0.0000 0101|1001\n",
+      " 0.0013 0101|0101\n",
+      "-0.0013 0101|0011\n",
+      " 0.0251 0011|1100\n",
+      "-0.0251 0011|1010\n",
+      "-0.0000 0011|0110\n",
+      "-0.0000 0011|1001\n",
+      " 0.0013 0011|0101\n",
+      "-0.0013 0011|0011\n"
+     ]
+    }
+   ],
    "source": [
     "expansion = gqcpy.LinearExpansion_SpinResolved.FromONVProjection(uhf_determinant, r_spinor_basis, u_spinor_basis)\n",
     "\n",
     "expansion.forEach(print_function)"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GHF on UHF projection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us start by performing an Unrestricted Hartree-Fock and a Generalized Hartree-Fock calculation on H3. Both should yield different results as H3 posseses a fully spin-symmetry broken solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "molecule = gqcpy.Molecule.HRingFromDistance(3, 1.889, 0)  # create a neutral molecule\n",
+    "N = molecule.numberOfElectrons()\n",
+    "N_alpha = N//2 + 1\n",
+    "N_beta = N//2\n",
+    "\n",
+    "spinor_basis = gqcpy.USpinOrbitalBasis_d(molecule, \"STO-3G\")\n",
+    "S = spinor_basis.quantize(gqcpy.OverlapOperator())\n",
+    "\n",
+    "sq_hamiltonian = spinor_basis.quantize(gqcpy.FQMolecularHamiltonian(molecule))  # 'sq' for 'second-quantized'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "-0.4987 0011|0011\n",
-      " 0.4987 0011|0101\n",
-      " 0.0000 0011|0110\n",
-      " 0.0000 0011|1001\n",
-      "-0.0251 0011|1010\n",
-      " 0.0251 0011|1100\n",
-      "-0.4987 0101|0011\n",
-      " 0.4987 0101|0101\n",
-      " 0.0000 0101|0110\n",
-      " 0.0000 0101|1001\n",
-      "-0.0251 0101|1010\n",
-      " 0.0251 0101|1100\n",
-      "-0.0000 0110|0011\n",
-      " 0.0000 0110|0101\n",
-      " 0.0000 0110|0110\n",
-      " 0.0000 0110|1001\n",
-      "-0.0000 0110|1010\n",
-      " 0.0000 0110|1100\n",
-      " 0.0000 1001|0011\n",
-      "-0.0000 1001|0101\n",
-      "-0.0000 1001|0110\n",
-      "-0.0000 1001|1001\n",
-      " 0.0000 1001|1010\n",
-      "-0.0000 1001|1100\n",
-      " 0.0251 1010|0011\n",
-      "-0.0251 1010|0101\n",
-      "-0.0000 1010|0110\n",
-      "-0.0000 1010|1001\n",
-      " 0.0013 1010|1010\n",
-      "-0.0013 1010|1100\n",
-      " 0.0251 1100|0011\n",
-      "-0.0251 1100|0101\n",
-      "-0.0000 1100|0110\n",
-      "-0.0000 1100|1001\n",
-      " 0.0013 1100|1010\n",
-      "-0.0013 1100|1100\n"
+      "-1.3358471555881106\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "UHF_environment = gqcpy.UHFSCFEnvironment_d.WithCoreGuess(N_alpha, N_beta, sq_hamiltonian, S)\n",
+    "UHF_solver = gqcpy.UHFSCFSolver_d.Plain(threshold=1.0e-04, maximum_number_of_iterations=1000)  # the system is not converging very rapidly\n",
+    "uqc_structure = gqcpy.UHF_d.optimize(UHF_solver, UHF_environment)\n",
+    "\n",
+    "print(uqc_structure.groundStateEnergy() + gqcpy.NuclearRepulsionOperator(molecule.nuclearFramework()).value())\n",
+    "uhf_parameters = uqc_structure.groundStateParameters()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now have a UHF solution with the wanted parameters saved in a variable. We can now do the same for GHF."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-1.3403026284286064\n"
+     ]
+    }
+   ],
+   "source": [
+    "basis = gqcpy.GSpinorBasis_d(molecule, \"STO-3G\")\n",
+    "gS = basis.quantize(gqcpy.OverlapOperator())\n",
+    "gsq_hamiltonian = basis.quantize(gqcpy.FQMolecularHamiltonian(molecule))\n",
+    "\n",
+    "# Generate a random guess in order to find a true GHF solution.\n",
+    "rand.seed(2)\n",
+    "K = spinor_basis.numberOfSpinors()\n",
+    "random_matrix = np.random.rand(K, K)\n",
+    "random_matrix_transpose = random_matrix.T\n",
+    "symmetric_random_matrix = random_matrix + random_matrix_transpose\n",
+    "_, guess = np.linalg.eigh(symmetric_random_matrix)\n",
+    "\n",
+    "GHF_environment = gqcpy.GHFSCFEnvironment_d(N, gsq_hamiltonian, gS, gqcpy.GTransformation_d(guess))\n",
+    "GHF_solver = gqcpy.GHFSCFSolver_d.Plain(1.0e-08, 4000)\n",
+    "gqc_structure = gqcpy.GHF_d.optimize(GHF_solver, GHF_environment)\n",
+    "    \n",
+    "print(gqc_structure.groundStateEnergy() + gqcpy.NuclearRepulsionOperator(molecule.nuclearFramework()).value())\n",
+    "ghf_parameters = gqc_structure.groundStateParameters()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to create a projection, we will need to transform the respective spino(bital) bases to MO basis, as well as transform the UHF basis to a spinor representation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basis.transform(ghf_parameters.expansion())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spinor_basis.transform(uhf_parameters.expansion())\n",
+    "spinor_basis = gqcpy.GSpinorBasis_d.FromUnrestricted(spinor_basis)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The final ingredient we need is a representation of the GHF determinant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "GHF_determinant = gqcpy.SpinUnresolvedONV.GHF(K, N, ghf_parameters.orbitalEnergies())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now create the projection and print it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0.0334 111000\n",
+      " 0.0334 110100\n",
+      "-0.2384 101100\n",
+      " 0.0334 011100\n",
+      "-0.6027 110010\n",
+      "-0.2384 101010\n",
+      "-0.6027 011010\n",
+      " 0.0334 100110\n",
+      "-0.0989 010110\n",
+      "-0.0989 001110\n",
+      " 0.0976 110001\n",
+      "-0.2384 101001\n",
+      " 0.2098 011001\n",
+      "-0.6027 100101\n",
+      "-0.0989 010101\n",
+      " 0.4620 001101\n",
+      " 0.0976 100011\n",
+      " 0.0339 010011\n",
+      " 0.2638 001011\n",
+      " 0.0976 000111\n"
+     ]
+    }
+   ],
+   "source": [
+    "expansion = gqcpy.LinearExpansion_SpinUnresolved.FromONVProjection(GHF_determinant, spinor_basis, basis)\n",
+    "\n",
+    "expansion.forEach(print_function)"
+   ]
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "e4c6ce54e6d1ccff551279c9aafc06b78c48fd9e60d6b4e74c0583a74ec1d1f9"
+  },
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.5 64-bit ('base': conda)"
+   "display_name": "Python 3.8.5 64-bit ('base': conda)",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -371,10 +556,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
-  },
-  "interpreter": {
-   "hash": "e4c6ce54e6d1ccff551279c9aafc06b78c48fd9e60d6b4e74c0583a74ec1d1f9"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**Short description**

At the moment, such a forEach() function is only provided for linear expansions in spin resolved ONV bases.

**To do**

- [x] Add example to notebook
- [x] Add C++ code
- [x] Add binding
