### PR TITLE
Feature - LAO gradient evaluation at point in space

### DIFF
--- a/gqcp/include/Basis/SpinorBasis/CurrentDensityMatrixElement.hpp
+++ b/gqcp/include/Basis/SpinorBasis/CurrentDensityMatrixElement.hpp
@@ -45,16 +45,16 @@ public:
     using Primitive = _Primitive;
 
     // The type of basis function that underlies this current density matrix element.
-    using BasisFunction = EvaluableLinearCombination<Scalar, Primitive>;
+    using BasisFunction = EvaluableLinearCombination<double, Primitive>;
 
     // The type of spatial orbital that underlies this current density matrix element.
     using SpatialOrbital = EvaluableLinearCombination<Scalar, BasisFunction>;
 
     // The type of the derivative of a primitive. The derivative of a Cartesian GTO is a linear combination of Cartesian GTOs.
-    using PrimitiveDerivative = EvaluableLinearCombination<Scalar, Primitive>;
+    using PrimitiveDerivative = EvaluableLinearCombination<double, Primitive>;
 
     // The type of the derivative of a basis function.
-    using BasisFunctionDerivative = EvaluableLinearCombination<Scalar, PrimitiveDerivative>;
+    using BasisFunctionDerivative = EvaluableLinearCombination<double, PrimitiveDerivative>;
 
     // The type of the derivative of a spatial orbital.
     using SpatialOrbitalDerivative = EvaluableLinearCombination<Scalar, BasisFunctionDerivative>;

--- a/gqcp/include/Basis/SpinorBasis/CurrentDensityMatrixElement.hpp
+++ b/gqcp/include/Basis/SpinorBasis/CurrentDensityMatrixElement.hpp
@@ -45,16 +45,16 @@ public:
     using Primitive = _Primitive;
 
     // The type of basis function that underlies this current density matrix element.
-    using BasisFunction = EvaluableLinearCombination<double, Primitive>;
+    using BasisFunction = EvaluableLinearCombination<Scalar, Primitive>;
 
     // The type of spatial orbital that underlies this current density matrix element.
     using SpatialOrbital = EvaluableLinearCombination<Scalar, BasisFunction>;
 
     // The type of the derivative of a primitive. The derivative of a Cartesian GTO is a linear combination of Cartesian GTOs.
-    using PrimitiveDerivative = EvaluableLinearCombination<double, Primitive>;
+    using PrimitiveDerivative = EvaluableLinearCombination<Scalar, Primitive>;
 
     // The type of the derivative of a basis function.
-    using BasisFunctionDerivative = EvaluableLinearCombination<double, PrimitiveDerivative>;
+    using BasisFunctionDerivative = EvaluableLinearCombination<Scalar, PrimitiveDerivative>;
 
     // The type of the derivative of a spatial orbital.
     using SpatialOrbitalDerivative = EvaluableLinearCombination<Scalar, BasisFunctionDerivative>;

--- a/gqcp/include/Basis/SpinorBasis/RSpinOrbitalBasis.hpp
+++ b/gqcp/include/Basis/SpinorBasis/RSpinOrbitalBasis.hpp
@@ -87,10 +87,10 @@ public:
     using DensityDistribution = FunctionProduct<SpatialOrbital>;
 
     // The type of the derivative of a primitive. The derivative of a Cartesian GTO is a linear combination of Cartesian GTOs.
-    using PrimitiveDerivative = EvaluableLinearCombination<double, Primitive>;
+    using PrimitiveDerivative = EvaluableLinearCombination<ExpansionScalar, Primitive>;
 
     // The type of the derivative of a basis function.
-    using BasisFunctionDerivative = EvaluableLinearCombination<double, PrimitiveDerivative>;
+    using BasisFunctionDerivative = EvaluableLinearCombination<ExpansionScalar, PrimitiveDerivative>;
 
     // The type of the derivative of a spatial orbital.
     using SpatialOrbitalDerivative = EvaluableLinearCombination<ExpansionScalar, BasisFunctionDerivative>;

--- a/gqcp/include/Basis/SpinorBasis/RSpinOrbitalBasis.hpp
+++ b/gqcp/include/Basis/SpinorBasis/RSpinOrbitalBasis.hpp
@@ -637,9 +637,8 @@ public:
      *  @return The value of each AO at the specified point in space
      */
      std::vector<ExpansionScalar> evalBasisSetAtPoint(const GQCP::Vector<double, 3>& r) const {
-        // gather basis set AOs from the first spatial orbital (which could eg be a spatial MO)
-        // which is expanded in the scalar basis set
-        const auto AOs = this->spatialOrbitals()[0].functions();
+        // get the contracted AOs from the scalar basis
+        const auto& AOs = this->scalarBasis().basisFunctions();
         // init vector in which to gather each AO's value at r
         std::vector<ExpansionScalar> AO_vals;
         AO_vals.reserve(this->numberOfSpatialOrbitals()); //n_AO = n_MO
@@ -651,6 +650,45 @@ public:
         }
         
         return AO_vals;
