### PR TITLE
update pybind version in dockerfiles to 2.10.3

### DIFF
--- a/.easybuild/gqcp-dev-intel-2019b-Python-3.7.4.eb
+++ b/.easybuild/gqcp-dev-intel-2019b-Python-3.7.4.eb
@@ -22,7 +22,7 @@ sources = [{
 dependencies = [
     ('Python', '3.7.4', '', ('GCCcore', '8.3.0')),
     ('SciPy-bundle', '2019.10', versionsuffix),
-    ('pybind11', '2.4.3', versionsuffix),
+    ('pybind11', '2.10.3', versionsuffix),
     ('Eigen', '3.3.7', '', True),
     ('spectra', '0.8.1', '', ('intel', '2019b')),
     ('Boost', '1.69.0', '', ('intel', '2019b')),

--- a/docker/GQCP-dev.docker
+++ b/docker/GQCP-dev.docker
@@ -22,7 +22,7 @@ RUN conda --version
 ENV LIBINT_DATA_PATH=/usr/local/miniconda3/share/libint/2.6.0/basis
 ARG LIBINT_DATA_PATH=/usr/local/miniconda3/share/libint/2.6.0/basis
 RUN conda install -c conda-forge -c intel -c gqcg openmp=8.0.1 cmake=3.20.2 boost-cpp=1.75.0 eigen=3.3.9 blas=2.15 benchmark numpy=1.20.3 jupyter=1.0.0 libint=2.6.0 cint=3.0.17 mkl=2020.4 mkl-include=2020.4 mkl-static=2020.4 intel-openmp=2020.3 doxygen=1.9.1 graphviz=2.47.2 jupyter-book=0.10.2 libblas=*=*mkl
-RUN conda install -c conda-forge pybind11=2.10.3
+RUN pip install pybind11=2.10.3
 
 RUN ldconfig
 

--- a/docker/GQCP-dev.docker
+++ b/docker/GQCP-dev.docker
@@ -21,7 +21,8 @@ RUN conda --version
 
 ENV LIBINT_DATA_PATH=/usr/local/miniconda3/share/libint/2.6.0/basis
 ARG LIBINT_DATA_PATH=/usr/local/miniconda3/share/libint/2.6.0/basis
-RUN conda install -c conda-forge -c intel -c gqcg openmp=8.0.1 cmake=3.20.2 boost-cpp=1.75.0 eigen=3.3.9 blas=2.15 pybind11=2.6.2 benchmark numpy=1.20.3 jupyter=1.0.0 libint=2.6.0 cint=3.0.17 mkl=2020.4 mkl-include=2020.4 mkl-static=2020.4 intel-openmp=2020.3 doxygen=1.9.1 graphviz=2.47.2 jupyter-book=0.10.2 libblas=*=*mkl
+RUN conda install -c conda-forge -c intel -c gqcg openmp=8.0.1 cmake=3.20.2 boost-cpp=1.75.0 eigen=3.3.9 blas=2.15 benchmark numpy=1.20.3 jupyter=1.0.0 libint=2.6.0 cint=3.0.17 mkl=2020.4 mkl-include=2020.4 mkl-static=2020.4 intel-openmp=2020.3 doxygen=1.9.1 graphviz=2.47.2 jupyter-book=0.10.2 libblas=*=*mkl
+RUN conda install -c conda-forge pybind11=2.10.3
 
 RUN ldconfig
 

--- a/docker/GQCP.docker
+++ b/docker/GQCP.docker
@@ -22,7 +22,7 @@ RUN conda --version
 ENV LIBINT_DATA_PATH=/usr/local/miniconda3/share/libint/2.6.0/basis
 ARG LIBINT_DATA_PATH=/usr/local/miniconda3/share/libint/2.6.0/basis
 RUN conda install -c conda-forge -c intel -c gqcg openmp=8.0.1 cmake=3.20.2 boost-cpp=1.75.0 eigen=3.3.9 blas=2.15 benchmark numpy=1.20.3 jupyter=1.0.0 libint=2.6.0 cint=3.0.17 mkl=2020.4 mkl-include=2020.4 mkl-static=2020.4 intel-openmp=2020.3 doxygen=1.9.1 graphviz=2.47.2 jupyter-book=0.10.2 libblas=*=*mkl
-RUN conda install -c conda-forge pybind11=2.10.3
+RUN pip install pybind11=2.10.3
 
 RUN ldconfig
 

--- a/docker/GQCP.docker
+++ b/docker/GQCP.docker
@@ -21,7 +21,8 @@ RUN conda --version
 
 ENV LIBINT_DATA_PATH=/usr/local/miniconda3/share/libint/2.6.0/basis
 ARG LIBINT_DATA_PATH=/usr/local/miniconda3/share/libint/2.6.0/basis
-RUN conda install -c conda-forge -c intel -c gqcg openmp=8.0.1 cmake=3.20.2 boost-cpp=1.75.0 eigen=3.3.9 blas=2.15 pybind11=2.6.2 benchmark numpy=1.20.3 jupyter=1.0.0 libint=2.6.0 cint=3.0.17 mkl=2020.4 mkl-include=2020.4 mkl-static=2020.4 intel-openmp=2020.3 doxygen=1.9.1 graphviz=2.47.2 jupyter-book=0.10.2 libblas=*=*mkl
+RUN conda install -c conda-forge -c intel -c gqcg openmp=8.0.1 cmake=3.20.2 boost-cpp=1.75.0 eigen=3.3.9 blas=2.15 benchmark numpy=1.20.3 jupyter=1.0.0 libint=2.6.0 cint=3.0.17 mkl=2020.4 mkl-include=2020.4 mkl-static=2020.4 intel-openmp=2020.3 doxygen=1.9.1 graphviz=2.47.2 jupyter-book=0.10.2 libblas=*=*mkl
+RUN conda install -c conda-forge pybind11=2.10.3
 
 RUN ldconfig
 


### PR DESCRIPTION
**Short description**

In order to provide `Eigen::Tensor` conversion support within the python bindings, we need to update the `pybind11` dependency to `version 2.10.3
