### PR TITLE
enable python bindings FCI on GHF reference

### DIFF
--- a/gqcpy/src/QCMethod/CI/CIEnvironment_bindings.cpp
+++ b/gqcpy/src/QCMethod/CI/CIEnvironment_bindings.cpp
@@ -36,7 +36,7 @@ using namespace GQCP;
 
 
 /**
- *  Bind a CI environment to a gqcpy submodule module.
+ *  Bind the full CI environment to a gqcpy submodule module.
  *
  *  @tparam Hamiltonian             the type of the Hamiltonian
  *  @tparam ONVBasis                the type of the ONV basis
@@ -68,6 +68,15 @@ void bindFullCIEnvironment(py::module& submodule, const std::string& documentati
 }
 
 
+/**
+ *  Bind the Dense only CI environment to a gqcpy submodule module.
+ *
+ *  @tparam Hamiltonian             the type of the Hamiltonian
+ *  @tparam ONVBasis                the type of the ONV basis
+ *
+ *  @param submodule                the gqcpy.CIEnvironment submodule
+ *  @param documentation            the documentation that should appear for the function
+ */
 template <typename Hamiltonian, typename ONVBasis>
 void bindDenseOnlyCIEnvironment(py::module& submodule, const std::string& documentation) {
 

--- a/gqcpy/src/QCMethod/CI/CIEnvironment_bindings.cpp
+++ b/gqcpy/src/QCMethod/CI/CIEnvironment_bindings.cpp
@@ -45,7 +45,7 @@ using namespace GQCP;
  *  @param documentation            the documentation that should appear for the function
  */
 template <typename Hamiltonian, typename ONVBasis>
-void bindCIEnvironment(py::module& submodule, const std::string& documentation) {
+void bindFullCIEnvironment(py::module& submodule, const std::string& documentation) {
 
     submodule.def(
         "Dense",
@@ -68,28 +68,36 @@ void bindCIEnvironment(py::module& submodule, const std::string& documentation) 
 }
 
 
-void bindCIEnvironments(py::module& module) {
+template <typename Hamiltonian, typename ONVBasis>
+void bindDenseOnlyCIEnvironment(py::module& submodule, const std::string& documentation) {
 
-    auto submodule = module.def_submodule("CIEnvironment");
-
-    bindCIEnvironment<RSQHamiltonian<double>, SpinResolvedONVBasis>(submodule, "Return an environment suitable for solving spin-resolved FCI eigenvalue problems.");
-    bindCIEnvironment<USQHamiltonian<double>, SpinResolvedONVBasis>(submodule, "Return an environment suitable for solving spin-resolved FCI eigenvalue problems.");
-    bindCIEnvironment<HubbardHamiltonian<double>, SpinResolvedONVBasis>(submodule, "Return an environment suitable for solving Hubbard problems.");
-
-    bindCIEnvironment<RSQHamiltonian<double>, SpinResolvedSelectedONVBasis>(submodule, "Return an environment suitable for solving spin-resolved selected eigenvalue problems.");
-    bindCIEnvironment<USQHamiltonian<double>, SpinResolvedSelectedONVBasis>(submodule, "Return an environment suitable for solving spin-resolved selected eigenvalue problems.");
-
-    bindCIEnvironment<RSQHamiltonian<double>, SeniorityZeroONVBasis>(submodule, "Return an environment suitable for solving seniority zero eigenvalue problems.");
-
-    // We haven't implemented matrix-vector products for `SpinUnresolvedSelectedONVBasis`, so we can't use the `Iterative` APIs.
     submodule.def(
         "Dense",
-        [](const GSQHamiltonian<double>& hamiltonian, const SpinUnresolvedSelectedONVBasis& onv_basis) {
+        [](const Hamiltonian& hamiltonian, const ONVBasis& onv_basis) {
             return CIEnvironment::Dense(hamiltonian, onv_basis);
         },
         py::arg("hamiltonian"),
         py::arg("onv_basis"),
-        "Return an environment suitable for solving spin-unresolved selected eigenvalue problems.");
+        documentation.c_str());
+}
+
+
+void bindCIEnvironments(py::module& module) {
+
+    auto submodule = module.def_submodule("CIEnvironment");
+
+    bindFullCIEnvironment<RSQHamiltonian<double>, SpinResolvedONVBasis>(submodule, "Return an environment suitable for solving spin-resolved FCI eigenvalue problems.");
+    bindFullCIEnvironment<USQHamiltonian<double>, SpinResolvedONVBasis>(submodule, "Return an environment suitable for solving spin-resolved FCI eigenvalue problems.");
+    bindFullCIEnvironment<HubbardHamiltonian<double>, SpinResolvedONVBasis>(submodule, "Return an environment suitable for solving Hubbard problems.");
+
+    bindFullCIEnvironment<RSQHamiltonian<double>, SpinResolvedSelectedONVBasis>(submodule, "Return an environment suitable for solving spin-resolved selected eigenvalue problems.");
+    bindFullCIEnvironment<USQHamiltonian<double>, SpinResolvedSelectedONVBasis>(submodule, "Return an environment suitable for solving spin-resolved selected eigenvalue problems.");
+
+    bindFullCIEnvironment<RSQHamiltonian<double>, SeniorityZeroONVBasis>(submodule, "Return an environment suitable for solving seniority zero eigenvalue problems.");
+
+    // We haven't implemented matrix-vector products for `SpinUnresolved(Selected)ONVBasis`, so we can't use the `Iterative` APIs.
+    bindDenseOnlyCIEnvironment<GSQHamiltonian<double>, SpinUnresolvedONVBasis>(submodule, "Return an environment suitable for solving spin-unresolved eigenvalue problems.");
+    bindDenseOnlyCIEnvironment<GSQHamiltonian<double>, SpinUnresolvedSelectedONVBasis>(submodule, "Return an environment suitable for solving spin-unresolved selected eigenvalue problems.");
 
     submodule.def(
         "Dense_cd",

--- a/gqcpy/src/QCMethod/CI/CI_factory_bindings.cpp
+++ b/gqcpy/src/QCMethod/CI/CI_factory_bindings.cpp
@@ -70,6 +70,7 @@ void bindCIFactory(py::module& module) {
     bindCIFactoryMethod<double, SpinResolvedONVBasis>(module);
     bindCIFactoryMethod<double, SpinResolvedSelectedONVBasis>(module);
 
+    bindCIFactoryMethod<double, SpinUnresolvedONVBasis>(module);
     bindCIFactoryMethod<double, SpinUnresolvedSelectedONVBasis>(module);
 
 

--- a/gqcpy/src/QCMethod/QCStructure_bindings.cpp
+++ b/gqcpy/src/QCMethod/QCStructure_bindings.cpp
@@ -105,6 +105,7 @@ void bindQCStructures(py::module& module) {
     bindQCStructure<LinearExpansion<double, SpinResolvedONVBasis>>(module, "LinearExpansion_SpinResolved", "A quantum chemical structure for real-valued linear expansions in a spin-resolved ONV basis.");
     bindQCStructure<LinearExpansion<double, SpinResolvedSelectedONVBasis>>(module, "LinearExpansion_SpinResolvedSelected", "A quantum chemical structure for real-valued linear expansions in a spin-resolved selected ONV basis.");
 
+    bindQCStructure<LinearExpansion<double, SpinUnresolvedONVBasis>>(module, "LinearExpansion_SpinUnresolved_d", "A quantum chemical structure for real-valued linear expansions in a spin-unresolved ONV basis.");
     bindQCStructure<LinearExpansion<double, SpinUnresolvedSelectedONVBasis>>(module, "LinearExpansion_SpinUnresolvedSelected_d", "A quantum chemical structure for real-valued linear expansions in a spin-unresolved selected ONV basis.");
     bindQCStructure<LinearExpansion<complex, SpinUnresolvedSelectedONVBasis>, complex>(module, "LinearExpansion_SpinUnresolvedSelected_cd", "A quantum chemical structure for complex-valued linear expansions in a spin-unresolved selected ONV basis.");
 

--- a/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
+++ b/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
@@ -401,7 +401,7 @@ void bindLinearExpansions(py::module& module) {
 
 
     // Define the python class related to a linear expansion of a spin unresolved selected ONV basis and expose the necessary interfaces.
-    py::class_<LinearExpansion<double, SpinUnresolvedSelectedONVBasis>> py_LinearExpansion_SpinUnresolvedSelected_d {module, "LinearExpansion_SpinResolvedSelected_d", "The real-valued linear expansion (configuration interaction) wave function model in a spin-unresolved selected ONV basis."};
+    py::class_<LinearExpansion<double, SpinUnresolvedSelectedONVBasis>> py_LinearExpansion_SpinUnresolvedSelected_d {module, "LinearExpansion_SpinUnresolvedSelected_d", "The real-valued linear expansion (configuration interaction) wave function model in a spin-unresolved selected ONV basis."};
 
     bindQCModelCILinearExpansionInterface(py_LinearExpansion_SpinUnresolvedSelected_d);
 


### PR DESCRIPTION
**Short description**

This PR enables FCI calculations in a spin Unresolved ONV basis.