+     }
+
+
+    /**
+     * 
+     *  @param r                    The point at which to evaluate the gradient of the AO basis functions.
+     * 
+     *  @return The value of the gradient of each AO at the specified point in space
+     */
+     std::vector<std::vector<ExpansionScalar>> evalGradBasisSetAtPoint(const GQCP::Vector<double, 3>& r) const {
+        // get the contracted AOs from the scalar basis
+        const auto& AOs = this->scalarBasis().basisFunctions();
+        size_t K = AOs.size();
+
+        // prepare return container: K arrays of 3 components
+        std::vector<std::vector<ExpansionScalar>> grad_AO_vals;
+        grad_AO_vals.reserve(K);
+
+        for (size_t i = 0; i < K; ++i) {
+            const auto& basis_function     = AOs[i];
+            const auto& contraction_coefficients = basis_function.coefficients();
+            const auto& primitives  = basis_function.functions();
+
+            // accumulate gradient in each direction
+            std::vector<ExpansionScalar> sum(3, ExpansionScalar{0});
+            for (size_t d = 0; d < primitives.size(); ++d) {
+                auto c = contraction_coefficients[d];
+                // primitive gradients: a Vector<EvaluableLinearCombination<...>,3>
+                auto prim_grad = primitives[d].calculatePositionGradient();
+
+                for (int dir = 0; dir < 3; ++dir) {
+                    // evaluate that linear combination at r
+                    sum[dir] += c * prim_grad(dir)(r);
+                }
+            }
+            grad_AO_vals.push_back(sum);
+        }
+
+        return grad_AO_vals;
      }
 
 };

--- a/gqcp/include/Basis/SpinorBasis/RSpinOrbitalBasis.hpp
+++ b/gqcp/include/Basis/SpinorBasis/RSpinOrbitalBasis.hpp
@@ -86,13 +86,19 @@ public:
     // The type that represents a density distribution for this spin-orbital basis.
     using DensityDistribution = FunctionProduct<SpatialOrbital>;
 
-    // The type of the derivative of a primitive. The derivative of a Cartesian GTO is a linear combination of Cartesian GTOs.
-    using PrimitiveDerivative = EvaluableLinearCombination<ExpansionScalar, Primitive>;
+    // figure out what a single primitive actually returns: 
+    //   for CartesianGTO that is double, for LondonCartesianGTO that is complex<double>
+    using PrimitiveScalar = decltype(
+        std::declval<Primitive>()(std::declval<Vector<double, 3>>())
+    );
 
-    // The type of the derivative of a basis function.
-    using BasisFunctionDerivative = EvaluableLinearCombination<ExpansionScalar, PrimitiveDerivative>;
+    // now the primitive‐derivative lives at the primitive’s own scalar
+    using PrimitiveDerivative = EvaluableLinearCombination<PrimitiveScalar, Primitive>;
 
-    // The type of the derivative of a spatial orbital.
+    // the basis‐function derivative uses the same contraction coefficients as the basis‐function itself
+    using BasisFunctionDerivative = EvaluableLinearCombination<PrimitiveScalar, PrimitiveDerivative>;
+
+    // and finally the spatial‐orbital derivative lives at the MO‐scalar level
     using SpatialOrbitalDerivative = EvaluableLinearCombination<ExpansionScalar, BasisFunctionDerivative>;
 
     // The type that represents a current density distribution for this spin-orbital basis.

--- a/gqcp/include/Mathematical/Functions/LondonCartesianGTO.hpp
+++ b/gqcp/include/Mathematical/Functions/LondonCartesianGTO.hpp
@@ -109,9 +109,15 @@ public:
     /**
      *  @param direction            the Cartesian direction in which the derivative should be calculated
      *
-     *  @return the derivative of this Cartesian GTO with respect to the position coordinate in the x-, y-, or z-direction
+     *  @return the derivative of this London Cartesian GTO with respect to the position coordinate in the x-, y-, or z-direction
      */
      EvaluableLinearCombination<complex, LondonCartesianGTO> calculatePositionDerivative(const CartesianDirection direction) const;
+
+    /**
+     *  @return the gradient of this London Cartesian GTO with respect to the position coordinate
+     */
+    Vector<EvaluableLinearCombination<complex, LondonCartesianGTO>, 3> calculatePositionGradient() const;
+
 };
 
 

--- a/gqcp/include/Mathematical/Functions/LondonCartesianGTO.hpp
+++ b/gqcp/include/Mathematical/Functions/LondonCartesianGTO.hpp
@@ -105,6 +105,13 @@ public:
      *  @return The value of the London (Cartesian) GTO at the given point.
      */
     complex operator()(const Vector<double, 3>& r) const;
