### PR TITLE
Implement functions to separate coulomb and exchange energy contributions in RHF

### DIFF
--- a/gqcp/include/QCModel/HF/RHF.hpp
+++ b/gqcp/include/QCModel/HF/RHF.hpp
@@ -738,6 +738,47 @@ public:
         return RHF<Scalar>::calculateScalarBasis2DM(this->expansion(), N);
     }
 
+    /**
+     *  Calculate the RHF direct (Coulomb) operator.
+     *
+     *  @param P                    The RHF density matrix expressed in the underlying scalar orbital basis.
+     *  @param sq_hamiltonian       The Hamiltonian expressed in the (same) underlying scalar orbital basis.
+     *
+     *  @return The RHF direct (Coulomb) operator.
+     */
+    static ScalarRSQOneElectronOperator<Scalar> calculateScalarBasisDirectMatrix(const Orbital1DM<Scalar>& D, const RSQHamiltonian<Scalar>& sq_hamiltonian) {
+
+        // Get the two-electron parameters.
+        const auto& g = sq_hamiltonian.twoElectron().parameters();
+
+        // To calculate J, we must perform a double contraction:
+        //      (mu nu|rho lambda) P(lambda rho),
+        const auto J = g.template einsum<2>("ijkl,kl->ij", D.matrix()).asMatrix();
+
+        return ScalarRSQOneElectronOperator<Scalar> {J};
+    };
+
+
+    /**
+     *  Calculate the RHF exchange operator.
+     *
+     *  @param P                    The RHF density matrix expressed in the underlying scalar orbital basis.
+     *  @param sq_hamiltonian       The Hamiltonian expressed in the (same) underlying scalar orbital basis.
+     *
+     *  @return The RHF Exchange operator.
+     */
+    static ScalarRSQOneElectronOperator<Scalar> calculateScalarBasisExchangeMatrix(const Orbital1DM<Scalar>& D, const RSQHamiltonian<Scalar>& sq_hamiltonian) {
+
+        // Get the two-electron parameters.
+        const auto& g = sq_hamiltonian.twoElectron().parameters();
+
+        // To calculate K, we must perform a double contraction:
+        //      (mu lambda|rho nu) P(lambda rho),
+        const auto K = g.template einsum<2>("ijkl,kj->il", D.matrix()).asMatrix();
+
+        return ScalarRSQOneElectronOperator<Scalar> {K};
+    }
+
 
     /**
      *  Calculate the RHF Fock operator F = H_core + G, in which G is a contraction of the density matrix and the two-electron integrals.

--- a/gqcp/sandbox/CMakeLists.txt
+++ b/gqcp/sandbox/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND sandbox_target_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/eval_ao_at_point_development.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/london_orbital_gradients.cpp    
     ${CMAKE_CURRENT_SOURCE_DIR}/current_density_bugfixing.cpp 
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_J_K_functions.cpp 
 )
 
 set(sandbox_target_sources ${sandbox_target_sources} PARENT_SCOPE)

--- a/gqcp/sandbox/test_J_K_bindings.ipynb
+++ b/gqcp/sandbox/test_J_K_bindings.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,24 +32,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "spinor_basis = gqcpy.RSpinOrbitalBasis_d(molecule, \"STO-3G\")"
+    "spinor_basis = gqcpy.RSpinOrbitalBasis_cd(molecule, \"STO-3G\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[0.99999999 0.65931816]\n",
-      " [0.65931816 0.99999999]]\n"
+      "[[0.99999999+0.j 0.65931816+0.j]\n",
+      " [0.65931816+0.j 0.99999999+0.j]]\n"
      ]
     }
    ],
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,15 +69,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[-1.12040896 -0.95837989]\n",
-      " [-0.95837989 -1.12040896]]\n"
+      "[[-1.12040896+0.j -0.95837989+0.j]\n",
+      " [-0.95837989+0.j -1.12040896+0.j]]\n"
      ]
     }
    ],
@@ -87,25 +87,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[[[0.77460593 0.44410762]\n",
-      "   [0.44410762 0.56967589]]\n",
+      "[[[[0.77460593+0.j 0.44410762+0.j]\n",
+      "   [0.44410762+0.j 0.56967589+0.j]]\n",
       "\n",
-      "  [[0.44410762 0.2970285 ]\n",
-      "   [0.2970285  0.44410762]]]\n",
+      "  [[0.44410762+0.j 0.2970285 +0.j]\n",
+      "   [0.2970285 +0.j 0.44410762+0.j]]]\n",
       "\n",
       "\n",
-      " [[[0.44410762 0.2970285 ]\n",
-      "   [0.2970285  0.44410762]]\n",
+      " [[[0.44410762+0.j 0.2970285 +0.j]\n",
+      "   [0.2970285 +0.j 0.44410762+0.j]]\n",
       "\n",
-      "  [[0.56967589 0.44410762]\n",
-      "   [0.44410762 0.77460593]]]]\n"
+      "  [[0.56967589+0.j 0.44410762+0.j]\n",
+      "   [0.44410762+0.j 0.77460593+0.j]]]]\n"
      ]
     }
    ],
@@ -115,43 +115,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
-    "environment = gqcpy.RHFSCFEnvironment_d.WithCoreGuess(N, sq_hamiltonian, S)\n",
-    "solver = gqcpy.RHFSCFSolver_d.DIIS()"
+    "environment = gqcpy.RHFSCFEnvironment_cd.WithCoreGuess(N, sq_hamiltonian, S)\n",
+    "solver = gqcpy.RHFSCFSolver_cd.DIIS()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
-    "objective = gqcpy.DiagonalRHFFockMatrixObjective_d(sq_hamiltonian)  # use the default threshold of 1.0e-08"
+    "objective = gqcpy.DiagonalRHFFockMatrixObjective_cd(sq_hamiltonian)  # use the default threshold of 1.0e-08"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
-    "rhf_parameters = gqcpy.RHF_d.optimize(objective, solver, environment).groundStateParameters()"
+    "rhf_parameters = gqcpy.RHF_cd.optimize(objective, solver, environment).groundStateParameters()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[-0.54893405 -1.21146402]\n",
-      " [-0.54893405  1.21146402]]\n"
+      "[[-0.54893405-0.j -1.21146402+0.j]\n",
+      " [-0.54893405-0.j  1.21146402+0.j]]\n"
      ]
     }
    ],
@@ -162,15 +162,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[0.60265718 0.60265718]\n",
-      " [0.60265718 0.60265718]]\n"
+     "data": {
+      "text/plain": [
+       "<gqcpy.RHFStabilityMatrices_cd at 0x757e5e988d70>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rhf_parameters.calculateStabilityMatrices(sq_hamiltonian)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<gqcpy.OrbitalSpace at 0x757e72090bb0>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rhf_parameters.orbitalSpace()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Unable to convert function return value to a Python type! The signature was\n\t(self: gqcpy.QCModel_RHF_cd) -> GQCP::Orbital1DM<std::complex<double> >\n\nDid you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,\n<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic\nconversions are optional and require extra headers to be included\nwhen compiling your pybind11 module.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;31mTypeError\u001b[0m: Unregistered type : GQCP::Orbital1DM<std::complex<double> >",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[24], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m D \u001b[38;5;241m=\u001b[39m \u001b[43mrhf_parameters\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcalculateScalarBasis1DM\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28mprint\u001b[39m(D\u001b[38;5;241m.\u001b[39mmatrix())\n",
+      "\u001b[0;31mTypeError\u001b[0m: Unable to convert function return value to a Python type! The signature was\n\t(self: gqcpy.QCModel_RHF_cd) -> GQCP::Orbital1DM<std::complex<double> >\n\nDid you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,\n<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic\nconversions are optional and require extra headers to be included\nwhen compiling your pybind11 module."
      ]
     }
    ],
@@ -181,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -200,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -219,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/gqcp/sandbox/test_J_K_bindings.ipynb
+++ b/gqcp/sandbox/test_J_K_bindings.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -162,16 +162,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<gqcpy.RHFStabilityMatrices_cd at 0x757e5e988d70>"
+       "<gqcpy.RHFStabilityMatrices_cd at 0x7493a2aa29b0>"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,16 +182,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<gqcpy.OrbitalSpace at 0x757e72090bb0>"
+       "<gqcpy.OrbitalSpace at 0x7493a4846ef0>"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -202,21 +202,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
-     "ename": "TypeError",
-     "evalue": "Unable to convert function return value to a Python type! The signature was\n\t(self: gqcpy.QCModel_RHF_cd) -> GQCP::Orbital1DM<std::complex<double> >\n\nDid you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,\n<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic\nconversions are optional and require extra headers to be included\nwhen compiling your pybind11 module.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;31mTypeError\u001b[0m: Unregistered type : GQCP::Orbital1DM<std::complex<double> >",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[24], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m D \u001b[38;5;241m=\u001b[39m \u001b[43mrhf_parameters\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcalculateScalarBasis1DM\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28mprint\u001b[39m(D\u001b[38;5;241m.\u001b[39mmatrix())\n",
-      "\u001b[0;31mTypeError\u001b[0m: Unable to convert function return value to a Python type! The signature was\n\t(self: gqcpy.QCModel_RHF_cd) -> GQCP::Orbital1DM<std::complex<double> >\n\nDid you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,\n<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic\nconversions are optional and require extra headers to be included\nwhen compiling your pybind11 module."
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0.60265718+0.j 0.60265718+0.j]\n",
+      " [0.60265718+0.j 0.60265718+0.j]]\n"
      ]
     }
    ],
@@ -227,15 +221,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[-0.36553732 -0.59388534]\n",
-      " [-0.59388534 -0.36553732]]\n"
+     "ename": "AttributeError",
+     "evalue": "'gqcpy.QCModel_RHF_cd' object has no attribute 'calculateScalarBasisFockMatrix'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[15], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m F \u001b[38;5;241m=\u001b[39m \u001b[43mrhf_parameters\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcalculateScalarBasisFockMatrix\u001b[49m(D, sq_hamiltonian)\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28mprint\u001b[39m(F\u001b[38;5;241m.\u001b[39mparameters())\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'gqcpy.QCModel_RHF_cd' object has no attribute 'calculateScalarBasisFockMatrix'"
      ]
     }
    ],

--- a/gqcp/sandbox/test_J_K_bindings.ipynb
+++ b/gqcp/sandbox/test_J_K_bindings.ipynb
@@ -168,7 +168,7 @@
     {
      "data": {
       "text/plain": [
-       "<gqcpy.RHFStabilityMatrices_cd at 0x7493a2aa29b0>"
+       "<gqcpy.RHFStabilityMatrices_cd at 0x7f255db6b670>"
       ]
      },
      "execution_count": 12,
@@ -188,7 +188,7 @@
     {
      "data": {
       "text/plain": [
-       "<gqcpy.OrbitalSpace at 0x7493a4846ef0>"
+       "<gqcpy.OrbitalSpace at 0x7f255db70d70>"
       ]
      },
      "execution_count": 13,
@@ -225,14 +225,11 @@
    "metadata": {},
    "outputs": [
     {
-     "ename": "AttributeError",
-     "evalue": "'gqcpy.QCModel_RHF_cd' object has no attribute 'calculateScalarBasisFockMatrix'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[15], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m F \u001b[38;5;241m=\u001b[39m \u001b[43mrhf_parameters\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcalculateScalarBasisFockMatrix\u001b[49m(D, sq_hamiltonian)\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28mprint\u001b[39m(F\u001b[38;5;241m.\u001b[39mparameters())\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'gqcpy.QCModel_RHF_cd' object has no attribute 'calculateScalarBasisFockMatrix'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[-0.36553732+0.j -0.59388534+0.j]\n",
+      " [-0.59388534+0.j -0.36553732+0.j]]\n"
      ]
     }
    ],
@@ -243,15 +240,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[1.34543038 0.89330201]\n",
-      " [0.89330201 1.34543038]]\n"
+      "[[1.34543038+0.j 0.89330201+0.j]\n",
+      " [0.89330201+0.j 1.34543038+0.j]]\n"
      ]
     }
    ],
@@ -262,15 +259,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[1.18111747 1.05761492]\n",
-      " [1.05761492 1.18111747]]\n"
+      "[[1.18111747+0.j 1.05761492+0.j]\n",
+      " [1.05761492+0.j 1.18111747+0.j]]\n"
      ]
     }
    ],

--- a/gqcp/sandbox/test_J_K_bindings.ipynb
+++ b/gqcp/sandbox/test_J_K_bindings.ipynb
@@ -168,7 +168,7 @@
     {
      "data": {
       "text/plain": [
-       "<gqcpy.RHFStabilityMatrices_cd at 0x7f255db6b670>"
+       "<gqcpy.RHFStabilityMatrices_cd at 0x7c764a008670>"
       ]
      },
      "execution_count": 12,
@@ -188,7 +188,7 @@
     {
      "data": {
       "text/plain": [
-       "<gqcpy.OrbitalSpace at 0x7f255db70d70>"
+       "<gqcpy.OrbitalSpace at 0x7c76462c7df0>"
       ]
      },
      "execution_count": 13,
@@ -247,6 +247,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "[[-1.12040896+0.j -0.95837989+0.j]\n",
+      " [-0.95837989+0.j -1.12040896+0.j]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "h = sq_hamiltonian.core()\n",
+    "print(h.parameters())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[[1.34543038+0.j 0.89330201+0.j]\n",
       " [0.89330201+0.j 1.34543038+0.j]]\n"
      ]
@@ -259,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -274,6 +293,27 @@
    "source": [
     "K = rhf_parameters.calculateScalarBasisExchangeMatrix(D, sq_hamiltonian)\n",
     "print(K.parameters())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ True,  True],\n",
+       "       [ True,  True]])"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "F.parameters() == (h + J - 0.5*K).parameters()"
    ]
   }
  ],

--- a/gqcp/sandbox/test_J_K_bindings.ipynb
+++ b/gqcp/sandbox/test_J_K_bindings.ipynb
@@ -1,0 +1,261 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting up the molecular Hamiltonian"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Force the local gqcpy to be imported\n",
+    "import sys\n",
+    "sys.path.insert(0, '../../build/gqcpy/')\n",
+    "\n",
+    "import gqcpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "molecule = gqcpy.Molecule.ReadXYZ(\"../../gqcp/tests/data/h2_szabo.xyz\" , 0)  # create a neutral molecule\n",
+    "N = molecule.numberOfElectrons()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spinor_basis = gqcpy.RSpinOrbitalBasis_d(molecule, \"STO-3G\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0.99999999 0.65931816]\n",
+      " [0.65931816 0.99999999]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "S = spinor_basis.quantize(gqcpy.OverlapOperator())\n",
+    "print(S.parameters())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sq_hamiltonian = spinor_basis.quantize(gqcpy.FQMolecularHamiltonian(molecule))  # 'sq' for 'second-quantized'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[-1.12040896 -0.95837989]\n",
+      " [-0.95837989 -1.12040896]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(sq_hamiltonian.core().parameters())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[[[0.77460593 0.44410762]\n",
+      "   [0.44410762 0.56967589]]\n",
+      "\n",
+      "  [[0.44410762 0.2970285 ]\n",
+      "   [0.2970285  0.44410762]]]\n",
+      "\n",
+      "\n",
+      " [[[0.44410762 0.2970285 ]\n",
+      "   [0.2970285  0.44410762]]\n",
+      "\n",
+      "  [[0.56967589 0.44410762]\n",
+      "   [0.44410762 0.77460593]]]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(sq_hamiltonian.twoElectron().parameters())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "environment = gqcpy.RHFSCFEnvironment_d.WithCoreGuess(N, sq_hamiltonian, S)\n",
+    "solver = gqcpy.RHFSCFSolver_d.DIIS()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "objective = gqcpy.DiagonalRHFFockMatrixObjective_d(sq_hamiltonian)  # use the default threshold of 1.0e-08"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rhf_parameters = gqcpy.RHF_d.optimize(objective, solver, environment).groundStateParameters()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[-0.54893405 -1.21146402]\n",
+      " [-0.54893405  1.21146402]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "C = rhf_parameters.expansion()\n",
+    "print(C.matrix())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0.60265718 0.60265718]\n",
+      " [0.60265718 0.60265718]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "D = rhf_parameters.calculateScalarBasis1DM()\n",
+    "print(D.matrix())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[-0.36553732 -0.59388534]\n",
+      " [-0.59388534 -0.36553732]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "F = rhf_parameters.calculateScalarBasisFockMatrix(D, sq_hamiltonian)\n",
+    "print(F.parameters())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1.34543038 0.89330201]\n",
+      " [0.89330201 1.34543038]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "J = rhf_parameters.calculateScalarBasisDirectMatrix(D, sq_hamiltonian)\n",
+    "print(J.parameters())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1.18111747 1.05761492]\n",
+      " [1.05761492 1.18111747]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "K = rhf_parameters.calculateScalarBasisExchangeMatrix(D, sq_hamiltonian)\n",
+    "print(K.parameters())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/gqcp/sandbox/test_J_K_functions.cpp
+++ b/gqcp/sandbox/test_J_K_functions.cpp
@@ -1,0 +1,52 @@
+#include "Basis/SpinorBasis/RSpinOrbitalBasis.hpp"
+#include "QCMethod/HF/RHF/DiagonalRHFFockMatrixObjective.hpp"
+#include "QCMethod/HF/RHF/RHF.hpp"
+#include "QCMethod/HF/RHF/RHFSCFSolver.hpp"
+#include "QCModel/HF/RHF.hpp"
+
+int main() {
+
+    // Create an STO-3G basisset on (a toy geometry of) H2O.
+    const GQCP::Nucleus h1 {1, 0.0, 0.0, 0.0};
+    const GQCP::Nucleus o {8, 1.0, 0.0, 0.0};
+    const GQCP::Nucleus h2 {1, 2.0, 0.0, 0.0};
+    const GQCP::Molecule molecule {{h1, o, h2}};
+
+    // Perform an RHF calculation.
+    const GQCP::RSpinOrbitalBasis<double, GQCP::GTOShell> spin_orbital_basis {molecule, "STO-3G"};
+    auto hamiltonian = spin_orbital_basis.quantize(GQCP::FQMolecularHamiltonian(molecule));  // In an AO basis.
+
+    auto rhf_environment = GQCP::RHFSCFEnvironment<double>::WithCoreGuess(molecule.numberOfElectrons(), hamiltonian, spin_orbital_basis.overlap());
+    auto plain_rhf_scf_solver = GQCP::RHFSCFSolver<double>::Plain();
+    const GQCP::DiagonalRHFFockMatrixObjective<double> objective {hamiltonian};
+
+    const auto rhf_qc_structure = GQCP::QCMethod::RHF<double>().optimize(objective, plain_rhf_scf_solver, rhf_environment);
+    const auto rhf_parameters = rhf_qc_structure.groundStateParameters();
+    const auto rhf_energy = rhf_qc_structure.groundStateEnergy();
+
+    // Determine the RHF energy through the expectation value of the Hamiltonian, and check the result.
+    // Do the calculations in the RHF MO basis, in order to check the implementation of the RHF density matrices in MO basis.
+    hamiltonian.transform(rhf_parameters.expansion());
+    const auto D_MO = rhf_parameters.calculateOrthonormalBasis1DM();
+    const auto d_MO = rhf_parameters.calculateOrthonormalBasis2DM();
+    const double expectation_value = hamiltonian.calculateExpectationValue(D_MO, d_MO);
+
+    // obtain F (established)
+    const auto& D = rhf_environment.density_matrices.back();  // The most recent density matrix.
+    const auto F = GQCP::QCModel::RHF<double>::calculateScalarBasisFockMatrix(D, rhf_environment.sq_hamiltonian);
+
+    std::cout << "F" << std::endl;
+    std::cout << F.parameters() << std::endl;
+
+    // obtain J and K (new functions)
+    const auto J = GQCP::QCModel::RHF<double>::calculateScalarBasisDirectMatrix(D, rhf_environment.sq_hamiltonian);
+    const auto K = GQCP::QCModel::RHF<double>::calculateScalarBasisExchangeMatrix(D, rhf_environment.sq_hamiltonian);
+
+    std::cout << "J" << std::endl;
+    std::cout << J.parameters() << std::endl;
+
+    std::cout << "K" << std::endl;
+    std::cout << K.parameters() << std::endl;
+
+    return 0;
+}

--- a/gqcpy/src/DensityMatrix/Orbital1DM_bindings.cpp
+++ b/gqcpy/src/DensityMatrix/Orbital1DM_bindings.cpp
@@ -16,6 +16,7 @@
 // along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "DensityMatrix/Orbital1DM.hpp"
+#include "Utilities/complex.hpp"
 #include "gqcpy/include/interfaces.hpp"
 
 #include <pybind11/pybind11.h>
@@ -38,12 +39,15 @@ void bindOrbital1DM(py::module& module) {
 
     // Define the Python class for `Orbital1DM`.
     py::class_<Orbital1DM<double>> py_Orbital1DM_d {module, "Orbital1DM_d", "The orbital one-electron density matrix."};
+    py::class_<Orbital1DM<complex>> py_Orbital1DM_cd {module, "Orbital1DM_cd", "The complex orbital one-electron density matrix."};
 
     // Expose the `Simple1DM` API to the Python class;
     bindSimple1DMInterface(py_Orbital1DM_d);
+    bindSimple1DMInterface(py_Orbital1DM_cd);
 
     // Expose the `BasisTransformable` API to the Python class.
     bindBasisTransformableInterface(py_Orbital1DM_d);
+    bindBasisTransformableInterface(py_Orbital1DM_cd);
 }
 
 

--- a/gqcpy/src/DensityMatrix/Orbital2DM_bindings.cpp
+++ b/gqcpy/src/DensityMatrix/Orbital2DM_bindings.cpp
@@ -16,6 +16,7 @@
 // along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "DensityMatrix/Orbital2DM.hpp"
+#include "Utilities/complex.hpp"
 #include "gqcpy/include/interfaces.hpp"
 
 #include <pybind11/pybind11.h>
@@ -38,10 +39,12 @@ void bindOrbital2DM(py::module& module) {
 
     // Define the Python class for `Orbital2DM`.
     py::class_<GQCP::Orbital2DM<double>> py_Orbital2DM_d {module, "Orbital2DM_d", "The orbital two-electron density matrix."};
+    py::class_<GQCP::Orbital2DM<complex>> py_Orbital2DM_cd {module, "Orbital2DM_cd", "The orbital two-electron density matrix."};
 
 
     // Expose the `Simple2DM` API to the Python class.
     bindSimple2DMInterface(py_Orbital2DM_d);
+    bindSimple2DMInterface(py_Orbital2DM_cd);
 }
 
 

--- a/gqcpy/src/DensityMatrix/SpinResolved1DMComponent_bindings.cpp
+++ b/gqcpy/src/DensityMatrix/SpinResolved1DMComponent_bindings.cpp
@@ -16,6 +16,7 @@
 // along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "DensityMatrix/SpinResolved1DMComponent.hpp"
+#include "Utilities/complex.hpp"
 #include "gqcpy/include/interfaces.hpp"
 
 #include <pybind11/pybind11.h>
@@ -38,12 +39,15 @@ void bindSpinResolved1DMComponent(py::module& module) {
 
     // Define the Python class for `SpinResolved1DMComponent`.
     py::class_<SpinResolved1DMComponent<double>> py_SpinResolved1DMComponent_d {module, "SpinResolved1DMComponent_d", "One of the spin components of a `SpinResolved1DM`."};
+    py::class_<SpinResolved1DMComponent<complex>> py_SpinResolved1DMComponent_cd {module, "SpinResolved1DMComponent_cd", "One of the spin components of a `SpinResolved1DM`."};
 
     // Expose the `Simple1DM` API to the Python class;
     bindSimple1DMInterface(py_SpinResolved1DMComponent_d);
+    bindSimple1DMInterface(py_SpinResolved1DMComponent_cd);
 
     // Expose the `BasisTransformable` API to the Python class.
     bindBasisTransformableInterface(py_SpinResolved1DMComponent_d);
+    bindBasisTransformableInterface(py_SpinResolved1DMComponent_cd);
 }
 
 

--- a/gqcpy/src/QCModel/HF/RHF_bindings.cpp
+++ b/gqcpy/src/QCModel/HF/RHF_bindings.cpp
@@ -138,6 +138,33 @@ void bindQCModelRHF(py::module& module) {
 
     py_QCModel_RHF_cd
         .def_static(
+            "calculateScalarBasisDirectMatrix",
+            [](const Orbital1DM<complex>& D, const RSQHamiltonian<complex>& sq_hamiltonian) {
+                return QCModel::RHF<complex>::calculateScalarBasisDirectMatrix(D, sq_hamiltonian);
+            },
+            py::arg("density_matrix"),
+            py::arg("hamiltonian"),
+            "Return the Coulomb (J) matrix.")
+
+        .def_static(
+            "calculateScalarBasisExchangeMatrix",
+            [](const Orbital1DM<complex>& D, const RSQHamiltonian<complex>& sq_hamiltonian) {
+                return QCModel::RHF<complex>::calculateScalarBasisExchangeMatrix(D, sq_hamiltonian);
+            },
+            py::arg("density_matrix"),
+            py::arg("hamiltonian"),
+            "Return the exchange (K) matrix.")
+
+        .def_static(
+            "calculateScalarBasisFockMatrix",
+            [](const Orbital1DM<complex>& D, const RSQHamiltonian<complex>& sq_hamiltonian) {
+                return QCModel::RHF<complex>::calculateScalarBasisFockMatrix(D, sq_hamiltonian);
+            },
+            py::arg("density_matrix"),
+            py::arg("hamiltonian"),
+            "Return the Fock matrix (F).")
+            
+        .def_static(
             "calculateIpsocentricMagneticInducibility",
             [](const Vector<double, 3>& r, const OrbitalSpace& orbital_space, const Matrix<complex, Dynamic, 3>& x_B, const Matrix<complex, Dynamic, 6>& x_G, const VectorEvaluableRSQOneElectronOperator<CurrentDensityMatrixElement<complex, CartesianGTO>>& j_op) {
                 return QCModel::RHF<complex>::calculateIpsocentricMagneticInducibility(r, orbital_space, x_B, x_G, j_op);

--- a/gqcpy/src/QCModel/HF/RHF_bindings.cpp
+++ b/gqcpy/src/QCModel/HF/RHF_bindings.cpp
@@ -88,6 +88,33 @@ void bindQCModelRHF(py::module& module) {
             py::arg("orbital_space"),
             "Calculate the RHF orbital Hessian (H_RI -i H_II), which can be used as a response force constant when solving the CP(R)HF equations for a purely imaginary response.")
 
+        .def_static(
+            "calculateScalarBasisDirectMatrix",
+            [](const Orbital1DM<double>& D, const RSQHamiltonian<double>& sq_hamiltonian) {
+                return QCModel::RHF<double>::calculateScalarBasisDirectMatrix(D, sq_hamiltonian);
+            },
+            py::arg("density_matrix"),
+            py::arg("hamiltonian"),
+            "Return the Coulomb (J) matrix.")
+
+        .def_static(
+            "calculateScalarBasisExchangeMatrix",
+            [](const Orbital1DM<double>& D, const RSQHamiltonian<double>& sq_hamiltonian) {
+                return QCModel::RHF<double>::calculateScalarBasisExchangeMatrix(D, sq_hamiltonian);
+            },
+            py::arg("density_matrix"),
+            py::arg("hamiltonian"),
+            "Return the exchange (K) matrix.")
+
+        .def_static(
+            "calculateScalarBasisFockMatrix",
+            [](const Orbital1DM<double>& D, const RSQHamiltonian<double>& sq_hamiltonian) {
+                return QCModel::RHF<double>::calculateScalarBasisFockMatrix(D, sq_hamiltonian);
+            },
+            py::arg("density_matrix"),
+            py::arg("hamiltonian"),
+            "Return the Fock matrix (F).")
+
         .def(
             "calculateMagneticFieldResponseForce",
             [](const QCModel::RHF<double>& rhf_parameters, const VectorRSQOneElectronOperator<complex>& L_op) {


### PR DESCRIPTION
**Supersedes #1093**.
Closes #1095 and #1091.

**Short description**

Separate the calculation of the Coulomb and Exchange matrix from the function that calculates the Fock matrix in RHF.

**Related issues**

[Coulomb and Exchange matrix python bindings ](https://github.com/GQCG/GQCP/issues/1091)

**To do**

- [x] Create a function for caluclating the Coulomb matrix in RHF in cpp code
- [x] Create a function for calculating the Exchange matrix in RHF in cpp code

