### PR TITLE
Bugfix - expose complex scalar instances of DM classes to pybind

### DIFF
--- a/gqcp/sandbox/test_J_K_bindings.ipynb
+++ b/gqcp/sandbox/test_J_K_bindings.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,24 +32,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "spinor_basis = gqcpy.RSpinOrbitalBasis_d(molecule, \"STO-3G\")"
+    "spinor_basis = gqcpy.RSpinOrbitalBasis_cd(molecule, \"STO-3G\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[0.99999999 0.65931816]\n",
-      " [0.65931816 0.99999999]]\n"
+      "[[0.99999999+0.j 0.65931816+0.j]\n",
+      " [0.65931816+0.j 0.99999999+0.j]]\n"
      ]
     }
    ],
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,15 +69,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[-1.12040896 -0.95837989]\n",
-      " [-0.95837989 -1.12040896]]\n"
+      "[[-1.12040896+0.j -0.95837989+0.j]\n",
+      " [-0.95837989+0.j -1.12040896+0.j]]\n"
      ]
     }
    ],
@@ -87,25 +87,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[[[0.77460593 0.44410762]\n",
-      "   [0.44410762 0.56967589]]\n",
+      "[[[[0.77460593+0.j 0.44410762+0.j]\n",
+      "   [0.44410762+0.j 0.56967589+0.j]]\n",
       "\n",
-      "  [[0.44410762 0.2970285 ]\n",
-      "   [0.2970285  0.44410762]]]\n",
+      "  [[0.44410762+0.j 0.2970285 +0.j]\n",
+      "   [0.2970285 +0.j 0.44410762+0.j]]]\n",
       "\n",
       "\n",
-      " [[[0.44410762 0.2970285 ]\n",
-      "   [0.2970285  0.44410762]]\n",
+      " [[[0.44410762+0.j 0.2970285 +0.j]\n",
+      "   [0.2970285 +0.j 0.44410762+0.j]]\n",
       "\n",
-      "  [[0.56967589 0.44410762]\n",
-      "   [0.44410762 0.77460593]]]]\n"
+      "  [[0.56967589+0.j 0.44410762+0.j]\n",
+      "   [0.44410762+0.j 0.77460593+0.j]]]]\n"
      ]
     }
    ],
@@ -115,43 +115,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
-    "environment = gqcpy.RHFSCFEnvironment_d.WithCoreGuess(N, sq_hamiltonian, S)\n",
-    "solver = gqcpy.RHFSCFSolver_d.DIIS()"
+    "environment = gqcpy.RHFSCFEnvironment_cd.WithCoreGuess(N, sq_hamiltonian, S)\n",
+    "solver = gqcpy.RHFSCFSolver_cd.DIIS()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
-    "objective = gqcpy.DiagonalRHFFockMatrixObjective_d(sq_hamiltonian)  # use the default threshold of 1.0e-08"
+    "objective = gqcpy.DiagonalRHFFockMatrixObjective_cd(sq_hamiltonian)  # use the default threshold of 1.0e-08"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
-    "rhf_parameters = gqcpy.RHF_d.optimize(objective, solver, environment).groundStateParameters()"
+    "rhf_parameters = gqcpy.RHF_cd.optimize(objective, solver, environment).groundStateParameters()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[-0.54893405 -1.21146402]\n",
-      " [-0.54893405  1.21146402]]\n"
+      "[[-0.54893405-0.j -1.21146402+0.j]\n",
+      " [-0.54893405-0.j  1.21146402+0.j]]\n"
      ]
     }
    ],