+
+    /**
+     *  @param direction            the Cartesian direction in which the derivative should be calculated
+     *
+     *  @return the derivative of this Cartesian GTO with respect to the position coordinate in the x-, y-, or z-direction
+     */
+     EvaluableLinearCombination<complex, LondonCartesianGTO> calculatePositionDerivative(const CartesianDirection direction) const;
 };
 
 

--- a/gqcp/sandbox/CMakeLists.txt
+++ b/gqcp/sandbox/CMakeLists.txt
@@ -5,6 +5,7 @@ list(APPEND sandbox_target_sources
     # ${CMAKE_CURRENT_SOURCE_DIR}/test_sandbox.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eval_ao_at_point_development.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/london_orbital_gradients.cpp    
+    ${CMAKE_CURRENT_SOURCE_DIR}/current_density_bugfixing.cpp 
 )
 
 set(sandbox_target_sources ${sandbox_target_sources} PARENT_SCOPE)

--- a/gqcp/sandbox/CMakeLists.txt
+++ b/gqcp/sandbox/CMakeLists.txt
@@ -4,6 +4,7 @@ set(sandbox_target_sources)
 list(APPEND sandbox_target_sources
     # ${CMAKE_CURRENT_SOURCE_DIR}/test_sandbox.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eval_ao_at_point_development.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/london_orbital_gradients.cpp    
 )
 
 set(sandbox_target_sources ${sandbox_target_sources} PARENT_SCOPE)

--- a/gqcp/sandbox/current_density_bugfixing.cpp
+++ b/gqcp/sandbox/current_density_bugfixing.cpp
@@ -1,0 +1,98 @@
+#include "Basis/SpinorBasis/RSpinOrbitalBasis.hpp"
+#include "QCMethod/HF/RHF/DiagonalRHFFockMatrixObjective.hpp"
+#include "QCMethod/HF/RHF/RHF.hpp"
+#include "QCMethod/HF/RHF/RHFSCFSolver.hpp"
+#include "QCModel/HF/RHF.hpp"
+
+// from RHF_test
+
+int main() {
+
+    using namespace GQCP::literals;
+
+    // Set up the molecular Hamiltonian in AO basis.
+    const GQCP::Molecule molecule {{GQCP::Nucleus(1, 0.0, 0.0, 0.0), GQCP::Nucleus(1, 0.0, 0.0, 1.0)}};
+    const auto N_P = molecule.numberOfElectronPairs();
+
+    const std::string basis_set {"STO-3G"};
+    GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spin_orbital_basis {molecule, basis_set};
+
+    auto hamiltonian = spin_orbital_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));
+
+
+    // Read in the GAMESS-UK RHF wave function model parameters. Even though GQCP finds the same orbitals and orbital energies, the phase factors (and orbital coefficients for degenerated orbitals) are unlikely to be reproducible.
+    GQCP::MatrixX<double> C_matrix {2, 2};
+    // clang-format off
+    C_matrix << 0.5275464665,  1.5678230259,
+                0.5275464665, -1.5678230259;
+    // clang-format on
+    GQCP::RTransformation<double> C {C_matrix};
+
+    GQCP::VectorX<double> orbital_energies {2};
+    orbital_energies << -0.6757801904, 0.9418115528;
+
+    const GQCP::QCModel::RHF<double> rhf_parameters {N_P, orbital_energies, C};
+
+
+    // Since we're going to work with complex operators, we have to let a complex spin-orbital basis do the quantization.
+    GQCP::RSpinOrbitalBasis<GQCP::complex, GQCP::GTOShell> complex_spin_orbital_basis {molecule, basis_set};
+    GQCP::RTransformation<GQCP::complex> C_complex {C_matrix.cast<GQCP::complex>()};
+    complex_spin_orbital_basis.transform(C_complex);
+
+    spin_orbital_basis.transform(C);
+    hamiltonian.transform(C);
+
+
+    // Calculate the orbital Hessian.
+    const auto orbital_space = rhf_parameters.orbitalSpace();
+    auto A = rhf_parameters.calculateOrbitalHessianForImaginaryResponse(hamiltonian, orbital_space);
+
+
+    // Solve the CPHF equations for the angular momentum operator.
+    const auto L = complex_spin_orbital_basis.quantize(GQCP::AngularMomentumOperator());
+    const auto F_B = rhf_parameters.calculateMagneticFieldResponseForce(L);
+
+
+    auto environment_B = GQCP::LinearEquationEnvironment<GQCP::complex>(A.asMatrix(), -F_B);
+    auto solver_B = GQCP::LinearEquationSolver<GQCP::complex>::HouseholderQR();
+    solver_B.perform(environment_B);
+    const auto x = environment_B.x;
+
+
+    // Solve the CPHF equations for the linear momentum operator.
+    const auto p = complex_spin_orbital_basis.quantize(GQCP::LinearMomentumOperator());
+    const auto F_G = rhf_parameters.calculateGaugeOriginTranslationResponseForce(p);
+
+    // In order to check with the reference values, we have to convert our dyadic Cartesian (i.e. xy, xz, etc.) representation to a Cartesian (i.e. x,y,z) one.
+    GQCP::MatrixX<GQCP::complex> F_G_reduced {1, 3};
+    F_G_reduced.col(0) = 2 * F_G.col(3);  // x <--> yz
+    F_G_reduced.col(1) = 2 * F_G.col(4);  // y <--> zx
+    F_G_reduced.col(2) = 2 * F_G.col(0);  // z <--> xy
+
+
+    auto environment_G = GQCP::LinearEquationEnvironment<GQCP::complex>(A.asMatrix(), -F_G);
+    auto solver_G = GQCP::LinearEquationSolver<GQCP::complex>::HouseholderQR();
+    solver_G.perform(environment_G);
+
+    const auto y = environment_G.x;
+
+    // In order to check with the reference values, we have to convert our dyadic Cartesian (i.e. xy, xz, etc.) representation to a Cartesian (i.e. x, y, z) one.
+    GQCP::MatrixX<GQCP::complex> y_reduced {1, 3};
+    y_reduced.col(0) = 2 * y.col(3);  // x <--> yz
+    y_reduced.col(1) = 2 * y.col(4);  // y <--> zx
+    y_reduced.col(2) = 2 * y.col(0);  // z <--> xy
+
+
+    // Calculate the ipsocentric magnetic inducibility on a grid and check the results.
+    const auto j_op = complex_spin_orbital_basis.quantize(GQCP::CurrentDensityOperator());
+
+    const GQCP::Vector<double, 3> origin {-2.0, -2.0, -2.0};
+    const std::array<size_t, 3> steps {6, 6, 6};
+    const std::array<double, 3> step_sizes {0.8, 0.8, 0.8};
+    const GQCP::CubicGrid grid {origin, steps, step_sizes};
+
+    const auto J_field = GQCP::QCModel::RHF<GQCP::complex>::calculateIpsocentricMagneticInducibility(grid, orbital_space, x, y, j_op);
+    const auto& J_values = J_field.values();
+
+    return 0;
+}

