### PR TITLE
Bugfix: build `Domain` and `Partition`-related bindings.

### DIFF
--- a/gqcpy/gqcpy.cpp
+++ b/gqcpy/gqcpy.cpp
@@ -88,6 +88,7 @@ void bindSpinResolved1DMComponent(py::module& module);
 void bindSpinResolved2DM(py::module& module);
 
 // Domain - HubbardDomain
+void bindDiscreteDomain(py::module& module);
 void bindHubbardDomain(py::module& module);
 
 
@@ -194,6 +195,13 @@ void bindSQHamiltonians(py::module& module);
 void bindUSQOneElectronOperator(py::module& module);
 void bindUSQOneElectronOperatorComponent(py::module& module);
 void bindUSQTwoElectronOperator(py::module& module);
+
+
+// Partition
+void bindDiscreteDomainPartition(py::module& module);
+void bindONVPartition(py::module& module);
+void bindSpinResolvedElectronPartition(py::module& module);
+void bindSpinUnresolvedElectronPartition(py::module& module);
 
 
 // Physical
@@ -368,6 +376,7 @@ PYBIND11_MODULE(gqcpy, module) {
 
 
     // Domain - HubbardDomain
+    gqcpy::bindDiscreteDomain(module);
     gqcpy::bindHubbardDomain(module);
 
 
@@ -474,6 +483,13 @@ PYBIND11_MODULE(gqcpy, module) {
     gqcpy::bindUSQOneElectronOperator(module);
     gqcpy::bindUSQOneElectronOperatorComponent(module);
     gqcpy::bindUSQTwoElectronOperator(module);
+
+
+    // Partition
+    gqcpy::bindDiscreteDomainPartition(module);
+    gqcpy::bindONVPartition(module);
+    gqcpy::bindSpinResolvedElectronPartition(module);
+    gqcpy::bindSpinUnresolvedElectronPartition(module);
 
 
     // Physical


### PR DESCRIPTION
**Short description**

During the implementation of `Domain` and `Partition` related functionality, I forgot to actually compile the Python bindings. This is fixed now in this PR.
