### PR TITLE
temporarily turn off GQCC check in github workflows.

### DIFF
--- a/.github/workflows/docker-gqcp-deploy.yml
+++ b/.github/workflows/docker-gqcp-deploy.yml
@@ -51,9 +51,9 @@ jobs:
         file: docker/GQCP.docker
         push: true
         tags: gqcg/gqcp:latest
-    - name: Test GQCC with updated container
-      uses: peter-evans/repository-dispatch@v2
-      with:
-        token: ${{ secrets.GQCC_ACCESS_TOKEN }}
-        repository: GQCG-res/GQCConstraints
-        event-type: GQCP-trigger
+    # - name: Test GQCC with updated container
+    #   uses: peter-evans/repository-dispatch@v2
+    #   with:
+    #     token: ${{ secrets.GQCC_ACCESS_TOKEN }}
+    #     repository: GQCG-res/GQCConstraints
+    #     event-type: GQCP-trigger


### PR DESCRIPTION
**Short description**

Temporarily turn off GQCC check in github workflows, such that GQCP dockerhub image gets updated upon merging to develop.

**Related issues**

#1086 