--- a/gqcp/sandbox/eval_ao_at_point_development.cpp
+++ b/gqcp/sandbox/eval_ao_at_point_development.cpp
@@ -5,42 +5,44 @@
 #include "Mathematical/Functions/LondonCartesianGTO.hpp"
 #include "Mathematical/Functions/EvaluableLinearCombination.hpp"
 #include "Basis/SpinorBasis/RSpinOrbitalBasis.hpp"
+#include <array>
 #include <iostream>
 
-// for determining type of object
-#include <typeinfo>
-#include <cxxabi.h>
+// -- free helper --
+auto evalGradAOsAtPoint(
+    const GQCP::RSpinOrbitalBasis<GQCP::complex, GQCP::LondonGTOShell>& spin_basis,
+    const GQCP::Vector<double,3>& r
+) {
+    // get the contracted AOs from the scalar basis
+    const auto& AOs = spin_basis.scalarBasis().basisFunctions();
+    size_t K = AOs.size();
 
+    // prepare return container: K arrays of 3 components
+    std::vector<std::array<GQCP::complex,3>> grad_AO_vals(K);
 
-std::vector<std::vector<GQCP::complex, 3>> evalGradBasisSetAtPoint(const GQCP::Vector<double, 3>& r) const {
-        // gather basis set AOs from the first spatial orbital (which could eg be a spatial MO)
-        // which is expanded in the scalar basis set
-        const auto AOs = this->spatialOrbitals()[0].functions();
-        // init vector in which to gather each AO's value at r
-        std::vector<std::vector<GQCP::complex, 3>> grad_AO_vals;
-        grad_AO_vals.reserve(this->numberOfSpatialOrbitals()); //n_AO = n_MO
-        std::vector<Vector<EvaluableLinearCombination<GQCP::complex, EvaluableLinearCombination<GQCP::complex, LondonCartesianGTO>>, 3>> basis_function_gradients {this->numberOfSpatialOrbitals()};
+    for (size_t i = 0; i < K; ++i) {
+        const auto& bf     = AOs[i];
+        const auto& coeffs = bf.coefficients();   // contraction coefficients
+        const auto& prims  = bf.functions();      // primitives
 
-        // loop through AOs
-        for (size_t i= 0; i < this->numberOfSpatialOrbitals(); i++) {
-            const auto& basis_function = AOs[i];
-            // loop through its primitives
-            const auto contraction_length = basis_function.length();
-            const auto& contraction_coefficients = basis_function.coefficients();
-            const auto& primitives = basis_function.functions();
+        // accumulate gradient in each direction
+        std::array<GQCP::complex,3> sum{0,0,0};
+        for (size_t d = 0; d < prims.size(); ++d) {
+            auto c = coeffs[d];
+            // primitive gradients: a Vector<EvaluableLinearCombination<...>,3>
+            auto prim_grad = prims[d].calculatePositionGradient();
 
-            for (size_t d = 0; d < contraction_length; d++) {
-                const auto& contraction_coefficient = contraction_coefficients[d];
-                const auto primitive_gradient = primitives[d].calculatePositionGradient();
-                grad_AO_vals[i].append(contraction_coefficient, primitive_gradient(m));
+            for (int dir = 0; dir < 3; ++dir) {
+                // evaluate that linear combination at r
+                sum[dir] += c * prim_grad(dir)(r);
             }
-
-            // evaluate value at r, put it in vector
-            grad_AO_vals.push_back(grad_AO_vals[i](r));
         }
-        
-        return AO_vals;
+        grad_AO_vals[i] = sum;
+    }
+
+    return grad_AO_vals;
 }
+
 
 int main() {
 
@@ -67,8 +69,12 @@ int main() {
     }
 
     // get gradient of LAOs.
-
-
+    auto grad_values = evalGradAOsAtPoint(spin_orbital_basis, r);
+    std::cout << "AO gradients at r:\n";
+    for (size_t i = 0; i < grad_values.size(); ++i) {
+        auto& g = grad_values[i];
+        std::cout << "  AO["<<i<<"] = (" << g[0] << ", " << g[1] << ", " << g[2] << ")\n";
+    }
 
     return 0;
 }

--- a/gqcp/sandbox/eval_ao_at_point_development.cpp
+++ b/gqcp/sandbox/eval_ao_at_point_development.cpp
@@ -5,44 +5,7 @@
 #include "Mathematical/Functions/LondonCartesianGTO.hpp"
 #include "Mathematical/Functions/EvaluableLinearCombination.hpp"
 #include "Basis/SpinorBasis/RSpinOrbitalBasis.hpp"
-#include <array>
 #include <iostream>
-
-// -- free helper --
-auto evalGradAOsAtPoint(
-    const GQCP::RSpinOrbitalBasis<GQCP::complex, GQCP::LondonGTOShell>& spin_basis,
-    const GQCP::Vector<double,3>& r
-) {
-    // get the contracted AOs from the scalar basis
-    const auto& AOs = spin_basis.scalarBasis().basisFunctions();
-    size_t K = AOs.size();
-
-    // prepare return container: K arrays of 3 components
-    std::vector<std::array<GQCP::complex,3>> grad_AO_vals(K);
-
-    for (size_t i = 0; i < K; ++i) {
-        const auto& bf     = AOs[i];
-        const auto& coeffs = bf.coefficients();   // contraction coefficients
-        const auto& prims  = bf.functions();      // primitives
-
-        // accumulate gradient in each direction
-        std::array<GQCP::complex,3> sum{0,0,0};
-        for (size_t d = 0; d < prims.size(); ++d) {
-            auto c = coeffs[d];
-            // primitive gradients: a Vector<EvaluableLinearCombination<...>,3>
-            auto prim_grad = prims[d].calculatePositionGradient();
-
-            for (int dir = 0; dir < 3; ++dir) {
-                // evaluate that linear combination at r
-                sum[dir] += c * prim_grad(dir)(r);
-            }
-        }
-        grad_AO_vals[i] = sum;
-    }
-
-    return grad_AO_vals;
-}
-
 
 int main() {
 
@@ -69,7 +32,7 @@ int main() {
     }
 
     // get gradient of LAOs.
-    auto grad_values = evalGradAOsAtPoint(spin_orbital_basis, r);
+    auto grad_values = spin_orbital_basis.evalGradBasisSetAtPoint(r);
     std::cout << "AO gradients at r:\n";
     for (size_t i = 0; i < grad_values.size(); ++i) {
         auto& g = grad_values[i];

--- a/gqcp/sandbox/eval_ao_at_point_development.cpp
+++ b/gqcp/sandbox/eval_ao_at_point_development.cpp
@@ -2,6 +2,7 @@
 #include "Basis/ScalarBasis/GTOShell.hpp"
 #include "Basis/ScalarBasis/ShellSet.hpp"
 #include "Mathematical/Functions/CartesianGTO.hpp"
+#include "Mathematical/Functions/LondonCartesianGTO.hpp"
 #include "Mathematical/Functions/EvaluableLinearCombination.hpp"
 #include "Basis/SpinorBasis/RSpinOrbitalBasis.hpp"
 #include <iostream>
@@ -10,6 +11,36 @@
 #include <typeinfo>
 #include <cxxabi.h>
 
+
+std::vector<std::vector<GQCP::complex, 3>> evalGradBasisSetAtPoint(const GQCP::Vector<double, 3>& r) const {
+        // gather basis set AOs from the first spatial orbital (which could eg be a spatial MO)
+        // which is expanded in the scalar basis set
+        const auto AOs = this->spatialOrbitals()[0].functions();
+        // init vector in which to gather each AO's value at r
+        std::vector<std::vector<GQCP::complex, 3>> grad_AO_vals;
+        grad_AO_vals.reserve(this->numberOfSpatialOrbitals()); //n_AO = n_MO
+        std::vector<Vector<EvaluableLinearCombination<GQCP::complex, EvaluableLinearCombination<GQCP::complex, LondonCartesianGTO>>, 3>> basis_function_gradients {this->numberOfSpatialOrbitals()};
+
+        // loop through AOs
+        for (size_t i= 0; i < this->numberOfSpatialOrbitals(); i++) {
+            const auto& basis_function = AOs[i];
+            // loop through its primitives
+            const auto contraction_length = basis_function.length();
+            const auto& contraction_coefficients = basis_function.coefficients();
+            const auto& primitives = basis_function.functions();
+
+            for (size_t d = 0; d < contraction_length; d++) {
+                const auto& contraction_coefficient = contraction_coefficients[d];
+                const auto primitive_gradient = primitives[d].calculatePositionGradient();
+                grad_AO_vals[i].append(contraction_coefficient, primitive_gradient(m));
+            }
+
+            // evaluate value at r, put it in vector
+            grad_AO_vals.push_back(grad_AO_vals[i](r));
+        }
+        
+        return AO_vals;
+}
 
 int main() {
 
@@ -34,6 +65,10 @@ int main() {
     for (size_t i = 0; i < ao_values.size(); ++i) {
         std::cout << "AO[" << i << "] = " << ao_values[i] << std::endl;
     }
+
+    // get gradient of LAOs.
+
+
 
     return 0;
 }

--- a/gqcp/sandbox/generate_pyscf_eval_gto_ref.ipynb
+++ b/gqcp/sandbox/generate_pyscf_eval_gto_ref.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "d94d7ddd",
    "metadata": {},
    "outputs": [],
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "id": "cac5e45b",
    "metadata": {},
    "outputs": [
@@ -42,6 +42,93 @@
     "ao_vals = mol.eval_gto('GTOval_cart', np.array([[1.3, -0.9, 3.7]]))\n",
     "\n",
     "for val in ao_vals[0]:\n",
+    "    print(np.around(val, 9))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "d51c33ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grad_ao_vals = mol.eval_gto('GTOval_ip_cart', np.array([[1.3, -0.9, 3.7]])) # Nabla AO\n",
+    "\n",
+    "grad_ao_vals_x, grad_ao_vals_y, grad_ao_vals_z = grad_ao_vals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "4828b8cb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-0.002398924\n",
+      "-0.0\n",
+      "-0.00021447\n",
+      "0.00060451\n",
+      "0.000133318\n",
+      "-0.000548086\n",
+      "0.00159041\n"
+     ]
+    }
+   ],
+   "source": [
+    "for val in grad_ao_vals_x[0]:\n",
+    "    print(np.around(val, 9))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c3eae90d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.001660794\n",
+      "0.0\n",
+      "0.000643411\n",
+      "0.000133318\n",
+      "0.000248995\n",
+      "0.001644258\n",
+      "0.002044813\n"
+     ]
+    }
+   ],
+   "source": [
+    "for val in grad_ao_vals_y[0]:\n",
+    "    print(np.around(val, 9))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a3811fb8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-0.006827708\n",
+      "-0.0\n",
+      "-0.002645134\n",
+      "-0.000548086\n",
+      "0.001644258\n",
+      "-0.006110777\n",
+      "-0.008406453\n"
+     ]
+    }
+   ],
+   "source": [
+    "for val in grad_ao_vals_z[0]:\n",
     "    print(np.around(val, 9))"
    ]
   }

