### PR TITLE
Hartree-Fock: Scalar basis 2-DM's

### DIFF
--- a/gqcp/include/QCModel/HF/GHF.hpp
+++ b/gqcp/include/QCModel/HF/GHF.hpp
@@ -34,7 +34,7 @@ namespace QCModel {
 
 /**
  *  The generalized Hartree-Fock wave function model.
- * 
+ *
  *  @tparam _Scalar             The type of scalar that is used for the expansion of the spinors in their underlying scalar basis.
  */
 template <typename _Scalar>
@@ -59,7 +59,7 @@ public:
 
     /**
      *  The standard member-wise constructor.
-     * 
+     *
      *  @param N                    The number of electrons.
      *  @param C                    The transformation that expresses the GHF MOs in terms of the atomic spinors.
      *  @param orbital_energies     The GHF MO energies.
@@ -85,7 +85,7 @@ public:
      *  @param F                The Fock operator expressed in the scalar bases.
      *  @param D                The GHF density matrix in the same scalar bases.
      *  @param S                The (spin-blocked) overlap operator of the scalar bases.
-     * 
+     *
      *  @return The GHF error matrix.
      */
     static SquareMatrix<Scalar> calculateError(const ScalarGSQOneElectronOperator<Scalar>& F, const G1DM<Scalar>& P, const ScalarGSQOneElectronOperator<Scalar>& S) {
@@ -138,13 +138,29 @@ public:
 
 
     /**
+     *  @param C            The coefficient matrix that expresses every spinor orbital (as a column) in the underlying scalar bases.
+     *  @param N            The number of electrons.
+     *
+     *  @return The GHF 2-DM expressed in the underlying scalar basis.
+     */
+    static G2DM<Scalar> calculateScalarBasis2DM(const GTransformation<Scalar>& C, const size_t N) {
+
+        const size_t M = C.dimension();
+        const auto P_orthonormal = GHF<Scalar>::calculateOrthonormalBasis2DM(M, N);
+
+        // Transform the 2-DM in an orthonormal basis to the underlying scalar basis.
+        return G2DM<Scalar>(P_orthonormal.transformed(C.inverse()));
+    }
+
+
+    /**
      *  Calculate the GHF direct (Coulomb) operator.
-     * 
+     *
      *  @param P                    The GHF density matrix expressed in the underlying scalar orbital basis.
      *  @param sq_hamiltonian       The Hamiltonian expressed in the scalar (AO) basis, resulting from a quantization using a GSpinorBasis.
-     * 
+     *
      *  @return The GHF direct (Coulomb) operator.
-     * 
+     *
      *  @note The scalar bases for the alpha- and beta-components must be the same.
      */
     static ScalarGSQOneElectronOperator<Scalar> calculateScalarBasisDirectMatrix(const G1DM<Scalar>& P, const GSQHamiltonian<Scalar>& sq_hamiltonian) {
@@ -172,10 +188,10 @@ public:
 
     /**
      *  Calculate the GHF exchange operator.
-     * 
+     *
      *  @param P                     The GHF density matrix expressed in the underlying scalar orbital bases.
      *  @param sq_hamiltonian        The Hamiltonian expressed in the scalar (AO) basis, resulting from a quantization using a GSpinorBasis.
-     * 
+     *
      *  @return The GHF direct (Coulomb) operator for spin sigma.
      */
     static ScalarGSQOneElectronOperator<Scalar> calculateScalarBasisExchangeMatrix(const G1DM<Scalar>& P, const GSQHamiltonian<Scalar>& sq_hamiltonian) {
@@ -230,7 +246,7 @@ public:
 
     /**
      *  Calculate the GHF 1-DM expressed in an orthonormal spinor basis.
-     * 
+     *
      *  @param M            The number of spinors.
      *  @param N            The number of electrons.
      *
@@ -254,7 +270,7 @@ public:
 
     /**
      *  Calculate the GHF 2-DM expressed in an orthonormal spinor basis.
-     * 
+     *
      *  @param M            The number of spinors.
      *  @param N            The number of electrons.
      *
@@ -292,7 +308,7 @@ public:
     /**
      *  @param M            The number of spinors.
      *  @param N            The number of electrons.
-     * 
+     *
      *  @return The implicit (i.e. with ascending and contiguous orbital indices) occupied-virtual orbital space that corresponds to these GHF model parameters.
      */
     static OrbitalSpace orbitalSpace(const size_t M, const size_t N) {
@@ -308,7 +324,7 @@ public:
     /**
      *  @param spin_op                      The electronic spin operator.
      *  @param S                            The (spin-blocked) overlap matrix of the underlying AO bases.
-     * 
+     *
      *  @return The expectation value of the electronic spin operator.
      */
     Vector<complex, 3> calculateExpectationValueOf(const ElectronicSpinOperator& spin_op, const ScalarGSQOneElectronOperator<Scalar>& S) const {
@@ -354,7 +370,7 @@ public:
     /**
      *  @param spin_op                      The electronic spin squared operator.
      *  @param S                            The (spin-blocked) overlap matrix of the underlying AO bases.
-     * 
+     *
      *  @return The expectation value of the electronic spin squared operator.
      */
     complex calculateExpectationValueOf(const ElectronicSpinSquaredOperator& spin_op, const ScalarGSQOneElectronOperator<Scalar>& S) const {
@@ -403,8 +419,8 @@ public:
 
 
     /**
-     *  @return A matrix containing all the possible excitation energies of the wavefunction model. 
-     * 
+     *  @return A matrix containing all the possible excitation energies of the wavefunction model.
+     *
      *  @note       The rows are determined by the number of virtual orbitals, the columns by the number of occupied orbitals.
      */
     GQCP::MatrixX<Scalar> excitationEnergies() const {
@@ -455,12 +471,12 @@ public:
 
     /**
      *  Construct the partial stability matrix `A` from the GHF stability conditions.
-     * 
+     *
      *  @note The formula for the `A` matrix is as follows:
      *      A_IAJB = \delta_IJ * F_BA - \delta_BA * F_IJ + (AI||JB).
-     * 
+     *
      *  @param gsq_hamiltonian      The second quantized Hamiltonian, expressed in the orthonormal, 'generalized' spinor basis of the GHF MOs, which contains the necessary two-electron operators.
-     * 
+     *
      *  @return The partial stability matrix A.
      */
     GQCP::MatrixX<Scalar> calculatePartialStabilityMatrixA(const GSQHamiltonian<Scalar>& gsq_hamiltonian) const {
@@ -516,7 +532,7 @@ public:
      *      B_IAJB = (AI||BJ).
      *
      *  @param gsq_hamiltonian      The second quantized Hamiltonian, expressed in the orthonormal, 'generalized' spinor basis of the GHF MOs, which contains the necessary two-electron operators.
-     * 
+     *
      *  @return The partial stability matrix B.
      */
     GQCP::MatrixX<Scalar> calculatePartialStabilityMatrixB(const GSQHamiltonian<Scalar>& gsq_hamiltonian) const {
@@ -565,8 +581,18 @@ public:
 
 
     /**
+     *  @return The GHF 2-DM in the scalar/AO basis related to these optimal GHF parameters.
+     */
+    G2DM<Scalar> calculateScalarBasis2DM() const {
+
+        const auto N = this->numberOfElectrons();
+        return GHF<Scalar>::calculateScalarBasis2DM(this->expansion(), N);
+    }
+
+
+    /**
      *  Calculate the GHF stability matrices and return them.
-     * 
+     *
      *  @param gsq_hamiltonian      The second quantized Hamiltonian, expressed in the orthonormal, 'generalized' spinor basis of the GHF MOs, which contains the necessary two-electron operators.
      *
      *  @return The GHF stability matrices.
@@ -618,7 +644,7 @@ public:
 
     /**
      *  @param i                The index of the orbital.
-     * 
+     *
      *  @return The i-th orbital energy.
      */
     Scalar orbitalEnergy(const size_t i) const { return this->orbital_energies(i); }

--- a/gqcp/include/QCModel/HF/RHF.hpp
+++ b/gqcp/include/QCModel/HF/RHF.hpp
@@ -714,6 +714,32 @@ public:
 
 
     /**
+     *  @param C    The coefficient matrix that expresses every spatial orbital (as a column) in its underlying scalar basis.
+     *  @param N    The number of electrons.
+     *
+     *  @return The RHF 2-DM expressed in the underlying scalar basis.
+     */
+    static Orbital2DM<Scalar> calculateScalarBasis2DM(const RTransformation<Scalar>& C, const size_t N) {
+
+        const size_t K = C.numberOfOrbitals();
+        const auto d_orthonormal = RHF<Scalar>::calculateOrthonormalBasis2DM(K, N);
+
+        // Transform the 1-DM in an orthonormal basis to the underlying scalar basis.
+        return d_orthonormal.transformed(C.inverse());
+    }
+
+
+    /**
+     *  @return The RHF 1-DM in the scalar/AO basis related to these optimal RHF parameters.
+     */
+    Orbital2DM<Scalar> calculateScalarBasis2DM() const {
+
+        const auto N = 2 * this->numberOfElectronPairs();
+        return RHF<Scalar>::calculateScalarBasis2DM(this->expansion(), N);
+    }
+
+
+    /**
      *  Calculate the RHF Fock operator F = H_core + G, in which G is a contraction of the density matrix and the two-electron integrals.
      *
      *  @param D                    The RHF density matrix in a scalar basis.

--- a/gqcp/include/QCModel/HF/UHF.hpp
+++ b/gqcp/include/QCModel/HF/UHF.hpp
@@ -309,6 +309,25 @@ public:
 
 
     /**
+     *  Calculate the UHF 2-DM expressed in the underlying scalar basis.
+     *
+     *  @param C            The transformation between the UHF MOs and the atomic spin-orbitals.
+     *  @param N_a          The number of alpha electrons, i.e. the number of occupied alpha spin-orbitals.
+     *  @param N_b          The number of beta electrons, i.e. the number of occupied beta spin-orbitals.
+     *
+     *  @return The UHF 2-DM expressed in the underlying scalar basis.
+     */
+    static SpinResolved2DM<Scalar> calculateScalarBasis2DM(const UTransformation<Scalar>& C, const size_t N_a, const size_t N_b) {
+
+        // Calculate the 2-DM in the spin-orbital basis, and transform to the underlying scalar basis.
+        const auto K = C.alpha().numberOfOrbitals();  // Assume K_alpha and K_beta are equal.
+        const auto d_orthonormal = UHF<Scalar>::calculateOrthonormalBasis2DM(K, N_a, N_b);
+
+        return d_orthonormal.transformed(C.inverse());
+    }
+
+
+    /**
      *  Calculate the UHF direct (Coulomb) operator.
      *
      *  @param P                    The UHF alpha density matrix expressed in the underlying scalar orbital basis.
@@ -450,6 +469,22 @@ public:
         const auto N_b = this->numberOfElectrons().beta();
 
         return UHF<Scalar>::calculateScalarBasis1DM(C, N_a, N_b);
+    }
+
+
+    /**
+     *  @return The spin resolved UHF 2-DM expressed in the underlying scalar basis for these UHF model parameters.
+     */
+    SpinResolved2DM<Scalar> calculateScalarBasis2DM() const {
+
+        const auto C_a = this->expansion().component(Spin::alpha);
+        const auto C_b = this->expansion().component(Spin::beta);
+        const UTransformation<Scalar> C {C_a, C_b};
+
+        const auto N_a = this->numberOfElectrons().alpha();
+        const auto N_b = this->numberOfElectrons().beta();
+
+        return UHF<Scalar>::calculateScalarBasis2DM(C, N_a, N_b);
     }
 
 

--- a/gqcpy/include/interfaces.hpp
+++ b/gqcpy/include/interfaces.hpp
@@ -1027,6 +1027,13 @@ void bindQCModelHartreeFockInterface(Class& py_class) {
             "Return the HF 1-DM in the scalar/AO basis related to these optimal parameters.")
 
         .def(
+            "calculateScalarBasis2DM",
+            [](const Type& parameters) {
+                return parameters.calculateScalarBasis2DM();
+            },
+            "Return the HF 2-DM in the scalar/AO basis related to these optimal parameters.")
+
+        .def(
             "calculateStabilityMatrices",
             &Type::calculateStabilityMatrices,
             py::arg("hamiltonian"),


### PR DESCRIPTION
**Short description**

This PR adds the Scalar basis 2DM's to the Hartree-Fock models, making it easier to calculate expectation values of 2-electron operators in the Hartree-Fock model. 

**To do**

- [x] Add GHF functionality + test
- [x] Add RHF functionality + test
- [x] Add UHF functionality + test
- [x] Add python bindings
