### PR TITLE
Devops/enable conda tests

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -19,6 +19,7 @@ if [ `uname` == Darwin ]; then
         -DCMAKE_CXX_FLAGS="${CXXFLAGS} ${OPTS}" \
         -DCMAKE_VERBOSE_MAKEFILE=TRUE \
         -DBUILD_PYTHON_BINDINGS=TRUE \
+        -DBUILD_TESTS=TRUE \
         -DPYTHON_EXECUTABLE=${PYTHON} \
         -DPYTHON_LIBRARY=${STDLIB_DIR}/libpython${PY_VER}.a
 fi
@@ -33,6 +34,7 @@ if [ `uname` == Linux ]; then
         -DCMAKE_CXX_FLAGS="${CXXFLAGS} ${OPTS}" \
         -DCMAKE_VERBOSE_MAKEFILE=TRUE \
         -DBUILD_PYTHON_BINDINGS=TRUE \
+        -DBUILD_TESTS=TRUE \
         -DPYTHON_EXECUTABLE=${PYTHON} \
         -DPYTHON_LIBRARY=${STDLIB_DIR}/libpython${PY_VER}.a
 fi

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -37,4 +37,4 @@ if [ `uname` == Linux ]; then
         -DPYTHON_LIBRARY=${STDLIB_DIR}/libpython${PY_VER}.a
 fi
 
-make -j${CPU_COUNT} VERBOSE=1 && make install
+make -j${CPU_COUNT} VERBOSE=1 && env CTEST_OUTPUT_ON_FAILURE=1 make test && make install

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     host:
       - blas
       - boost-cpp
-      - cint
+      - cint ==3.0.17
       - eigen
       - intel-openmp
       - mkl-include
@@ -33,7 +33,7 @@ requirements:
     run:
       - blas
       - boost-cpp
-      - cint
+      - cint ==3.0.17
       - eigen
       - intel-openmp
       - mkl-include


### PR DESCRIPTION
**Short description**

While the build-tests are failing in PR #1030, the conda builds seem ok. However, this is because the test are apparently disabled in the conda build. I will re-enable them in this PR.

Tagging @xdvriend .