--- a/gqcp/sandbox/london_orbital_gradients.cpp
+++ b/gqcp/sandbox/london_orbital_gradients.cpp
@@ -1,0 +1,32 @@
+#include "Basis/ScalarBasis/GTOBasisSet.hpp"
+#include "Basis/ScalarBasis/GTOShell.hpp"
+#include "Basis/ScalarBasis/ShellSet.hpp"
+#include "Mathematical/Functions/CartesianGTO.hpp"
+#include "Mathematical/Functions/EvaluableLinearCombination.hpp"
+#include "Basis/SpinorBasis/RSpinOrbitalBasis.hpp"
+#include <iostream>
+
+// for determining type of object
+#include <typeinfo>
+#include <cxxabi.h>
+
+
+int main() {
+
+    // Create an STO-3G basisset on (a toy geometry of) H2O.
+    const GQCP::Nucleus h1 {1, 0.0, 0.0, 0.0};
+    const GQCP::Nucleus o {8, 1.0, 0.0, 0.0};
+    const GQCP::Nucleus h2 {1, 2.0, 0.0, 0.0};
+    const GQCP::Molecule molecule {{h1, o, h2}};
+
+    const auto B = GQCP::HomogeneousMagneticField {{0.0, 0.0, 0.0}};  // Gauge origin at cartesian origin.
+    // const auto B = GQCP::HomogeneousMagneticField {{0.0, 0.0, 1.0}, {0.4, 12.2, -0.789}};  // Gauge origin at random point in space.
+    auto spin_orbital_basis = GQCP::RSpinOrbitalBasis<GQCP::complex, GQCP::LondonGTOShell> {molecule, "STO-3G", B};
+    // auto spin_orbital_basis = GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> {molecule, "STO-3G"};
+    
+    auto const orbs = spin_orbital_basis.spatialOrbitalGradients();
+    
+    std::cout << orbs[0].size() << std::endl;
+
+    return 0;
+}