@@ -162,15 +162,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[0.60265718 0.60265718]\n",
-      " [0.60265718 0.60265718]]\n"
+     "data": {
+      "text/plain": [
+       "<gqcpy.RHFStabilityMatrices_cd at 0x757e5e988d70>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rhf_parameters.calculateStabilityMatrices(sq_hamiltonian)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<gqcpy.OrbitalSpace at 0x757e72090bb0>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rhf_parameters.orbitalSpace()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Unable to convert function return value to a Python type! The signature was\n\t(self: gqcpy.QCModel_RHF_cd) -> GQCP::Orbital1DM<std::complex<double> >\n\nDid you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,\n<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic\nconversions are optional and require extra headers to be included\nwhen compiling your pybind11 module.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;31mTypeError\u001b[0m: Unregistered type : GQCP::Orbital1DM<std::complex<double> >",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[24], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m D \u001b[38;5;241m=\u001b[39m \u001b[43mrhf_parameters\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcalculateScalarBasis1DM\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28mprint\u001b[39m(D\u001b[38;5;241m.\u001b[39mmatrix())\n",
+      "\u001b[0;31mTypeError\u001b[0m: Unable to convert function return value to a Python type! The signature was\n\t(self: gqcpy.QCModel_RHF_cd) -> GQCP::Orbital1DM<std::complex<double> >\n\nDid you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,\n<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic\nconversions are optional and require extra headers to be included\nwhen compiling your pybind11 module."
      ]
     }
    ],
@@ -181,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -200,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -219,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/gqcp/sandbox/test_J_K_bindings.ipynb
+++ b/gqcp/sandbox/test_J_K_bindings.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -162,16 +162,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<gqcpy.RHFStabilityMatrices_cd at 0x757e5e988d70>"
+       "<gqcpy.RHFStabilityMatrices_cd at 0x7493a2aa29b0>"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,16 +182,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<gqcpy.OrbitalSpace at 0x757e72090bb0>"
+       "<gqcpy.OrbitalSpace at 0x7493a4846ef0>"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -202,21 +202,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
-     "ename": "TypeError",
-     "evalue": "Unable to convert function return value to a Python type! The signature was\n\t(self: gqcpy.QCModel_RHF_cd) -> GQCP::Orbital1DM<std::complex<double> >\n\nDid you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,\n<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic\nconversions are optional and require extra headers to be included\nwhen compiling your pybind11 module.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;31mTypeError\u001b[0m: Unregistered type : GQCP::Orbital1DM<std::complex<double> >",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[24], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m D \u001b[38;5;241m=\u001b[39m \u001b[43mrhf_parameters\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcalculateScalarBasis1DM\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28mprint\u001b[39m(D\u001b[38;5;241m.\u001b[39mmatrix())\n",
-      "\u001b[0;31mTypeError\u001b[0m: Unable to convert function return value to a Python type! The signature was\n\t(self: gqcpy.QCModel_RHF_cd) -> GQCP::Orbital1DM<std::complex<double> >\n\nDid you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,\n<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic\nconversions are optional and require extra headers to be included\nwhen compiling your pybind11 module."
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0.60265718+0.j 0.60265718+0.j]\n",
+      " [0.60265718+0.j 0.60265718+0.j]]\n"
      ]
     }
    ],
@@ -227,15 +221,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[-0.36553732 -0.59388534]\n",
-      " [-0.59388534 -0.36553732]]\n"
+     "ename": "AttributeError",
+     "evalue": "'gqcpy.QCModel_RHF_cd' object has no attribute 'calculateScalarBasisFockMatrix'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[15], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m F \u001b[38;5;241m=\u001b[39m \u001b[43mrhf_parameters\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcalculateScalarBasisFockMatrix\u001b[49m(D, sq_hamiltonian)\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28mprint\u001b[39m(F\u001b[38;5;241m.\u001b[39mparameters())\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'gqcpy.QCModel_RHF_cd' object has no attribute 'calculateScalarBasisFockMatrix'"
      ]
     }
    ],

--- a/gqcpy/src/DensityMatrix/Orbital1DM_bindings.cpp
+++ b/gqcpy/src/DensityMatrix/Orbital1DM_bindings.cpp
@@ -16,6 +16,7 @@
 // along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "DensityMatrix/Orbital1DM.hpp"
+#include "Utilities/complex.hpp"
 #include "gqcpy/include/interfaces.hpp"
 
 #include <pybind11/pybind11.h>
@@ -38,12 +39,15 @@ void bindOrbital1DM(py::module& module) {
 
     // Define the Python class for `Orbital1DM`.
     py::class_<Orbital1DM<double>> py_Orbital1DM_d {module, "Orbital1DM_d", "The orbital one-electron density matrix."};
+    py::class_<Orbital1DM<complex>> py_Orbital1DM_cd {module, "Orbital1DM_cd", "The complex orbital one-electron density matrix."};
 
     // Expose the `Simple1DM` API to the Python class;
     bindSimple1DMInterface(py_Orbital1DM_d);
+    bindSimple1DMInterface(py_Orbital1DM_cd);
 
     // Expose the `BasisTransformable` API to the Python class.
     bindBasisTransformableInterface(py_Orbital1DM_d);
+    bindBasisTransformableInterface(py_Orbital1DM_cd);
 }
 
 

--- a/gqcpy/src/DensityMatrix/Orbital2DM_bindings.cpp
+++ b/gqcpy/src/DensityMatrix/Orbital2DM_bindings.cpp
@@ -16,6 +16,7 @@
 // along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "DensityMatrix/Orbital2DM.hpp"
+#include "Utilities/complex.hpp"
 #include "gqcpy/include/interfaces.hpp"
 
 #include <pybind11/pybind11.h>
@@ -38,10 +39,12 @@ void bindOrbital2DM(py::module& module) {
 
     // Define the Python class for `Orbital2DM`.
     py::class_<GQCP::Orbital2DM<double>> py_Orbital2DM_d {module, "Orbital2DM_d", "The orbital two-electron density matrix."};
+    py::class_<GQCP::Orbital2DM<complex>> py_Orbital2DM_cd {module, "Orbital2DM_cd", "The orbital two-electron density matrix."};
 
 
     // Expose the `Simple2DM` API to the Python class.
     bindSimple2DMInterface(py_Orbital2DM_d);
+    bindSimple2DMInterface(py_Orbital2DM_cd);
 }
 
 

--- a/gqcpy/src/DensityMatrix/SpinResolved1DMComponent_bindings.cpp
+++ b/gqcpy/src/DensityMatrix/SpinResolved1DMComponent_bindings.cpp
@@ -16,6 +16,7 @@
 // along with GQCG-GQCP.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "DensityMatrix/SpinResolved1DMComponent.hpp"
+#include "Utilities/complex.hpp"
 #include "gqcpy/include/interfaces.hpp"
 
 #include <pybind11/pybind11.h>
@@ -38,12 +39,15 @@ void bindSpinResolved1DMComponent(py::module& module) {
 
     // Define the Python class for `SpinResolved1DMComponent`.
     py::class_<SpinResolved1DMComponent<double>> py_SpinResolved1DMComponent_d {module, "SpinResolved1DMComponent_d", "One of the spin components of a `SpinResolved1DM`."};
+    py::class_<SpinResolved1DMComponent<complex>> py_SpinResolved1DMComponent_cd {module, "SpinResolved1DMComponent_cd", "One of the spin components of a `SpinResolved1DM`."};
 
     // Expose the `Simple1DM` API to the Python class;
     bindSimple1DMInterface(py_SpinResolved1DMComponent_d);
+    bindSimple1DMInterface(py_SpinResolved1DMComponent_cd);
 
     // Expose the `BasisTransformable` API to the Python class.
     bindBasisTransformableInterface(py_SpinResolved1DMComponent_d);
+    bindBasisTransformableInterface(py_SpinResolved1DMComponent_cd);
 }
 
 


### PR DESCRIPTION
**Short description**

Multiple instances of pybind throwing an error in a complex basis, where it does not for a real-type scalar basis. The error is of the type `Unregistered type : ...<std::complex<double> >` and appears for bindings implemented in `interfaces.hpp`.

**Related issues**

#1089 

**To do**

- [x] isolate root of issue
- [x] fix issue (such that complex type scalar GQCP objects are also "registered" to pybind)
