### PR TITLE
Open 2DM binding for linear expansion

### DIFF
--- a/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
+++ b/gqcpy/src/QCModel/CI/LinearExpansion_bindings.cpp
@@ -140,6 +140,13 @@ void bindQCModelCILinearExpansionDensityMatrixInterface(Class& py_class) {
             },
             "Return the one-electron density matrix (1-DM) for a wave function expansion of the specified type.")
 
+        .def(
+            "calculate2DM",
+            [](const Type& linear_expansion) {
+                return linear_expansion.calculate2DM();
+            },
+            "Return the two-electron density matrix (2-DM) for a wave function expansion of the specified type.")
+
         /*
          * MARK: Spin resolved
          */


### PR DESCRIPTION
**Short description**

Linear expansion bindings to calculate orbital 2D were not open yet. This PR fixes that.