--- a/gqcp/sandbox/london_orbital_gradients.cpp
+++ b/gqcp/sandbox/london_orbital_gradients.cpp
@@ -25,8 +25,10 @@ int main() {
     // auto spin_orbital_basis = GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> {molecule, "STO-3G"};
     
     auto const orbs = spin_orbital_basis.spatialOrbitalGradients();
+
+    const GQCP::Vector<double, 3> r = {1.3, -0.9, 3.7};
     
-    std::cout << orbs[0].size() << std::endl;
+    std::cout << orbs[0][1](r) << std::endl;
 
     return 0;
 }

--- a/gqcp/src/Mathematical/Functions/LondonCartesianGTO.cpp
+++ b/gqcp/src/Mathematical/Functions/LondonCartesianGTO.cpp
@@ -80,4 +80,55 @@ complex LondonCartesianGTO::operator()(const Vector<double, 3>& r) const {
 }
 
 
+/**
+ *  @param direction            the Cartesian direction in which the derivative should be calculated
+ *
+ *  @return the derivative of this Cartesian GTO with respect to the position coordinate in the x-, y-, or z-direction
+ */
+ EvaluableLinearCombination<complex, LondonCartesianGTO> LondonCartesianGTO::calculatePositionDerivative(const CartesianDirection direction) const {
+
+    // The formula consists of a part with the derivative of the plane wave, and a part with the derivative of the underlying GTO.
+    // We start with the GTO derivative part, based on CartesianGTO::calculatePositionDerivative:
+
+    // The formula is a sum of two parts: the derivative of the exponential and the derivative of the linear term (if applicable)
+
+    // Derivative of the exponential (for eg component x): -2\alpha * x times original primitive 
+    CartesianExponents exponential_derivative_exponents = this->gto.cartesian_exponents;
+    exponential_derivative_exponents.exponents[direction] += 1;
+    CartesianGTO exponential_derivative_gto {this->gto.gaussian_exponent, exponential_derivative_exponents, this->gto.m_center};
+    // turn this into a london gto
+    LondonCartesianGTO exponential_derivative_london_gto = {this->B, exponential_derivative_gto};
+    // get coefficient for linear combination
+    complex exponential_derivative_coefficient = -2 * this->gaussian_exponent;
+
+    // add as first term to linear combination (one of three)
+    EvaluableLinearCombination<complex, LondonCartesianGTO> lc {exponential_derivative_coefficient, exponential_derivative_london_gto};  // lc: linear combination
+
+
+    // If the exponent in x, y or z is non-zero, there is an extra contribution of the linear term
+    // i * 1/x with i the original exponent for x
+    if (this->gto.cartesian_exponents.value(direction) > 0) {
+
+        CartesianExponents linear_derivative_exponents = this->gto.cartesian_exponents;
+        linear_derivative_exponents.exponents[direction] -= 1;
+
+        CartesianGTO linear_derivative_gto(this->gaussian_exponent, linear_derivative_exponents, this->m_center);
+        // again, turn into london gto
+        LondonCartesianGTO linear_derivative_london_gto = {this->B, linear_derivative_gto};
+        // get coefficient
+        complex linear_derivative_coefficient = this->cartesian_exponents.value(direction);
+
+        lc += EvaluableLinearCombination<complex, LondonCartesianGTO>(linear_derivative_coefficient, linear_derivative_london_gto);
+    }
+
+    // third term: simply original London GTO + i * k_x
+    double k_component = this->kVector()[direction];
+    complex plane_wave_derivative_coefficient = 1.0_ii * k_component;
+
+    lc += EvaluableLinearCombination<complex, LondonCartesianGTO>(plane_wave_derivative_coefficient, *this);
+
+    return lc;
+}
+
+
 }  // namespace GQCP

