### PR TITLE
Benchmark LAO evaluation at point in space

### DIFF
--- a/gqcp/sandbox/London-integrals.ipynb
+++ b/gqcp/sandbox/London-integrals.ipynb
@@ -280,6 +280,59 @@
     "# z comp\n",
     "print('z comp:', (spinor_basis_B1.evalGradBasisSetAtPoint(eval_loc)[0][2]/spinor_basis_B1.evalBasisSetAtPoint(eval_loc)[0]).imag)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c204ca1",
+   "metadata": {},
+   "source": [
+    "## Adding phase factor manually on GTO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "43688459",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_phase_factor(r, R_K=np.array([0, 0, 0]), B=np.array([0, 0, 0]), G=np.array([0, 0, 0])):\n",
+    "    k = 1/2 * (np.cross(B, R_K - G))\n",
+    "    return np.exp(-1.0j*np.dot(k, r))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "f5e421de",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "manual: (0.12000723071576481-0.06556024893928053j)\n",
+      "gqcp: (0.1200072307157648+0.06556024893928053j)\n"
+     ]
+    }
+   ],
+   "source": [
+    "phase_factor = compute_phase_factor(eval_loc, R_K=np.array([0, 1, 0]), G=np.array([0, 0, 0]), B=np.array([0, 0, 1]))\n",
+    "gto_r = spinor_basis_noB.evalBasisSetAtPoint(eval_loc)[0]\n",
+    "manual_lao_r = phase_factor * gto_r\n",
+    "print('manual:', manual_lao_r)\n",
+    "print('gqcp:', spinor_basis_B1.evalBasisSetAtPoint(eval_loc)[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1a14340",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compute gradient\n"
+   ]
   }
  ],
  "metadata": {

--- a/gqcp/sandbox/London-integrals.ipynb
+++ b/gqcp/sandbox/London-integrals.ipynb
@@ -303,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 44,
    "id": "f5e421de",
    "metadata": {},
    "outputs": [
@@ -311,13 +311,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "manual: (0.12000723071576481-0.06556024893928053j)\n",
+      "manual: (0.12000723071576481+0.06556024893928053j)\n",
       "gqcp: (0.1200072307157648+0.06556024893928053j)\n"
      ]
     }
    ],
    "source": [
-    "phase_factor = compute_phase_factor(eval_loc, R_K=np.array([0, 1, 0]), G=np.array([0, 0, 0]), B=np.array([0, 0, 1]))\n",
+    "phase_factor = compute_phase_factor(eval_loc, R_K=np.array([0, 1, 0]), G=np.array([0, 0, 0]), B=np.array([0, 0, -1]))\n",
     "gto_r = spinor_basis_noB.evalBasisSetAtPoint(eval_loc)[0]\n",
     "manual_lao_r = phase_factor * gto_r\n",
     "print('manual:', manual_lao_r)\n",

--- a/gqcp/sandbox/London-integrals.ipynb
+++ b/gqcp/sandbox/London-integrals.ipynb
@@ -1,0 +1,306 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "narrative-albany",
+   "metadata": {},
+   "source": [
+    "# Gauge-origin independence for London kinetic integrals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "greek-dealer",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Force the local gqcpy to be imported.\n",
+    "import sys\n",
+    "sys.path.insert(0, '../../build/gqcpy/')\n",
+    "\n",
+    "import gqcpy\n",
+    "import numpy as np\n",
+    "\n",
+    "np.set_printoptions(precision=8, linewidth=120)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e1683d0",
+   "metadata": {},
+   "source": [
+    "## Set up molecules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "alike-fantasy",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "H_atom = gqcpy.Molecule([gqcpy.Nucleus(1, 0.0, 0.0, 0.0)])\n",
+    "H_atom_moved = gqcpy.Molecule([gqcpy.Nucleus(1, 0.0, 1.0, 0.0)])\n",
+    "H_2 = gqcpy.Molecule([gqcpy.Nucleus(1, 0.0, 0.0, 0.0), gqcpy.Nucleus(1, 0.0, 1.0, 0.0)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "047d0979",
+   "metadata": {},
+   "source": [
+    "## Set up bases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "19b83cef",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of electrons: 1 \n",
+      "H  (0, 1, 0)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# molecule = H_atom\n",
+    "molecule = H_atom_moved\n",
+    "# molecule = H_2\n",
+    "\n",
+    "print(molecule)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1047d2a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "B0 = gqcpy.HomogeneousMagneticField([0.0, 0.0, 0], [0.0, 0.0, 0.0])\n",
+    "B1 = gqcpy.HomogeneousMagneticField([0.0, 0.0, -1], [0.0, 0.0, 0.0])\n",
+    "B1_randomG = gqcpy.HomogeneousMagneticField([0.0, 0.0, -1], [124.21, 6.34, 0.564])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "bb4a4a21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basisset = 'STO-3G'\n",
+    "\n",
+    "spinor_basis_noB = gqcpy.RSpinOrbitalBasis_d(molecule, basisset)\n",
+    "spinor_basis_B0 = gqcpy.LondonRSpinOrbitalBasis(molecule, basisset, B0)\n",
+    "spinor_basis_B1 = gqcpy.LondonRSpinOrbitalBasis(molecule, basisset, B1)\n",
+    "spinor_basis_B1_randomG = gqcpy.LondonRSpinOrbitalBasis(molecule, basisset, B1_randomG)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b666bc95",
+   "metadata": {},
+   "source": [
+    "## Evaluate AO at point in space"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97d18b7d",
+   "metadata": {},
+   "source": [
+    "We can also evaluate London AOs at a specific point in space."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "388fd0b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.1367475106356501]\n",
+      "[(0.1367475106356501+0j)]\n",
+      "[(0.1200072307157648+0.06556024893928053j)]\n",
+      "[(-0.1218209546423018-0.06212516941695598j)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "eval_loc = np.array([-1, 0, 0])\n",
+    "\n",
+    "print(spinor_basis_noB.evalBasisSetAtPoint(eval_loc))\n",
+    "print(spinor_basis_B0.evalBasisSetAtPoint(eval_loc))\n",
+    "print(spinor_basis_B1.evalBasisSetAtPoint(eval_loc))\n",
+    "print(spinor_basis_B1_randomG.evalBasisSetAtPoint(eval_loc))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "a5b9a3e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(0.1200072307157648+0.06556024893928053j)]"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spinor_basis_B1.evalBasisSetAtPoint(eval_loc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "2e44585e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_phase_factor_from_value(val):\n",
+    "    # since LAO = GTO(cos(\\phi) - i sin(\\phi)) with \\phi the phase argument (phase factor exp(-i \\phi))\n",
+    "    return np.arctan(-val.imag/val.real)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e805bd83",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-0.5000000000000001"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_phase_factor_from_value(spinor_basis_B1.evalBasisSetAtPoint(eval_loc)[0]) # k \\cdot r"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "f74fa900",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def numerical_gradient_basis(\n",
+    "    basis,\n",
+    "    r,\n",
+    "    h=1e-5,\n",
+    "):\n",
+    "    r = np.asarray(r, dtype=float)\n",
+    "    f0 = np.asarray(basis.evalBasisSetAtPoint(r), dtype=complex)\n",
+    "\n",
+    "    n_basis = len(f0)\n",
+    "    grad = np.zeros((n_basis, 3), dtype=complex)\n",
+    "\n",
+    "    for j in range(3):\n",
+    "        dr = np.zeros(3)\n",
+    "        dr[j] = h\n",
+    "\n",
+    "        f_plus  = np.asarray(basis.evalBasisSetAtPoint(r + dr), dtype=complex)\n",
+    "        f_minus = np.asarray(basis.evalBasisSetAtPoint(r - dr), dtype=complex)\n",
+    "\n",
+    "        grad[:, j] = (f_plus - f_minus) / (2.0 * h)\n",
+    "\n",
+    "    return grad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "c4c9ecc8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "numerical: [[0.13640738-0.00339179j 0.10362725+0.05661183j 0.        +0.j        ]]\n",
+      "analytic function: [[(0.13640737715649182-0.003391789199383762j), (0.10362725268685155+0.05661182615849864j), 0j]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('numerical:', numerical_gradient_basis(spinor_basis_B1, eval_loc))\n",
+    "print('analytic function:', spinor_basis_B1.evalGradBasisSetAtPoint(eval_loc))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "cfac8f3e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x comp: -0.5000000000000001\n",
+      "y comp: 0.0\n",
+      "z comp: 0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# since \\grad LAO = exp(-i k \\cdot r) (\\grad GTO - i k GTO)\n",
+    "# \\grad LAO / LAO = \\grad GTO / GTO - i k\n",
+    "# so need to check if imag part of \\grad LAO / LAO = k\n",
+    "\n",
+    "# should give k = (-1/2, 0, 0) for G = (0,0,0), H at (0, 1, 0) and B = (0, 0, 1)\n",
+    "\n",
+    "# x comp\n",
+    "print('x comp:', (spinor_basis_B1.evalGradBasisSetAtPoint(eval_loc)[0][0]/spinor_basis_B1.evalBasisSetAtPoint(eval_loc)[0]).imag)\n",
+    "# y comp\n",
+    "print('y comp:', (spinor_basis_B1.evalGradBasisSetAtPoint(eval_loc)[0][1]/spinor_basis_B1.evalBasisSetAtPoint(eval_loc)[0]).imag)\n",
+    "# z comp\n",
+    "print('z comp:', (spinor_basis_B1.evalGradBasisSetAtPoint(eval_loc)[0][2]/spinor_basis_B1.evalBasisSetAtPoint(eval_loc)[0]).imag)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gqcp/sandbox/London-integrals.ipynb
+++ b/gqcp/sandbox/London-integrals.ipynb
@@ -240,14 +240,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "numerical: [[0.13640738-0.00339179j 0.10362725+0.05661183j 0.        +0.j        ]]\n",
-      "analytic function: [[(0.13640737715649182-0.003391789199383762j), (0.10362725268685155+0.05661182615849864j), 0j]]\n"
+      "numerical: [[ 0.06068078-0.37890755j -3.9634768 +7.51204431j  0.        +0.j        ]]\n",
+      "analytic function: [[(0.060680783796927006-0.3789075550054003j), (-3.963477065186396+7.512044781949698j), 0j]]\n"
      ]
     }
    ],
    "source": [
-    "print('numerical:', numerical_gradient_basis(spinor_basis_B1, eval_loc))\n",
-    "print('analytic function:', spinor_basis_B1.evalGradBasisSetAtPoint(eval_loc))"
+    "print('numerical:', numerical_gradient_basis(spinor_basis_B1_randomG, eval_loc))\n",
+    "print('analytic function:', spinor_basis_B1_randomG.evalGradBasisSetAtPoint(eval_loc))"
    ]
   },
   {
@@ -292,6 +292,16 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "2ab8c282",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G = np.array([124.21, 6.34, 0.564])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "id": "43688459",
    "metadata": {},
    "outputs": [],
@@ -303,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "f5e421de",
    "metadata": {},
    "outputs": [
@@ -311,22 +321,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "manual: (0.12000723071576481+0.06556024893928053j)\n",
-      "gqcp: (0.1200072307157648+0.06556024893928053j)\n"
+      "manual: (-0.1218209546423018-0.06212516941695598j)\n",
+      "gqcp: (-0.1218209546423018-0.06212516941695598j)\n"
      ]
     }
    ],
    "source": [
-    "k, phase_factor = compute_phase_factor(eval_loc, R_K=np.array([0, 1, 0]), G=np.array([0, 0, 0]), B=np.array([0, 0, -1]))\n",
+    "k, phase_factor = compute_phase_factor(eval_loc, R_K=np.array([0, 1, 0]), G=G, B=np.array([0, 0, -1]))\n",
     "gto_r = spinor_basis_noB.evalBasisSetAtPoint(eval_loc)[0]\n",
     "manual_lao_r = phase_factor * gto_r\n",
     "print('manual:', manual_lao_r)\n",
-    "print('gqcp:', spinor_basis_B1.evalBasisSetAtPoint(eval_loc)[0])"
+    "print('gqcp:', spinor_basis_B1_randomG.evalBasisSetAtPoint(eval_loc)[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "f1a14340",
    "metadata": {},
    "outputs": [],
@@ -346,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "aa3bdd61",
    "metadata": {},
    "outputs": [
@@ -354,15 +364,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "manual: [0.13640738-0.00339179j 0.10362725+0.05661183j 0.        +0.j        ]\n",
-      "gqcp: [(0.13640737715649182-0.003391789199383762j), (0.10362725268685155+0.05661182615849864j), 0j]\n"
+      "manual: [ 0.06068078-0.37890756j -3.96347707+7.51204478j  0.        -0.j        ]\n",
+      "gqcp: [(0.060680783796927006-0.3789075550054003j), (-3.963477065186396+7.512044781949698j), 0j]\n"
      ]
     }
    ],
    "source": [
-    "manual_grad_lao_r = compute_grad_lao_manually_analytically(eval_loc, spinor_basis_noB, R_K=np.array([0, 1, 0]), G=np.array([0, 0, 0]), B=np.array([0, 0, -1]))\n",
+    "manual_grad_lao_r = compute_grad_lao_manually_analytically(eval_loc, spinor_basis_noB, R_K=np.array([0, 1, 0]), G=G, B=np.array([0, 0, -1]))\n",
     "print('manual:', manual_grad_lao_r)\n",
-    "print('gqcp:', spinor_basis_B1.evalGradBasisSetAtPoint(eval_loc)[0])"
+    "print('gqcp:', spinor_basis_B1_randomG.evalGradBasisSetAtPoint(eval_loc)[0])"
    ]
   },
   {

--- a/gqcp/sandbox/London-integrals.ipynb
+++ b/gqcp/sandbox/London-integrals.ipynb
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 6,
    "id": "388fd0b0",
    "metadata": {},
    "outputs": [
@@ -148,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 7,
    "id": "a5b9a3e7",
    "metadata": {},
    "outputs": [
@@ -158,7 +158,7 @@
        "[(0.1200072307157648+0.06556024893928053j)]"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 8,
    "id": "2e44585e",
    "metadata": {},
    "outputs": [],
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "e805bd83",
    "metadata": {},
    "outputs": [
@@ -191,7 +191,7 @@
        "-0.5000000000000001"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -202,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 10,
    "id": "f74fa900",
    "metadata": {},
    "outputs": [],
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 11,
    "id": "c4c9ecc8",
    "metadata": {},
    "outputs": [
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 12,
    "id": "cfac8f3e",
    "metadata": {},
    "outputs": [
@@ -291,19 +291,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 13,
    "id": "43688459",
    "metadata": {},
    "outputs": [],
    "source": [
     "def compute_phase_factor(r, R_K=np.array([0, 0, 0]), B=np.array([0, 0, 0]), G=np.array([0, 0, 0])):\n",
     "    k = 1/2 * (np.cross(B, R_K - G))\n",
-    "    return np.exp(-1.0j*np.dot(k, r))"
+    "    return k, np.exp(-1.0j*np.dot(k, r)) # k and phase factor"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 14,
    "id": "f5e421de",
    "metadata": {},
    "outputs": [
@@ -317,7 +317,7 @@
     }
    ],
    "source": [
-    "phase_factor = compute_phase_factor(eval_loc, R_K=np.array([0, 1, 0]), G=np.array([0, 0, 0]), B=np.array([0, 0, -1]))\n",
+    "k, phase_factor = compute_phase_factor(eval_loc, R_K=np.array([0, 1, 0]), G=np.array([0, 0, 0]), B=np.array([0, 0, -1]))\n",
     "gto_r = spinor_basis_noB.evalBasisSetAtPoint(eval_loc)[0]\n",
     "manual_lao_r = phase_factor * gto_r\n",
     "print('manual:', manual_lao_r)\n",
@@ -326,13 +326,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "f1a14340",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# compute gradient\n"
+    "# compute gradient\n",
+    "def compute_grad_lao_manually_analytically(eval_loc, gto_basis, R_K=np.array([0, 1, 0]), G=np.array([0, 0, 0]), B=np.array([0, 0, -1])):\n",
+    "    # compute k and phase factor\n",
+    "    k, phase_factor = compute_phase_factor(eval_loc, R_K=R_K, B=B, G=G) # k is a vector\n",
+    "\n",
+    "    # compute base GTO value\n",
+    "    gto_r = gto_basis.evalBasisSetAtPoint(eval_loc)[0]\n",
+    "    # compute grad of base GTO\n",
+    "    grad_gto_r = gto_basis.evalGradBasisSetAtPoint(eval_loc)[0] # 1x3 array!\n",
+    "\n",
+    "    return phase_factor * (grad_gto_r - 1.0j * k * gto_r)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "aa3bdd61",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "manual: [0.13640738-0.00339179j 0.10362725+0.05661183j 0.        +0.j        ]\n",
+      "gqcp: [(0.13640737715649182-0.003391789199383762j), (0.10362725268685155+0.05661182615849864j), 0j]\n"
+     ]
+    }
+   ],
+   "source": [
+    "manual_grad_lao_r = compute_grad_lao_manually_analytically(eval_loc, spinor_basis_noB, R_K=np.array([0, 1, 0]), G=np.array([0, 0, 0]), B=np.array([0, 0, -1]))\n",
+    "print('manual:', manual_grad_lao_r)\n",
+    "print('gqcp:', spinor_basis_B1.evalGradBasisSetAtPoint(eval_loc)[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ff35c78",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/gqcp/sandbox/generate_pyscf_eval_gto_ref.ipynb
+++ b/gqcp/sandbox/generate_pyscf_eval_gto_ref.ipynb
@@ -2,7 +2,39 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
+   "id": "28d33f15",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting pyscf\n",
+      "  Downloading pyscf-2.11.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (51.3 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m51.3/51.3 MB\u001b[0m \u001b[31m14.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: setuptools in /usr/local/miniconda3/lib/python3.8/site-packages (from pyscf) (65.6.3)\n",
+      "Collecting h5py>=2.7\n",
+      "  Downloading h5py-3.11.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (5.3 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.3/5.3 MB\u001b[0m \u001b[31m7.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m0:00:01\u001b[0m0:01\u001b[0m\n",
+      "\u001b[?25hCollecting scipy>=1.6.0\n",
+      "  Downloading scipy-1.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (34.5 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m34.5/34.5 MB\u001b[0m \u001b[31m13.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: numpy!=1.16,!=1.17,>=1.13 in /usr/local/miniconda3/lib/python3.8/site-packages (from pyscf) (1.24.2)\n",
+      "Installing collected packages: scipy, h5py, pyscf\n",
+      "Successfully installed h5py-3.11.0 pyscf-2.11.0 scipy-1.10.1\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\u001b[33m\n",
+      "\u001b[0mNote: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "pip install pyscf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "d94d7ddd",
    "metadata": {},
    "outputs": [],
@@ -13,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "cac5e45b",
    "metadata": {},
    "outputs": [
@@ -47,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "id": "d51c33ad",
    "metadata": {},
    "outputs": [],
@@ -59,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "id": "4828b8cb",
    "metadata": {},
    "outputs": [
@@ -84,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "id": "c3eae90d",
    "metadata": {},
    "outputs": [
@@ -109,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "id": "a3811fb8",
    "metadata": {},
    "outputs": [
@@ -131,6 +163,14 @@
     "for val in grad_ao_vals_z[0]:\n",
     "    print(np.around(val, 9))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a66439e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Current LAO and $\nabla$ LAO evaluations at a point in space (`basis.evalBasisSetAtPoint` and `basis.evalGradBasisSetAtPoint`) are not benchmarked for LAO values (they _are_ benchmarked against PySCF for normal GTO basis sets).

In this PR, I aim to benchmark the current implementation.

- [ ] **ChronusQ**: ChronusQ reference data appears hard to get (see https://github.com/GQCG-res/chronusq-reference-data/issues/2#issuecomment-3646093207).
- [x] Grad LAO as **finite difference**: Finite difference approximation of grad LAO corresponds to current cpp implementation.
- [x] **Analytical** reference: 
  - Current implementation appears well-behaved in reference to analytical behaviour. $k$ can be extracted from evaluated points and its value is as expected.
  - Manual implementation of phase-factor on top of benchmarked bare-GTO point evaluations is in agreement with GQCP's source implementation.