--- a/gqcp/src/Mathematical/Functions/LondonCartesianGTO.cpp
+++ b/gqcp/src/Mathematical/Functions/LondonCartesianGTO.cpp
@@ -83,7 +83,7 @@ complex LondonCartesianGTO::operator()(const Vector<double, 3>& r) const {
 /**
  *  @param direction            the Cartesian direction in which the derivative should be calculated
  *
- *  @return the derivative of this Cartesian GTO with respect to the position coordinate in the x-, y-, or z-direction
+ *  @return the derivative of this London Cartesian GTO with respect to the position coordinate in the x-, y-, or z-direction
  */
  EvaluableLinearCombination<complex, LondonCartesianGTO> LondonCartesianGTO::calculatePositionDerivative(const CartesianDirection direction) const {
 
@@ -130,6 +130,21 @@ complex LondonCartesianGTO::operator()(const Vector<double, 3>& r) const {
     lc += EvaluableLinearCombination<complex, LondonCartesianGTO>(plane_wave_derivative_coefficient, *this);
 
     return lc;
+}
+
+
+/**
+ *  @return the gradient of this London Cartesian GTO with respect to the position coordinate
+ */
+ Vector<EvaluableLinearCombination<complex, LondonCartesianGTO>, 3> LondonCartesianGTO::calculatePositionGradient() const {
+
+    // Calculate the gradient for each of the Cartesian components.
+    Vector<EvaluableLinearCombination<complex, LondonCartesianGTO>, 3> gradient;
+    for (const auto& direction : {CartesianDirection::x, CartesianDirection::y, CartesianDirection::z}) {
+        gradient(direction) = this->calculatePositionDerivative(direction);
+    }
+
+    return gradient;
 }
 
 

--- a/gqcp/src/Mathematical/Functions/LondonCartesianGTO.cpp
+++ b/gqcp/src/Mathematical/Functions/LondonCartesianGTO.cpp
@@ -87,19 +87,21 @@ complex LondonCartesianGTO::operator()(const Vector<double, 3>& r) const {
  */
  EvaluableLinearCombination<complex, LondonCartesianGTO> LondonCartesianGTO::calculatePositionDerivative(const CartesianDirection direction) const {
 
+    using namespace GQCP::literals;
+
     // The formula consists of a part with the derivative of the plane wave, and a part with the derivative of the underlying GTO.
     // We start with the GTO derivative part, based on CartesianGTO::calculatePositionDerivative:
 
     // The formula is a sum of two parts: the derivative of the exponential and the derivative of the linear term (if applicable)
 
     // Derivative of the exponential (for eg component x): -2\alpha * x times original primitive 
-    CartesianExponents exponential_derivative_exponents = this->gto.cartesian_exponents;
+    CartesianExponents exponential_derivative_exponents = this->gto.cartesianExponents();
     exponential_derivative_exponents.exponents[direction] += 1;
-    CartesianGTO exponential_derivative_gto {this->gto.gaussian_exponent, exponential_derivative_exponents, this->gto.m_center};
+    CartesianGTO exponential_derivative_gto {this->gto.gaussianExponent(), exponential_derivative_exponents, this->gto.center()};
     // turn this into a london gto
     LondonCartesianGTO exponential_derivative_london_gto = {this->B, exponential_derivative_gto};
     // get coefficient for linear combination
-    complex exponential_derivative_coefficient = -2 * this->gaussian_exponent;
+    complex exponential_derivative_coefficient = -2 * this->gto.gaussianExponent();
 
     // add as first term to linear combination (one of three)
     EvaluableLinearCombination<complex, LondonCartesianGTO> lc {exponential_derivative_coefficient, exponential_derivative_london_gto};  // lc: linear combination
@@ -107,16 +109,16 @@ complex LondonCartesianGTO::operator()(const Vector<double, 3>& r) const {
 
     // If the exponent in x, y or z is non-zero, there is an extra contribution of the linear term
     // i * 1/x with i the original exponent for x
-    if (this->gto.cartesian_exponents.value(direction) > 0) {
+    if (this->gto.cartesianExponents().value(direction) > 0) {
 
-        CartesianExponents linear_derivative_exponents = this->gto.cartesian_exponents;
+        CartesianExponents linear_derivative_exponents = this->gto.cartesianExponents();
         linear_derivative_exponents.exponents[direction] -= 1;
 
-        CartesianGTO linear_derivative_gto(this->gaussian_exponent, linear_derivative_exponents, this->m_center);
+        CartesianGTO linear_derivative_gto(this->gto.gaussianExponent(), linear_derivative_exponents, this->gto.center());
         // again, turn into london gto
         LondonCartesianGTO linear_derivative_london_gto = {this->B, linear_derivative_gto};
         // get coefficient
-        complex linear_derivative_coefficient = this->cartesian_exponents.value(direction);
+        complex linear_derivative_coefficient = this->gto.cartesianExponents().value(direction);
 
         lc += EvaluableLinearCombination<complex, LondonCartesianGTO>(linear_derivative_coefficient, linear_derivative_london_gto);
     }


### PR DESCRIPTION
**Short description**

Add functionality to evaluate the gradient of a london atomic orbital in a point in space.

**Related issues**

#1081 

**To do**

- [x] implement gradient of LAO inside LondonCartesianGTO
- [x] benchmark with PySCF data (for zero-field reference)
